### PR TITLE
ENH: More environment scripts

### DIFF
--- a/mfxenv
+++ b/mfxenv
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Source this to load the full environment that hutch python uses
+HERE=`readlink -f $(dirname $0)`
+source "${HERE}/mfxversion"
+pathmunge "${CONDA_BASE}/bin"
+source activate "${CONDA_ENVNAME}"

--- a/mfxpython
+++ b/mfxpython
@@ -1,15 +1,6 @@
 #!/bin/bash
-CONDA_ENVNAME='pcds-0.5.2'
-CONDA_BASE='/reg/g/pcds/pyps/conda/py36'
-
+# Launch hutch-python with all devices
 HERE=`readlink -f $(dirname $0)`
-
-export PYTHONPATH="${HERE}:${HERE}/dev/devpath"
-export LD_LIBRARY_PATH=''
-
-CONDA_ENV="${CONDA_BASE}/envs/${CONDA_ENVNAME}"
-CONDA_BIN="${CONDA_ENV}/bin/wrappers/conda"
-
-source /reg/g/pcds/setup/pathmunge.sh
+source "${HERE}/mfxversion"
 pathmunge "${CONDA_BIN}"
 hutch-python --cfg "${HERE}/conf.yml" --db "${HERE}/../device_config/db.json" $@

--- a/mfxrun
+++ b/mfxrun
@@ -5,4 +5,4 @@
 HERE=`readlink -f $(dirname $0)`
 source "${HERE}/mfxversion"
 pathmunge "${CONDA_BIN}"
-run-in $@
+run-in python $@

--- a/mfxrun
+++ b/mfxrun
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Use this to run arbitrary scripts in the same environment as hutch python
+# without loading the databases, beamline files, e.g. mfxrun script.py.
+# This skips loading the full conda environment which can be slow.
+HERE=`readlink -f $(dirname $0)`
+source "${HERE}/mfxversion"
+pathmunge "${CONDA_BIN}"
+run-in $@

--- a/mfxversion
+++ b/mfxversion
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Define the current conda environment
+export CONDA_ENVNAME='pcds-0.5.2'
+export CONDA_BASE='/reg/g/pcds/pyps/conda/py36'
+
+HERE=`readlink -f $(dirname $0)`
+export PYTHONPATH="${HERE}:${HERE}/dev/devpath"
+export LD_LIBRARY_PATH=''
+
+export CONDA_ENV="${CONDA_BASE}/envs/${CONDA_ENVNAME}"
+export CONDA_BIN="${CONDA_ENV}/bin/wrappers/conda"
+
+source /reg/g/pcds/setup/pathmunge.sh

--- a/mfxversion
+++ b/mfxversion
@@ -1,13 +1,16 @@
 #!/bin/bash
-# Define the current conda environment
+# Define the current conda environment.
+# This is referenced by the three launcher scripts.
+
+# edit this line only
 export CONDA_ENVNAME='pcds-0.5.2'
+
 export CONDA_BASE='/reg/g/pcds/pyps/conda/py36'
+export CONDA_ENV="${CONDA_BASE}/envs/${CONDA_ENVNAME}"
+export CONDA_BIN="${CONDA_ENV}/bin/wrappers/conda"
 
 HERE=`readlink -f $(dirname $0)`
 export PYTHONPATH="${HERE}:${HERE}/dev/devpath"
 export LD_LIBRARY_PATH=''
-
-export CONDA_ENV="${CONDA_BASE}/envs/${CONDA_ENVNAME}"
-export CONDA_BIN="${CONDA_ENV}/bin/wrappers/conda"
 
 source /reg/g/pcds/setup/pathmunge.sh


### PR DESCRIPTION
Let's add some options for launching python scripts for the mfx environment:

- `source mfxenv` puts you in the full conda environment
- `mfxrun script.py` runs the script in the conda environment without doing a full source activate
- `mfxpython` opens an `ipython` terminal with all `mfx` objects
- `mfxpython script.py` loads all `mfx` objects, then runs the script

`mfxversion` stores version info and other commonalities that the other three scripts need.

These are trivially portable to other hutches.