### PR TITLE
MNT: pre-bump to pcds-0.6.0 and simplify config file

### DIFF
--- a/conf.yml
+++ b/conf.yml
@@ -1,7 +1,7 @@
 hutch: mfx
 
 # Locate happi database
-db: ../device_config/db.json
+db: /reg/g/pcds/pyps/apps/hutch-python/device_config/db.json
 
 # Hutch-specific imports
 load: mfx.beamline

--- a/conf.yml
+++ b/conf.yml
@@ -1,29 +1,7 @@
-# Pick which devices to load from database
 hutch: mfx
 
+# Locate happi database
+db: ../device_config/db.json
+
 # Hutch-specific imports
-load:
-  - mfx.beamline
-
-# Create experiment-specific objects
-experiment:
-  proposal: LS21
-  run: 16
-  import: experiment.User() as x
-
-# Organize object groups
-namespace:
-
-  # Group objects by parent class
-  class:
-    EpicsMotor:
-      - motors
-      - m
-    Slits:
-      - slits
-      - s
-
-  # Group objects by beamline metadata
-  metadata:
-    - beamline
-    - stand
+load: mfx.beamline

--- a/mfxpython
+++ b/mfxpython
@@ -3,4 +3,4 @@
 HERE=`dirname $(readlink -f $0)`
 source "${HERE}/mfxversion"
 pathmunge "${CONDA_BIN}"
-hutch-python --cfg "${HERE}/conf.yml" --db "${HERE}/../device_config/db.json" $@
+hutch-python --cfg "${HERE}/conf.yml" $@

--- a/mfxversion
+++ b/mfxversion
@@ -3,7 +3,7 @@
 # This is referenced by the three launcher scripts.
 
 # edit this line only
-export CONDA_ENVNAME='pcds-0.5.2'
+export CONDA_ENVNAME='pcds-0.6.0'
 
 export CONDA_BASE='/reg/g/pcds/pyps/conda/py36'
 export CONDA_ENV="${CONDA_BASE}/envs/${CONDA_ENVNAME}"

--- a/set-dev
+++ b/set-dev
@@ -1,0 +1,24 @@
+#!/bin/bash
+MODULE="$1"
+if [ -z "$2" ]; then
+  IMPORT="${MODULE}"
+else
+  IMPORT="$2"
+fi
+if [ -z "$3" ]; then
+  REPO='pcdshub'
+else
+  REPO="$3"
+fi
+
+HERE=`dirname $(readlink -f $0)`
+mkdir -p "${HERE}/dev/devpath"
+
+pushd "${HERE}/dev"
+
+if [ ! -d "${MODULE}" ]; then
+  git clone "https://github.com/${REPO}/${MODULE}.git"
+  ln -s `readlink -f "${MODULE}/${IMPORT}"` "devpath/${IMPORT}"
+fi
+
+popd


### PR DESCRIPTION
Don't merge until pcds-0.6.0 is ready.

This is in anticipation of recent `hutch-python` updates. I'm making this PR before I forget.

This update probably also breaks any old user defined plans that use the daq.