### PR TITLE
40 l10125 mfx timing fix

### DIFF
--- a/mfx/macros.py
+++ b/mfx/macros.py
@@ -120,48 +120,46 @@ class MFX_Timing:
         for step in steps:
             self.sequence.append(self._step(step[0], step[1]))
         self.seq.sequence.put_seq(self.sequence)
+
+    def _seq_30hz(self):
+        steps = [['ray1', 1],
+                 ['pp_trigger', 0],
+                 ['ray2', 1],
+                 ['ray_readout', 1],
+                 ['daq_readout', 0],
+                 ['ray3', 1]]
+        return steps
+
+    def _seq_20hz(self):
+        steps = [['ray3', 1],
+                 ['pp_trigger', 0],
+                 ['ray2', 1],
+                 ['ray1', 1],
+                 ['daq_readout', 0],
+                 ['ray_readout', 1],
+                 ['ray3', 1],
+                 ['ray_readout', 1]]
+        return steps
     def set_30hz(self):
         self._seq_init(sync_mark=30)
-        steps = [['laser_on',0],
-                 ['daq_readout',0],
-                 ['ray3',1],
-                 ['ray_readout',1],
-                 ['pp_trigger',0],
-                 ['ray1',1],
-                 ['ray2', 1]]
-        self._seq_put(steps)
+        self._seq_put(self._seq_30hz())
         self.seq.start()
         return
     def set_30hz_laser(self, laser_evt_list=None):
         self._seq_init(sync_mark=30)
-        steps = [['laser_on', 0],
-                 ['daq_readout', 0],
-                 ['ray3', 1],
-                 ['ray_readout', 1],
-                 ['pp_trigger', 0],
-                 ['ray1', 1],
-                 ['ray2', 1]]
         try:
             for laser_evt in laser_evt_list:
-                block = steps
+                block = self._seq_30hz()
                 block.append(laser_evt)
                 self._seq_put(block)
         except:
-            self._seq_put(steps)
+            self._seq_put(self._seq_30hz())
         self.seq.start()
         print(self.sequence)
         return    
     def set_20hz(self):
         self._seq_init(sync_mark=60)
-        steps = [['ray3',1],
-                 ['ray2',1],
-                 ['ray_readout',1],
-                 ['pp_trig',1],
-                 ['ray2',0],
-                 ['ray1', 1],
-                 ['ray_readout',1],
-                 ['daq_readout',0]]
-        self._seq_put(steps)
+        self._seq_put(self._seq_20hz())
         self.seq.start()
         return
     def set_120hz(self):

--- a/mfx/macros.py
+++ b/mfx/macros.py
@@ -113,7 +113,7 @@ class MFX_Timing:
         self.seq.sync_marker.put(self.sync_markers[sync_mark])
         sequence = []
         for ii in range(15):
-            sequence.append(self._step('wait', 0))
+            sequence.append(self._seq_step('wait', 0))
         self.seq.sequence.put_seq(sequence)
         time.sleep(1)
     def _seq_put(self, steps):

--- a/mfx/macros.py
+++ b/mfx/macros.py
@@ -118,7 +118,7 @@ class MFX_Timing:
         time.sleep(1)
     def _seq_put(self, steps):
         for step in steps:
-            self.sequence.append(self._step(step[0], step[1]))
+            self.sequence.append(self._seq_step(step[0], step[1]))
         self.seq.sequence.put_seq(self.sequence)
 
     def _seq_30hz(self):

--- a/mfx/macros.py
+++ b/mfx/macros.py
@@ -104,26 +104,31 @@ class MFX_Timing:
         }
         self.sync_markers = {0.5:0, 1:1, 5:2, 10:3, 30:4, 60:5, 120:6, 360:7}
         self.sequence = []
+    
     def _seq_step(self, evt_code_name=None, delta_beam=0):
         try:
             return [self.evt_code[evt_code_name], delta_beam, 0, 0]
         except:
             print('Error: event sequencer step not recognized.')
+    
     def _seq_init(self, sync_mark=30):
         self.seq.sync_marker.put(self.sync_markers[sync_mark])
+        self.sequence = []
         sequence = []
         for ii in range(15):
             sequence.append(self._seq_step('wait', 0))
         self.seq.sequence.put_seq(sequence)
         time.sleep(1)
+    
     def _seq_put(self, steps):
         for step in steps:
             self.sequence.append(self._seq_step(step[0], step[1]))
         self.seq.sequence.put_seq(self.sequence)
 
     def _seq_30hz(self):
+        # make sure daq_readout is penultimate event (set_30hz_laser assumes it)
         steps = [['ray1', 1],
-                 ['pp_trigger', 0],
+                 ['pp_trig', 0],
                  ['ray2', 1],
                  ['ray_readout', 1],
                  ['daq_readout', 0],
@@ -132,36 +137,40 @@ class MFX_Timing:
 
     def _seq_20hz(self):
         steps = [['ray3', 1],
-                 ['pp_trigger', 0],
+                 ['pp_trig', 0],
                  ['ray2', 1],
                  ['ray1', 1],
                  ['daq_readout', 0],
-                 ['ray_readout', 1],
-                 ['ray3', 1],
-                 ['ray_readout', 1]]
+                 ['ray_readout', 3]]
         return steps
+    
     def set_30hz(self):
         self._seq_init(sync_mark=30)
         self._seq_put(self._seq_30hz())
         self.seq.start()
         return
+    
     def set_30hz_laser(self, laser_evt_list=None):
         self._seq_init(sync_mark=30)
         try:
             for laser_evt in laser_evt_list:
-                block = self._seq_30hz()
+                sequence = self._seq_30hz()
+                block = sequence[:-1]
                 block.append(laser_evt)
+                block.append(sequence[-1])
                 self._seq_put(block)
         except:
             self._seq_put(self._seq_30hz())
         self.seq.start()
         print(self.sequence)
         return    
+    
     def set_20hz(self):
         self._seq_init(sync_mark=60)
         self._seq_put(self._seq_20hz())
         self.seq.start()
         return
+    
     def set_120hz(self):
         self._seq_init(sync_mark=60)
         steps = [['ray3', 1],


### PR DESCRIPTION
Closes #40

```python
In [1]: timing = MFX_Timing()
In [2]: timing.set_30hz_laser([['laser_on',0],['laser_off',0]])
[[211, 1, 0, 0], [197, 0, 0, 0], [212, 1, 0, 0], [210, 1, 0, 0], [198, 0, 0, 0], [203, 0, 0, 0], [213, 1, 0, 0], [211, 1, 0, 0], [197, 0, 0, 0], [212, 1, 0, 0], [210, 1, 0, 0], [198, 0, 0, 0], [204, 0, 0, 0], [213, 1, 0, 0]]
```

<img width="550" alt="image" src="https://github.com/pcdshub/mfx/assets/4610338/2fac0e5f-c033-448b-b5ac-addb34b517de">

We'll need to rethink this to improve usability.
