### PR TITLE
Optional DAQ in attenuator scans

### DIFF
--- a/mfx/attenuator_scan.py
+++ b/mfx/attenuator_scan.py
@@ -1,16 +1,19 @@
 def attenuator_scan_separate_runs(
-        events: int =240,
-        record: bool =False,
-        transmissions: list = [0.01,0.02,0.03],
-        use_daq: bool = True
+    duration: int = None,
+    record: bool = False,
+    transmissions: list = [0.01, 0.02, 0.03],
+    use_daq: bool = True,
+    **kwargs
 ) -> None:
     """
     Runs through attenuator conditions and records each as an individual run
 
     Parameters
     ----------
-    events: int, optional
-        number of events. default 240
+    duration: int, optional
+        When using the DAQ this corresponds to the number of events. If not
+        using the DAQ, it corresponds to the number of seconds to wait at ech
+        attenuator step. Default is 240 events (with DAQ), or 3 seconds (no DAQ).
 
     record: bool, optional
         set True to record
@@ -22,40 +25,61 @@ def attenuator_scan_separate_runs(
         Whether to include the DAQ or not. Default: True. If False can run the
         scans while using the DAQ elsewhere.
 
+    **kwargs - Additional optional keyword arguments
+        events: int
+            Provided for backwards compatibility. When using the DAQ, if this
+            keyword argument is passed, and `duration` is not, it will be used
+            as the number of events.
+
     Operations
     ----------
 
     """
     from time import sleep
     from mfx.db import att, pp
+
     if use_daq:
         from mfx.db import daq
+
+    evts = kwargs.get("events")
+    if duration is None:
+        if use_daq:
+            duration = evts if evts else 240
+        else:
+            duration = 3
+            if evts is not None:
+                print("`events` parameter ignored when not using DAQ! Use `duration`!")
 
     pp.open()
     for i in transmissions:
         att(i)
-        sleep(3)
         if use_daq:
-            daq.begin(events=events,record=record,wait=True, use_l3t=False)
+            sleep(3)
+            daq.begin(events=duration, record=record, wait=True, use_l3t=False)
             daq.end_run()
+        else:
+            sleep(duration)
     pp.close()
     if use_daq:
         daq.disconnect()
 
 
 def attenuator_scan_single_run(
-        events: int = 240,
-        record: bool = False,
-        transmissions: list = [0.01,0.02,0.03],
-        use_daq: bool = True
+    duration: int = None,
+    record: bool = False,
+    transmissions: list = [0.01, 0.02, 0.03],
+    use_daq: bool = True,
+    **kwargs
 ) -> None:
     """
     Runs through attenuator conditions and records them all as one continuous run
 
     Parameters
     ----------
-    events: int, optional
-        number of events. default 240
+    duration: int, optional
+        When using the DAQ this corresponds to the number of events. If not
+        using the DAQ, it corresponds to the number of seconds to wait at ech
+        attenuator step. Default is 240 events (with DAQ), or 3 seconds (no DAQ).
 
     record: bool, optional
         set True to record
@@ -67,6 +91,12 @@ def attenuator_scan_single_run(
         Whether to include the DAQ or not. Default: True. If False can run the
         scans while using the DAQ elsewhere.
 
+    **kwargs - Additional optional keyword arguments
+        events: int
+            Provided for backwards compatibility. When using the DAQ, if this
+            keyword argument is passed, and `duration` is not, it will be used
+            as the number of events. It is ignored when not using the DAQ.
+
     Operations
     ----------
 
@@ -76,19 +106,31 @@ def attenuator_scan_single_run(
 
     if use_daq:
         from mfx.db import daq
+
         daq.end_run()
         daq.disconnect()
+
+    evts = kwargs.get("events")
+    if duration is None:
+        if use_daq:
+            duration = evts if evts else 240
+        else:
+            duration = 3
+            if evts is not None:
+                print("`events` parameter ignored when not using DAQ! Use `duration`!")
 
     try:
         pp.open()
         if use_daq:
             daq.configure(record=record)
-        sleep(3)
-        for i in transmissions:
-            att(i,wait=True)
             sleep(3)
+        for i in transmissions:
+            att(i, wait=True)
             if use_daq:
-                daq.begin(events=events,record=record,wait=True, use_l3t=False)
+                sleep(3)
+                daq.begin(events=duration, record=record, wait=True, use_l3t=False)
+            else:
+                sleep(duration)
     finally:
         if use_daq:
             daq.end_run()

--- a/mfx/attenuator_scan.py
+++ b/mfx/attenuator_scan.py
@@ -1,4 +1,9 @@
-def attenuator_scan_separate_runs(events=240, record=False, config=True, transmissions=[0.01,0.02,0.03]):
+def attenuator_scan_separate_runs(
+        events: int =240,
+        record: bool =False,
+        transmissions: list = [0.01,0.02,0.03],
+        use_daq: bool = True
+) -> None:
     """
     Runs through attenuator conditions and records each as an individual run
 
@@ -13,24 +18,37 @@ def attenuator_scan_separate_runs(events=240, record=False, config=True, transmi
     transmissions: list of floats, optional
         list of transmissions to run through. default [0.01,0.02,0.03]
 
+    use_daq: bool, optional
+        Whether to include the DAQ or not. Default: True. If False can run the
+        scans while using the DAQ elsewhere.
+
     Operations
     ----------
 
     """
     from time import sleep
-    from mfx.db import daq, att, pp
+    from mfx.db import att, pp
+    if use_daq:
+        from mfx.db import daq
 
     pp.open()
     for i in transmissions:
         att(i)
         sleep(3)
-        daq.begin(events=events,record=record,wait=True, use_l3t=False)
-        daq.end_run()
+        if use_daq:
+            daq.begin(events=events,record=record,wait=True, use_l3t=False)
+            daq.end_run()
     pp.close()
-    daq.disconnect()
+    if use_daq:
+        daq.disconnect()
 
 
-def attenuator_scan_single_run(events=240, record=False, transmissions=[0.01,0.02,0.03]):
+def attenuator_scan_single_run(
+        events: int = 240,
+        record: bool = False,
+        transmissions: list = [0.01,0.02,0.03],
+        use_daq: bool = True
+) -> None:
     """
     Runs through attenuator conditions and records them all as one continuous run
 
@@ -45,24 +63,34 @@ def attenuator_scan_single_run(events=240, record=False, transmissions=[0.01,0.0
     transmissions: list of floats, optional
         list of transmissions to run through. default [0.01,0.02,0.03]
 
+    use_daq: bool, optional
+        Whether to include the DAQ or not. Default: True. If False can run the
+        scans while using the DAQ elsewhere.
+
     Operations
     ----------
 
     """
     from time import sleep
-    from mfx.db import daq, att, pp
+    from mfx.db import att, pp
 
-    daq.end_run()
-    daq.disconnect()
+    if use_daq:
+        from mfx.db import daq
+        daq.end_run()
+        daq.disconnect()
+
     try:
         pp.open()
-        daq.configure(record=record)
+        if use_daq:
+            daq.configure(record=record)
         sleep(3)
         for i in transmissions:
             att(i,wait=True)
             sleep(3)
-            daq.begin(events=events,record=record,wait=True, use_l3t=False)
+            if use_daq:
+                daq.begin(events=events,record=record,wait=True, use_l3t=False)
     finally:
-        daq.end_run()
+        if use_daq:
+            daq.end_run()
+            daq.disconnect()
         pp.close()
-        daq.disconnect()


### PR DESCRIPTION
Change Log
------------------
- Make the use of the DAQ optional when running attenuator scans.

Usage
----------
```py
attenuator_scan_separate_runs(..., use_daq=True) # Includes DAQ
attenuator_scan_separate_runs(..., use_daq=False) # DAQ is not imported or used
```
Analogous usage for `attenuator_scan_single_run`