### PR TITLE
Add env files to run sim

### DIFF
--- a/mfx/optimize/environment.yml
+++ b/mfx/optimize/environment.yml
@@ -13,6 +13,6 @@ dependencies:
   - ipython
   - pip
   - pip:
-      - blop @ git+https://github.com/NSLS-II/blop.git
+      - blop
       - lcls-tools @ git+https://github.com/slaclab/lcls-tools.git
       - pcdsdevices @ git+https://github.com/pcdshub/pcdsdevices.git

--- a/mfx/optimize/pixi.toml
+++ b/mfx/optimize/pixi.toml
@@ -16,6 +16,6 @@ ipython = "*"
 pip = "*"
 
 [pypi-dependencies]
-blop = { git = "https://github.com/NSLS-II/blop.git" }
+blop = "*"
 lcls-tools = { git = "https://github.com/slaclab/lcls-tools.git" }
 pcdsdevices = { git = "https://github.com/pcdshub/pcdsdevices.git" }


### PR DESCRIPTION
# Description
This PR adds environment files for conda and pixi to allow devs to easily set up the packages needed to run the beam alignment optimization simulation.

# To run
You can create a conda environment from this file with `conda env create -f /path/to/environment.yml` or a pixi environment with `pixi install --manifest-path /path/to/pixi.toml`. Once the environment is ready, you can run the sim as noted in the scan modules, e.g. `python -m mfx.optimize.xopt_scans`. Note that the relative imports in the modules might cause some issues depending on where you set up your pixi environment.