### PR TITLE
Add validation and type checking

### DIFF
--- a/mfx/optimize/align.py
+++ b/mfx/optimize/align.py
@@ -11,7 +11,7 @@ Turbo = Literal["safety", "optimize"]
 
 def validate_w_lowercase_args(func):
     """
-   Decorator to make string inputs lowercase before validating.
+    Decorator to make string inputs lowercase, and then validate.
 
     Parameters:
     -----------
@@ -61,9 +61,9 @@ class Align:
         with_goal : float
             Goal to align to.
         on_diagnostic : str, optional
-            Diagnostic to use for alignment. Options: "XCS1, DG1, DG2". Default is "dg1".
+            Diagnostic to use for alignment. Options: "xcs1, dg1, dg2". Default is "dg1".
         with_method : str, optional
-            Method to use for alignment. Options: "blop, Xopt". Default is "xopt".
+            Method to use for alignment. Options: "blop, xopt". Default is "xopt".
         using_device : str, optional
             Device to use for alignment. Options: "yag, wave8". Default is "yag".
         xopt_turbo_option : str, optional

--- a/mfx/optimize/align.py
+++ b/mfx/optimize/align.py
@@ -1,41 +1,85 @@
+from typing import Literal
+from pydantic import validate_call, ConfigDict
 from bluesky import RunEngine
 
 
-class Align:
-    def __init__(self):
-        self.beam_alignment_diagnostics = ["XCS1", "DG1", "DG2"]
-        self.beam_alignment_methods = ["Xopt", "blop"]
-        self.beam_alignment_devices = ["yag", "wave8"]
+Diagnostics = Literal["xcs1", "dg1", "dg2"]
+Methods = Literal["xopt", "blop"]
+Devices = Literal["yag", "wave8"]
+Turbo = Literal["safety", "optimize"]
 
+
+def validate_w_lowercase_args(func):
+    """
+   Decorator to make string inputs lowercase before validating.
+
+    Parameters:
+    -----------
+    func (Callable): 
+        The function to decorate.
+
+    Returns:
+    --------
+    Callable: 
+        The decorated function with string arguments converted to lowercase.
+    """
+    def wrapper(*args, **kwargs):
+        # Convert all string arguments to lowercase
+        new_args = tuple(arg.lower() if isinstance(arg, str) else arg for arg in args)
+        new_kwargs = {k: v.lower() if isinstance(v, str) else v for k, v in kwargs.items()}
+
+        # Call the original function with the modified arguments, validated by Pydantic
+        validated_func = validate_call(func, config=ConfigDict(validate_default=True))
+        return validated_func(*new_args, **new_kwargs)
+
+    return wrapper
+
+
+class Align:
+    @validate_call
+    def __init__(self, mirror_pitch: list[float] = [-549.0, -546.0]):
+        self.mirror_pitch: list[float] = mirror_pitch
+
+    @validate_w_lowercase_args
     def beam(
             self,
             with_goal: float,
-            on_diagnostic: str = "DG1",
-            with_method: str = 'Xopt',
-            using_device: str = "yag",
-            xopt_turbo_option: str = "safety",
+            on_diagnostic: Diagnostics = "dg1",
+            with_method: Methods = "xopt",
+            using_device: Devices = "yag",
+            xopt_turbo_option: Turbo = "safety",
+            xopt_rand_evaluate: int = 3,
+            xopt_steps: int = 10,
+            blop_qr_n: int = 16,
+            blop_qei_n: int = 16,
+            blop_qei_iterations: int = 5
             ):
         """Perform Beam Alignment
 
-        Parameters:
-
-            on_diagnostic (str): diagnostic to use for alignment. Options: "XCS1, DG1, DG2".
-
-            with_method(str): method to use for alignment. Options: "blop, Xopt".
+        Parameters
+        ----------
+        with_goal : float
+            Goal to align to.
+        on_diagnostic : str, optional
+            Diagnostic to use for alignment. Options: "XCS1, DG1, DG2". Default is "dg1".
+        with_method : str, optional
+            Method to use for alignment. Options: "blop, Xopt". Default is "xopt".
+        using_device : str, optional
+            Device to use for alignment. Options: "yag, wave8". Default is "yag".
+        xopt_turbo_option : str, optional
+            Xopt turbo controller option. Options: "safety, optimize". Default is "safety".
+        xopt_rand_evaluate : int, optional
+            Number of random evaluations to perform in Xopt. Default is 3.
+        xopt_steps : int, optional
+            Number of steps to perform in Xopt. Default is 10.
+        blop_qr_n : int, optional
+            Number of qr iterations to perform in blop. Default is 16.
+        blop_qei_n : int, optional
+            Number of qei iterations to perform in blop. Default is 16.
+        blop_qei_iterations : int, optional
+            Number of iterations to perform in blop. Default is 5.
         """
-        if on_diagnostic not in self.beam_alignment_diagnostics:
-            print(f"Diagnostic {on_diagnostic} not usable for beam alignment. Use {self.beam_alignment_diagnostics}.")
-            return None
-
-        if with_method not in self.beam_alignment_methods:
-            print(f"Alignment method {with_method} not implemented yet. Use {self.beam_alignment_methods}.")
-            return None
-
-        if using_device not in self.beam_alignment_devices:
-            print(f"Only implemented devices: {self.beam_alignment_devices}")
-            return None
-
-        if with_method == 'Xopt':
+        if with_method == "xopt":
             from .xopt_scans import get_xopt_obj, init_devices
             xopt = get_xopt_obj(
                 device_type=using_device,
@@ -43,10 +87,10 @@ class Align:
                 goal=with_goal,
                 xopt_generator_turbo_controller=xopt_turbo_option,
             )
-            customized_boundaries = {'mirror_pitch': [-549.0,-546.0]}
-            xopt.random_evaluate(3, custom_bounds=customized_boundaries)
+            customized_boundaries = {"mirror_pitch": self.mirror_pitch}
+            xopt.random_evaluate(xopt_rand_evaluate, custom_bounds=customized_boundaries)
             print(xopt.data)
-            for num in range(10):
+            for num in range(xopt_steps):
                 print(f"Step {num + 1}")
                 xopt.step()
                 print(xopt.data)
@@ -58,15 +102,15 @@ class Align:
             print(f"pitch is at {mirror_pitch.position}")
             xopt.data.plot(y=xopt.vocs.objective_names)
             return xopt
-        elif with_method == 'blop':
+        elif with_method == "blop":
             from .blop_scans import get_blop_agent
             try:
                 from mfx.db import RE
             except ImportError:
                 RE = RunEngine({})
             agent = get_blop_agent(on_diagnostic.lower(), wave8_xpos=with_goal)
-            RE(agent.learn("qr", n=16))
-            RE(agent.learn("qei", n=16, iterations=5))
+            RE(agent.learn("qr", n=blop_qr_n))
+            RE(agent.learn("qei", n=blop_qei_n, iterations=blop_qei_iterations))
             RE(agent.go_to_best())
             agent.plot_objectives()
             return agent

--- a/mfx/optimize/align.py
+++ b/mfx/optimize/align.py
@@ -114,3 +114,5 @@ class Align:
             RE(agent.go_to_best())
             agent.plot_objectives()
             return agent
+        else:
+            raise ValueError("Only 'xopt' and 'blop' methods are supported.")

--- a/mfx/optimize/blop_scans.py
+++ b/mfx/optimize/blop_scans.py
@@ -12,6 +12,7 @@ from databroker import Broker
 from matplotlib import pyplot as plt
 from pandas import DataFrame
 
+from .align import Diagnostics, validate_w_lowercase_args
 from .mirror_hw import (
     DG1_WAVE8_XPOS,
     DG2_WAVE8_XPOS,
@@ -91,9 +92,9 @@ def clean_re(re: RunEngine, bec: BestEffortCallback):
         bec.enable_plots()
         re_setup_info["bec_starting_state"] = None
 
-
+@validate_w_lowercase_args
 def get_blop_agent(
-    wave8: str = "dg1",
+    wave8: Diagnostics = "dg1",
     mirror_nominal: float = MIRROR_NOMINAL,
     search_delta: float = 5,
     wave8_xpos: float | None = None,
@@ -159,7 +160,7 @@ def get_blop_agent(
         # Data validity
         Objective(
             name=df_name,
-            trust_domain=(-1 * wave8_max_value, wave8_max_value),
+            constraint=(-1 * wave8_max_value, wave8_max_value),
         ),
     ]
     detectors = [devices[wave8_name].xpos]
@@ -180,13 +181,13 @@ def get_blop_agent(
     return Agent(
         dofs=dofs,
         objectives=objectives,
-        dets=detectors,         # blop =0.7.0
-        # detectors=detectors,  # blop >0.7.0
+        #dets=detectors,         # blop =0.7.0
+        detectors=detectors,  # blop >0.7.0
         digestion=digestion,
         verbose=True,
         db=bluesky_objs["broker"],
         tolerate_acquisition_errors=False,
-        # enforce_all_objectives_valid=True,  # blop >0.7.0
+        enforce_all_objectives_valid=True,  # blop >0.7.0
         train_every=1,
     )
 

--- a/mfx/optimize/mirror_hw.py
+++ b/mfx/optimize/mirror_hw.py
@@ -32,7 +32,6 @@ YAG_CENTROID_Y_MIN_MAX = (400, 600)
 WAVE8_CENTROID_X_MIN_MAX = (None, None)
 WAVE8_CENTROID_Y_MIN_MAX = (None, None)
 
-
 devices: dict[str, Device] = {}
 
 

--- a/mfx/optimize/mirror_hw.py
+++ b/mfx/optimize/mirror_hw.py
@@ -32,6 +32,7 @@ YAG_CENTROID_Y_MIN_MAX = (400, 600)
 WAVE8_CENTROID_X_MIN_MAX = (None, None)
 WAVE8_CENTROID_Y_MIN_MAX = (None, None)
 
+
 devices: dict[str, Device] = {}
 
 

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -7,12 +7,14 @@ from __future__ import annotations
 
 import numpy as np
 import matplotlib.pyplot as plt
+
 from xopt import VOCS, Evaluator, Xopt
 from xopt.generators.bayesian import ExpectedImprovementGenerator
 
 from lcls_tools.common.frontend.plotting.image import plot_image_projection_fit
 from lcls_tools.common.image.fit import ImageProjectionFit
 
+from .align import Devices, Diagnostics, Turbo, validate_w_lowercase_args
 from .mirror_hw import (
     XCS_YAG_XPOS,
     DG1_WAVE8_XPOS,
@@ -200,9 +202,10 @@ def get_evaluator_yag_2d(
     return Evaluator(function=evaluate)
 
 
+@validate_w_lowercase_args
 def get_xopt_obj(
-    device_type: str,
-    location: str,
+    device_type: Devices,
+    location: Diagnostics,
     goal: float,
     mirror_nominal: float = MIRROR_NOMINAL,
     search_delta: float = 5,
@@ -211,11 +214,11 @@ def get_xopt_obj(
     yag_size_max: float | None = None,
     yag_intensity_min: float | None = None,
     yag_intensity_max: float | None = None,
-    centroid_x_min: float = None,
-    centroid_x_max: float = None,
-    centroid_y_min: float = None,
-    centroid_y_max: float = None,
-    xopt_generator_turbo_controller: str | None = None,
+    centroid_x_min: float | None = None,
+    centroid_x_max: float | None = None,
+    centroid_y_min: float | None = None,
+    centroid_y_max: float | None = None,
+    xopt_generator_turbo_controller: Turbo | None = None,
 ) -> Xopt:
     """
     Create an appropriate xopt optimization object.
@@ -230,33 +233,56 @@ def get_xopt_obj(
 
     Parameters
     ----------
-    device_type: str
+    device_type : str
         One of "yag" or "wave8"
     location : str
-        One of "xcs1", "dg1", "dg2", "ip"
+        One of "xcs1", "dg1", "dg2", "ip" # TODO: should IP be added to Diagnostics?
     goal : float
         Either the wave8 xpos to aim for, or the x coordinate to aim for on a yag.
     mirror_nominal : float
         The starting mirror pitch position and midpoint of the optimization search.
     search_delta : float
         How far +/- we check away from the mirror nominal pitch position
+    wave8_max_value: float, optional
+        Constraint on maximum wave8 xpos for data to be valid
     yag_size_min : float, optional
-        Constraint on minimum yag spot size for data to be valid
+        Constraint on minimum yag spot size (RMS) for data to be valid
     yag_size_max : float, optional
-        Constraint on maximum yag spot size for data to be valid
+        Constraint on maximum yag spot size (RMS) for data to be valid
     yag_intensity_min : float, optional
         Constraint on minimum yag total intensity count for data to be valid
     yag_intensity_max : float, optional
         Constraint on maximum yag total intensity count for data to be valid
+    centroid_x_min : float, optional
+        Constraint on minimum centroid x value for data to be valid
+    centroid_x_max : float, optional
+        Constraint on maximum centroid x value for data to be valid
+    centroid_y_min : float, optional
+    Constraint on minimum centroid y value for data to be valid
+    centroid_y_max : float, optional
+        Constraint on maximum centroid y value for data to be valid
+    xopt_generator_turbo_controller : str, optional
+        Which turbo controller to use. Options: "safety, optimize"
     """
     device_type = device_type.lower()
-    if device_type not in ("yag", "wave8"):
-        raise ValueError("device_type must be yag or wave8")
     location = location.lower()
-    if location not in ("xcs1", "dg1", "dg2", "ip"):
-        raise ValueError("location must be one of xcs1, dg1, dg2, or ip")
-    if device_type == "wave8" and location == "ip":
-        raise ValueError("There is no wave8 at the ip")
+
+    if device_type == "wave8":
+        if location == "ip":
+            raise ValueError("There is no wave8 at the ip.")
+        if {yag_size_min, yag_size_max, yag_intensity_min, yag_intensity_max} != {None}:
+            raise ValueError(
+                "Arguments yag_size_min, yag_size_max, yag_intensity_min, and yag_intensity_max "
+                "are only valid for yag devices. "
+                "Set to None to run with wave8 devices. Current values: "
+                f"yag_size_min={yag_size_min}, yag_size_max={yag_size_max}, "
+                f"yag_intensity_min={yag_intensity_min}, yag_intensity_max={yag_intensity_max}"
+            )
+    if device_type == "yag" and wave8_max_value is not None:
+        raise ValueError(
+            "Argument wave8_max_value is only valid for wave8 devices. "
+            "Set to None to run with yag devices."
+        )
 
     # Set min/max values for centroid_x and centroid_y based on device
     if device_type == "yag":
@@ -294,7 +320,6 @@ def get_xopt_obj(
             wave8=location,
             wave8_xpos=goal,
         )
-    #generator = ExpectedImprovementGenerator(vocs=vocs)
     generator = ExpectedImprovementGenerator(vocs=vocs, turbo_controller=xopt_generator_turbo_controller)
     generator.gp_constructor.use_low_noise_prior = False
     return Xopt(

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -236,7 +236,7 @@ def get_xopt_obj(
     device_type : str
         One of "yag" or "wave8"
     location : str
-        One of "xcs1", "dg1", "dg2", "ip" # TODO: should IP be added to Diagnostics?
+        One of "xcs1", "dg1", "dg2", "ip"
     goal : float
         Either the wave8 xpos to aim for, or the x coordinate to aim for on a yag.
     mirror_nominal : float
@@ -320,67 +320,6 @@ def get_xopt_obj(
             wave8=location,
             wave8_xpos=goal,
         )
-    generator = ExpectedImprovementGenerator(vocs=vocs, turbo_controller=xopt_generator_turbo_controller)
-    generator.gp_constructor.use_low_noise_prior = False
-    return Xopt(
-        vocs=vocs,
-        generator=generator,
-        evaluator=evaluator,
-    )
-
-
-def get_xopt_obj_2d_markers(
-    location: str,
-    mirror_nominal: float = MIRROR_NOMINAL,
-    search_delta: float = 5,
-    yag_size_min: float | None = None,
-    yag_size_max: float | None = None,
-    yag_intensity_min: float | None = None,
-    yag_intensity_max: float | None = None,
-    centroid_x_min: float = None,
-    centroid_x_max: float = None,
-    centroid_y_min: float = None,
-    centroid_y_max: float = None,
-    xopt_generator_turbo_controller: str | None = None,
-) -> Xopt:
-    """
-    Create an appropriate xopt optimization object for a 2D YAG optimization.
-
-    Uses the camviewer markers as a goal only by using the default goal
-    argument in get_evaluator_yag_2d.
-
-    Parameters
-    ----------
-    location : str
-        One of "xcs1", "dg1", "dg2", "ip"
-    mirror_nominal : float
-        The starting mirror pitch position and midpoint of the optimization search.
-    search_delta : float
-        How far +/- we check away from the mirror nominal pitch position
-    """
-    if location not in ("xcs1", "dg1", "dg2", "ip"):
-        raise ValueError("location must be one of xcs1, dg1, dg2, or ip")
-
-    centroid_x_min = centroid_x_min or YAG_CENTROID_X_MIN_MAX[0]
-    centroid_x_max = centroid_x_max or YAG_CENTROID_X_MIN_MAX[1]
-    centroid_y_min = centroid_y_min or YAG_CENTROID_Y_MIN_MAX[0]
-    centroid_y_max = centroid_y_max or YAG_CENTROID_Y_MIN_MAX[1]
-
-    vocs = get_vocs(
-        mirror_nominal=mirror_nominal,
-        search_delta=search_delta,
-        yag_size_min=yag_size_min,
-        yag_size_max=yag_size_max,
-        yag_intensity_min=yag_intensity_min,
-        yag_intensity_max=yag_intensity_max,
-        centroid_x_min=centroid_x_min,
-        centroid_x_max=centroid_x_max,
-        centroid_y_min=centroid_y_min,
-        centroid_y_max=centroid_y_max,
-    )
-    print(vocs)
-    evaluator = get_evaluator_yag_2d(yag=location)
-
     generator = ExpectedImprovementGenerator(vocs=vocs, turbo_controller=xopt_generator_turbo_controller)
     generator.gp_constructor.use_low_noise_prior = False
     return Xopt(

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -258,7 +258,7 @@ def get_xopt_obj(
     centroid_x_max : float, optional
         Constraint on maximum centroid x value for data to be valid
     centroid_y_min : float, optional
-    Constraint on minimum centroid y value for data to be valid
+        Constraint on minimum centroid y value for data to be valid
     centroid_y_max : float, optional
         Constraint on maximum centroid y value for data to be valid
     xopt_generator_turbo_controller : str, optional
@@ -270,7 +270,7 @@ def get_xopt_obj(
     if device_type == "wave8":
         if location == "ip":
             raise ValueError("There is no wave8 at the ip.")
-        if {yag_size_min, yag_size_max, yag_intensity_min, yag_intensity_max} != {None}:
+        if any(v is not None for v in (yag_size_min, yag_size_max, yag_intensity_min, yag_intensity_max)):
             raise ValueError(
                 "Arguments yag_size_min, yag_size_max, yag_intensity_min, and yag_intensity_max "
                 "are only valid for yag devices. "

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -158,7 +158,7 @@ def get_evaluator_yag(
 def get_evaluator_yag_2d(
     yag: str = "dg1",
     goal: tuple[float, float] | None = None,
-):
+) -> Evaluator:
     """
     Alternate evaluator in 2d space.
 
@@ -233,9 +233,9 @@ def get_xopt_obj(
 
     Parameters
     ----------
-    device_type : str
+    device_type : Devices
         One of "yag" or "wave8"
-    location : str
+    location : Diagnostics
         One of "xcs1", "dg1", "dg2", "ip"
     goal : float
         Either the wave8 xpos to aim for, or the x coordinate to aim for on a yag.
@@ -243,7 +243,7 @@ def get_xopt_obj(
         The starting mirror pitch position and midpoint of the optimization search.
     search_delta : float
         How far +/- we check away from the mirror nominal pitch position
-    wave8_max_value: float, optional
+    wave8_max_value : float, optional
         Constraint on maximum wave8 xpos for data to be valid
     yag_size_min : float, optional
         Constraint on minimum yag spot size (RMS) for data to be valid
@@ -264,9 +264,6 @@ def get_xopt_obj(
     xopt_generator_turbo_controller : str, optional
         Which turbo controller to use. Options: "safety, optimize"
     """
-    device_type = device_type.lower()
-    location = location.lower()
-
     if device_type == "wave8":
         if location == "ip":
             raise ValueError("There is no wave8 at the ip.")
@@ -329,18 +326,19 @@ def get_xopt_obj(
     )
 
 
+@validate_w_lowercase_args
 def get_xopt_obj_2d_markers(
-    location: str,
+    location: Diagnostics,
     mirror_nominal: float = MIRROR_NOMINAL,
     search_delta: float = 5,
     yag_size_min: float | None = None,
     yag_size_max: float | None = None,
     yag_intensity_min: float | None = None,
     yag_intensity_max: float | None = None,
-    centroid_x_min: float = None,
-    centroid_x_max: float = None,
-    centroid_y_min: float = None,
-    centroid_y_max: float = None,
+    centroid_x_min: float | None = None,
+    centroid_x_max: float | None = None,
+    centroid_y_min: float | None = None,
+    centroid_y_max: float | None = None,
     xopt_generator_turbo_controller: str | None = None,
 ) -> Xopt:
     """
@@ -351,12 +349,30 @@ def get_xopt_obj_2d_markers(
 
     Parameters
     ----------
-    location : str
+    location : Diagnostics
         One of "xcs1", "dg1", "dg2", "ip"
     mirror_nominal : float
         The starting mirror pitch position and midpoint of the optimization search.
     search_delta : float
         How far +/- we check away from the mirror nominal pitch position
+        yag_size_min : float, optional
+        Constraint on minimum yag spot size (RMS) for data to be valid
+    yag_size_max : float, optional
+        Constraint on maximum yag spot size (RMS) for data to be valid
+    yag_intensity_min : float, optional
+        Constraint on minimum yag total intensity count for data to be valid
+    yag_intensity_max : float, optional
+        Constraint on maximum yag total intensity count for data to be valid
+    centroid_x_min : float, optional
+        Constraint on minimum centroid x value for data to be valid
+    centroid_x_max : float, optional
+        Constraint on maximum centroid x value for data to be valid
+    centroid_y_min : float, optional
+        Constraint on minimum centroid y value for data to be valid
+    centroid_y_max : float, optional
+        Constraint on maximum centroid y value for data to be valid
+    xopt_generator_turbo_controller : str, optional
+        Which turbo controller to use. Options: "safety, optimize"
     """
     if location not in ("xcs1", "dg1", "dg2", "ip"):
         raise ValueError("location must be one of xcs1, dg1, dg2, or ip")

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -365,6 +365,67 @@ def get_xopt_obj_2d_markers(
     )
 
 
+def get_xopt_obj_2d_markers(
+    location: str,
+    mirror_nominal: float = MIRROR_NOMINAL,
+    search_delta: float = 5,
+    yag_size_min: float | None = None,
+    yag_size_max: float | None = None,
+    yag_intensity_min: float | None = None,
+    yag_intensity_max: float | None = None,
+    centroid_x_min: float = None,
+    centroid_x_max: float = None,
+    centroid_y_min: float = None,
+    centroid_y_max: float = None,
+    xopt_generator_turbo_controller: str | None = None,
+) -> Xopt:
+    """
+    Create an appropriate xopt optimization object for a 2D YAG optimization.
+
+    Uses the camviewer markers as a goal only by using the default goal
+    argument in get_evaluator_yag_2d.
+
+    Parameters
+    ----------
+    location : str
+        One of "xcs1", "dg1", "dg2", "ip"
+    mirror_nominal : float
+        The starting mirror pitch position and midpoint of the optimization search.
+    search_delta : float
+        How far +/- we check away from the mirror nominal pitch position
+    """
+    if location not in ("xcs1", "dg1", "dg2", "ip"):
+        raise ValueError("location must be one of xcs1, dg1, dg2, or ip")
+
+    centroid_x_min = centroid_x_min or YAG_CENTROID_X_MIN_MAX[0]
+    centroid_x_max = centroid_x_max or YAG_CENTROID_X_MIN_MAX[1]
+    centroid_y_min = centroid_y_min or YAG_CENTROID_Y_MIN_MAX[0]
+    centroid_y_max = centroid_y_max or YAG_CENTROID_Y_MIN_MAX[1]
+
+    vocs = get_vocs(
+        mirror_nominal=mirror_nominal,
+        search_delta=search_delta,
+        yag_size_min=yag_size_min,
+        yag_size_max=yag_size_max,
+        yag_intensity_min=yag_intensity_min,
+        yag_intensity_max=yag_intensity_max,
+        centroid_x_min=centroid_x_min,
+        centroid_x_max=centroid_x_max,
+        centroid_y_min=centroid_y_min,
+        centroid_y_max=centroid_y_max,
+    )
+    print(vocs)
+    evaluator = get_evaluator_yag_2d(yag=location)
+
+    generator = ExpectedImprovementGenerator(vocs=vocs, turbo_controller=xopt_generator_turbo_controller)
+    generator.gp_constructor.use_low_noise_prior = False
+    return Xopt(
+        vocs=vocs,
+        generator=generator,
+        evaluator=evaluator,
+    )
+
+
 def setup_sim_test() -> None:
     """
     Prep offline test without using mfx hardware or mfx3 startup script


### PR DESCRIPTION
This PR addresses #120. Type checking and input validation is added to the following user-facing classes/functions in `mfx.optimize`:
- `Align` and `align.beam`
- `xopt_scans.get_xopt_obj`
- `blop_scans.get_blop_agent`

Notes/questions:
- with the current defaults having no constraints set for the wave8 detectors, Xopt will fail to run in safe mode. This should be resolved once the new detectors are calibrated and the constraints are updated.
- ~the "ip" location is missing in the `align` module, but is listed in `get_xopt_obj`. Is this something that needs to be adjusted?~ discussed on 4/8, issues created
- ~is blop  only setup up with wave8 and no yag on purpose or does this need development?~ discussed on 4/8, needs development

Remaining to-dos in this PR:
- [X] add validation to `blop_scans` module, similarly to `xopt_scans`
- [X] merge #144 first before adjusting/merging this one
- (edit: will do in another PR) add unit tests that cover all expected data types and potential causes of failures (nans, etc)