### PR TITLE
ENH yag camviewer marker targets

### DIFF
--- a/mfx/optimize/devices.py
+++ b/mfx/optimize/devices.py
@@ -26,11 +26,11 @@ class Marker(Device):
     xpos = Cpt(EpicsSignalRO, "X")
     ypos = Cpt(EpicsSignalRO, "Y")
 
-    def get_coordinate(self) -> np.ndarray[int]:
+    def get_coordinate(self) -> tuple[int, int]:
         coords = (self.xpos.get(), self.ypos.get())
         if coords == (0, 0):
             raise RuntimeError(f"Marker coordinates for {self.name} not initialized!")
-        return np.ndarray(coords)
+        return coords
 
 
 class CamViewerCoords(Device):

--- a/mfx/optimize/devices.py
+++ b/mfx/optimize/devices.py
@@ -150,6 +150,9 @@ class FakeLCLSImagePlugin(LCLSImagePlugin):
             peak=self.__peak,
         )
 
+    def get_centroid(self):
+        return self.__centroid
+
     def sim_set_image(
         self,
         size: tuple[int, int] | None = None,

--- a/mfx/optimize/devices.py
+++ b/mfx/optimize/devices.py
@@ -1,0 +1,200 @@
+"""
+Ophyd devices created for these optimize routines.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+from ophyd.areadetector.plugins import ImagePlugin
+from ophyd.device import Component as Cpt
+from ophyd.device import Device
+from ophyd.signal import AttributeSignal, EpicsSignalRO, Signal
+
+
+class Marker(Device):
+    """
+    Device representing a single camviewer global marker.
+
+    Parameters
+    ----------
+    prefix : str
+        The base prefix of the marker, for example MFX:DG1:P6740:Cross1
+    """
+
+    xpos = Cpt(EpicsSignalRO, "X")
+    ypos = Cpt(EpicsSignalRO, "Y")
+
+    def get_coordinate(self) -> np.ndarray[int]:
+        coords = (self.xpos.get(), self.ypos.get())
+        if coords == (0, 0):
+            raise RuntimeError(f"Marker coordinates for {self.name} not initialized!")
+        return np.ndarray(coords)
+
+
+class CamViewerCoords(Device):
+    """
+    Device for interpretting camviewer's global markers as scan targets.
+
+    Parameters
+    ----------
+    prefix : str
+        The base prefix of the camera, for example MFX:DG1:P6740
+    """
+
+    marker1 = Cpt(Marker, "Cross1")
+    marker2 = Cpt(Marker, "Cross2")
+    marker3 = Cpt(Marker, "Cross3")
+    marker4 = Cpt(Marker, "Cross4")
+
+    def specific_marker_target(self, marker_num: int) -> tuple[int, int]:
+        """
+        Get the coordinates of the specified marker for use as a scan target.
+        """
+        return getattr(self, f"marker{marker_num}").get_coordinate()
+
+    def average_marker_target(
+        self, marker_nums: tuple[int, ...] | list[int]
+    ) -> tuple[int, int]:
+        """
+        Get the coordinate of the average position of the numbered markers.
+        """
+        if not marker_nums:
+            raise ValueError("At least one marker number must be provided.")
+        tot = sum(np.array(self.specific_marker_target(num)) for num in marker_nums)
+        return tuple(tot / len(marker_nums))
+
+    def standard_two_corners_target(self) -> tuple[int, int]:
+        """
+        Get the coordinate defined by markers 1 and 2 placed at the corners.
+
+        Old camviewer versions only allow the user to change markers 1 and 2
+        as global markers, so by convention these markers are placed at
+        diagonally opposite corners of the apparent slit aperture.
+        """
+        return self.average_marker_target((1, 2))
+
+    def standard_box_target(self) -> tuple[int, int]:
+        """
+        Get the coordinate defined by all four markers placed at the corners.
+
+        New camviewer versions allow the user to change all four markers
+        as global markers, so if these are all placed at the four corners
+        the average of four markers may be preferrable to the average of two
+        markers.
+        """
+        return self.average_marker_target((1, 2, 3, 4))
+
+
+class LCLSImagePlugin(ImagePlugin):
+    """
+    Small patch on top of built-in Image plugin to work around bug/incompatibility.
+    """
+
+    shaped_image = Cpt(AttributeSignal, "image", add_prefix=(), kind="omitted")
+
+
+class YagCamera(Device):
+    """
+    One area detector camera on the beamline.
+
+    Customized with what is most useful for us during an optimization routine.
+    """
+
+    image1 = Cpt(LCLSImagePlugin, "IMAGE1:")
+    coords = Cpt(CamViewerCoords, "")
+
+
+class FakeMarker(Marker):
+    """
+    Fake Marker to facilitate testing.
+    """
+
+    xpos = Cpt(Signal)
+    ypos = Cpt(Signal)
+
+
+class FakeCoords(CamViewerCoords):
+    """
+    Fake CamViewerCoords to facilitate testing.
+    """
+
+    marker1 = Cpt(FakeMarker, "")
+    marker2 = Cpt(FakeMarker, "")
+    marker3 = Cpt(FakeMarker, "")
+    marker4 = Cpt(FakeMarker, "")
+
+
+class FakeLCLSImagePlugin(LCLSImagePlugin):
+    """
+    Fake LCLSImagePlugin to facilitate testing.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__size = (500, 500)
+        self.__centroid = (100, 100)
+        self.__fwhm = 10
+        self.__peak = 255
+        self.__updater = lambda _: None
+
+    @property
+    def image(self):
+        self.__updater(self)
+        return fake_yag_image(
+            size=self.__size,
+            centroid=self.__centroid,
+            fwhm=self.__fwhm,
+            peak=self.__peak,
+        )
+
+    def sim_set_image(
+        self,
+        size: tuple[int, int] | None = None,
+        centroid: tuple[int, int] | None = None,
+        fwhm: int | None = None,
+        peak: int | None = None,
+    ):
+        """Test-only helper to set up the image."""
+        if size is not None:
+            self.__size = size
+        if centroid is not None:
+            self.__centroid = centroid
+        if fwhm is not None:
+            self.__fwhm = fwhm
+        if peak is not None:
+            self.__fwhm = fwhm
+
+    def sim_install_updater(self, updater: Callable[[FakeLCLSImagePlugin], None]):
+        """
+        Install an imager updater function to be run before we get the image.
+        """
+        self.__updater = updater
+
+
+def fake_yag_image(
+    size: tuple[int, int],
+    centroid: tuple[int, int],
+    fwhm: int,
+    peak: int,
+) -> np.ndarray:
+    """
+    Return a gaussian blob that sort of looks like a beam profile.
+    """
+    # Adapted from https://stackoverflow.com/questions/7687679/how-to-generate-2d-gaussian-with-python
+    x = np.arange(0, size[0], 1, float)
+    y = np.arange(0, size[1], 1, float)[:, np.newaxis]
+    x0 = centroid[0]
+    y0 = centroid[1]
+    arr = np.exp(-4 * np.log(2) * ((x - x0) ** 2 + (y - y0) ** 2) / fwhm**2)
+    return arr * peak
+
+
+class FakeYagCamera(YagCamera):
+    """
+    Fake YagCamera for testing.
+    """
+
+    image1 = Cpt(FakeLCLSImagePlugin, "IMAGE1:")
+    coords = Cpt(FakeCoords, "")

--- a/mfx/optimize/devices.py
+++ b/mfx/optimize/devices.py
@@ -82,7 +82,8 @@ class CamViewerCoords(Device):
         New camviewer versions allow the user to change all four markers
         as global markers, so if these are all placed at the four corners
         the average of four markers may be preferrable to the average of two
-        markers.
+        markers. This makes it so the function is not sentitive to
+        marker ordering, for example.
         """
         return self.average_marker_target((1, 2, 3, 4))
 

--- a/mfx/optimize/mirror_hw.py
+++ b/mfx/optimize/mirror_hw.py
@@ -160,7 +160,7 @@ def sim_devices() -> dict[str, Device]:
         devices[name].coords.marker1.xpos.put(100)
         devices[name].coords.marker1.ypos.put(100)
         devices[name].coords.marker2.xpos.put(500)
-        devices[name].coords.marker2.ypos.put(500)
+        devices[name].coords.marker2.ypos.put(950)
 
     devices["mfx_dg1_wave8"].kind = "hinted"
     devices["mfx_dg2_wave8"].kind = "hinted"

--- a/mfx/optimize/mirror_hw.py
+++ b/mfx/optimize/mirror_hw.py
@@ -4,14 +4,12 @@ Initialize hardware for blop_scans and xopt_scans
 import random
 from types import SimpleNamespace
 
-import numpy as np
 from happi import Client
-from ophyd.areadetector.plugins import ImagePlugin
-from ophyd.device import Component as Cpt
 from ophyd.device import Device
-from ophyd.signal import AttributeSignal
 from ophyd.sim import SynAxis, SynSignal
 from pcdsdevices.ipm import Wave8
+
+from .devices import FakeLCLSImagePlugin, FakeYagCamera, YagCamera
 
 HAPPI_NAMES = (
     "mr1l4_homs",
@@ -35,10 +33,6 @@ WAVE8_CENTROID_X_MIN_MAX = (None, None)
 WAVE8_CENTROID_Y_MIN_MAX = (None, None)
 
 devices: dict[str, Device] = {}
-
-
-class LCLSImagePlugin(ImagePlugin):
-    shaped_image = Cpt(AttributeSignal, "image", add_prefix=(), kind="omitted")
 
 
 def init_devices(force: bool = False) -> dict[str, Device]:
@@ -65,12 +59,11 @@ def init_devices(force: bool = False) -> dict[str, Device]:
     # Happi PIMs don't work how I want them to, add manually
     for stand in ("dg1", "dg2"):
         name = f"mfx_{stand}_yag"
-        devices[name] = LCLSImagePlugin(f"MFX:{stand.upper()}:P6740:IMAGE1:", name=name)
+        devices[name] = YagCamera(f"MFX:GIGE:{stand.upper()}:YAG:", name=name)
         devices[name].kind = "hinted"
-    name = "xcs_yag1"
-    devices[name] = LCLSImagePlugin(f"XCS:GIGE:YAG1:IMAGE1:", name=name)
 
-    devices["mfx_ip_yag"] = LCLSImagePlugin("MFX:GIGE:LBL:01:IMAGE1:", name="mfx_ip1_yag")
+    devices["xcs_yag1"] = YagCamera("XCS:GIGE:YAG1:", name="xcs_yag1")
+    devices["mfx_ip_yag"] = YagCamera("MFX:GIGE:LBL:01:", name="mfx_ip1_yag")
     devices["mfx_ip_yag"].kind = "hinted"
 
     return devices
@@ -104,34 +97,6 @@ def sim_devices() -> dict[str, Device]:
         pitch = devices["mr1l4_homs"].pitch.position
         return pitch - MIRROR_NOMINAL + DG2_WAVE8_XPOS + dg2_wave8_offset + random.uniform(-0.1, 0.1)
 
-    def get_fake_dg1_yag() -> np.ndarray:
-        pitch = devices["mr1l4_homs"].pitch.position
-        return fake_yag_image(
-            size=(640, 480),
-            centroid=((pitch - MIRROR_NOMINAL) * 30 + DG1_YAG_XPOS + dg1_yag_offset + random.uniform(-3, 3), 240 + random.uniform(-3, 3)),
-            fwhm=30,
-            peak=255,
-        )
-
-    def get_fake_dg2_yag() -> np.ndarray:
-        pitch = devices["mr1l4_homs"].pitch.position
-        return fake_yag_image(
-            size=(640, 480),
-            centroid=((pitch - MIRROR_NOMINAL) * 50 + DG2_YAG_XPOS + dg2_yag_offset + random.uniform(-5, 5), 240 + random.uniform(-5, 5)),
-            fwhm=50,
-            peak=255,
-        )
-
-    def get_fake_ip_yag() -> np.ndarray:
-        pitch = devices["mr1l4_homs"].pitch.position
-        return fake_yag_image(
-            size=(688, 538),
-            centroid=((pitch - MIRROR_NOMINAL) * 70 + IP_YAG_XPOS + ip_yag_offset + random.uniform(-7, 7), 269 + random.uniform(-7, 7)),
-            fwhm=70,
-            peak=255,
-        )
-
-
     devices["mfx_dg1_wave8"] = SimpleNamespace(
         xpos=SynSignal(
             func=get_fake_dg1_wave8,
@@ -144,28 +109,57 @@ def sim_devices() -> dict[str, Device]:
             name="mfx_dg2_wave8_xpos"
         )
     )
-    devices["mfx_dg1_yag"] = SimpleNamespace(
-        shaped_image=SynSignal(
-            func=get_fake_dg1_yag,
-            name="mfx_dg1_yag_shaped_image",
+    devices["mfx_dg1_yag"] = FakeYagCamera("", name="mfx_dg1_yag")
+    devices["mfx_dg2_yag"] = FakeYagCamera("", name="mfx_dg2_yag")
+    devices["xcs_yag1"] = FakeYagCamera("", name="xcs_yag1")
+    devices["mfx_ip_yag"] = FakeYagCamera("", name="mfx_ip_yag")
+
+    def update_fake_dg1_yag(cam: FakeLCLSImagePlugin):
+        pitch = devices["mr1l4_homs"].pitch.position
+        cam.sim_set_image(
+            size=(1388, 1038),
+            centroid=((pitch - MIRROR_NOMINAL) * 60 + DG1_YAG_XPOS + dg1_yag_offset + random.uniform(-6, 6), 519 + random.uniform(-3, 3)),
+            fwhm=30,
+            peak=255,
         )
-    )
-    devices["mfx_dg2_yag"] = SimpleNamespace(
-        shaped_image=SynSignal(
-            func=get_fake_dg2_yag,
-            name="mfx_dg2_yag_shaped_image",
+
+    def update_fake_dg2_yag(cam: FakeLCLSImagePlugin):
+        pitch = devices["mr1l4_homs"].pitch.position
+        cam.sim_set_image(
+            size=(1388, 1038),
+            centroid=((pitch - MIRROR_NOMINAL) * 80 + DG2_YAG_XPOS + dg2_yag_offset + random.uniform(-8, 8), 519 + random.uniform(-5, 5)),
+            fwhm=50,
+            peak=255,
         )
-    )
-    devices["mfx_ip_yag"] = SimpleNamespace(
-        shaped_image=SynSignal(
-            func=get_fake_ip_yag,
-            name="mfx_ip_yag_shaped_image",
+
+    def update_fake_xcs_yag1(cam: FakeLCLSImagePlugin):
+        pitch = devices["mr1l4_homs"].pitch.position
+        cam.sim_set_image(
+            size=(728, 544),
+            centroid=((pitch - MIRROR_NOMINAL) * 70 + XCS_YAG_XPOS + ip_yag_offset + random.uniform(-7, 7), 274 + random.uniform(-7, 7)),
+            fwhm=70,
+            peak=255,
         )
-    )
+
+    def update_fake_ip1_yag(cam: FakeLCLSImagePlugin):
+        pitch = devices["mr1l4_homs"].pitch.position
+        cam.sim_set_image(
+            size=(688, 538),
+            centroid=((pitch - MIRROR_NOMINAL) * 70 + IP_YAG_XPOS + ip_yag_offset + random.uniform(-7, 7), 269 + random.uniform(-7, 7)),
+            fwhm=70,
+            peak=255,
+        )
+
+    devices["mfx_dg1_yag"].image1.sim_install_updater(update_fake_dg1_yag)
+    devices["mfx_dg2_yag"].image1.sim_install_updater(update_fake_dg2_yag)
+    devices["xcs_yag1"].image1.sim_install_updater(update_fake_xcs_yag1)
+    devices["mfx_ip_yag"].image1.sim_install_updater(update_fake_ip1_yag)
+
     devices["mfx_dg1_wave8"].kind = "hinted"
     devices["mfx_dg2_wave8"].kind = "hinted"
     devices["mfx_dg1_yag"].kind = "hinted"
     devices["mfx_dg2_yag"].kind = "hinted"
+    devices["xcs_yag1"].kind = "hinted"
     devices["mfx_ip_yag"].kind = "hinted"
 
     print("Generated fake dg1 and dg2 signals and images")
@@ -183,17 +177,3 @@ def sim_devices() -> dict[str, Device]:
 
     return devices
 
-
-def fake_yag_image(
-    size: tuple[int, int],
-    centroid: tuple[int, int],
-    fwhm: int,
-    peak: int,
-) -> np.ndarray:
-    # Adapted from https://stackoverflow.com/questions/7687679/how-to-generate-2d-gaussian-with-python
-    x = np.arange(0, size[0], 1, float)
-    y = np.arange(0, size[1], 1, float)[:, np.newaxis]
-    x0 = centroid[0]
-    y0 = centroid[1]
-    arr = np.exp(-4*np.log(2) * ((x-x0)**2 + (y-y0)**2) / fwhm**2)
-    return arr * peak

--- a/mfx/optimize/mirror_hw.py
+++ b/mfx/optimize/mirror_hw.py
@@ -155,6 +155,13 @@ def sim_devices() -> dict[str, Device]:
     devices["xcs_yag1"].image1.sim_install_updater(update_fake_xcs_yag1)
     devices["mfx_ip_yag"].image1.sim_install_updater(update_fake_ip1_yag)
 
+    # Aim vaguely toward 300, 300 for the 2d camviewer marker test
+    for name in ("mfx_dg1_yag", "mfx_dg2_yag", "xcs_yag1", "mfx_ip_yag"):
+        devices[name].coords.marker1.xpos.put(100)
+        devices[name].coords.marker1.ypos.put(100)
+        devices[name].coords.marker2.xpos.put(500)
+        devices[name].coords.marker2.ypos.put(500)
+
     devices["mfx_dg1_wave8"].kind = "hinted"
     devices["mfx_dg2_wave8"].kind = "hinted"
     devices["mfx_dg1_yag"].kind = "hinted"

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -193,7 +193,7 @@ def get_evaluator_yag_2d(
         results["rms_size_x"] = fit_result.rms_size[0]
         results["rms_size_y"] = fit_result.rms_size[1]
         results["total_intensity"] = fit_result.total_intensity
-        results["objective"] = np.sqrt((fit_result.centroid[0] - goal[0])**2 + (fit_result.centroid[1] - goal[1]))
+        results["objective"] = np.sqrt((fit_result.centroid[0] - goal[0])**2 + (fit_result.centroid[1] - goal[1])**2)
         print(f"Distance from goal is {results['objective']}")
         return results
 

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -127,9 +127,9 @@ def get_evaluator_yag(
         devices = init_devices()
         devices["mr1l4_homs"].pitch.set(input["mirror_pitch"]).wait(timeout=20)
         if yag == 'xcs1':
-            image_device = devices["xcs_yag1"].shaped_image
+            image_device = devices["xcs_yag1"].image1.shaped_image
         else:
-            image_device = devices[f"mfx_{yag}_yag"].shaped_image
+            image_device = devices[f"mfx_{yag}_yag"].image1.shaped_image
         image_device.trigger().wait(timeout=10)
         image = image_device.get()
         print(f"image shape: {image.shape}")

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -443,24 +443,36 @@ def run_sim_test_yag_2d() -> Xopt:
     print("Randomly evaluate 3 points")
     xopt.random_evaluate(3)
     print("Step xopt object 10 times")
+    imager = init_devices()["mfx_dg1_yag"]
+    centroids = [imager.image1.get_centroid()]
     for num in range(10):
         print(f"Step {num + 1}")
         xopt.step()
+        centroids.append(imager.image1.get_centroid())
     print("Get best point")
     _, val, params = xopt.vocs.select_best(xopt.data)
     print(f"Best objective value {val}")
     print(f"Best point {params}")
     print("Move to best point")
-    mirror_pitch = init_devices()["mr1l4_homs"].pitch
+    devices = init_devices()
+    mirror_pitch = devices["mr1l4_homs"].pitch
     mirror_pitch.set(params["mirror_pitch"]).wait(timeout=20)
     print(f"pitch is at {mirror_pitch.position}")
+    goal = devices["mfx_dg1_yag"].coords.standard_two_corners_target()
+    print(f"Goal was {goal}")
     print("Generating plots")
     xopt.data.plot(y=xopt.vocs.objective_names)
-    imager = init_devices()["mfx_dg1_yag"]
+
     imager.image1.shaped_image.trigger()
     fit = ImageProjectionFit()
-    fit_result = fit.fit_image(imager.image1.shaped_image.get())
+    image = imager.image1.shaped_image.get()
+    fit_result = fit.fit_image(image)
     plot_image_projection_fit(fit_result)
+    plt.figure()
+    plt.imshow(image)
+    plt.plot(*goal, marker="o", color="red")
+    for pt in centroids:
+        plt.plot(*pt, marker=".", color="white")
     plt.show()
     return xopt
 

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -5,6 +5,7 @@ Or python -m mfx.optimize.xopt_scans for a default sim run-through
 """
 from __future__ import annotations
 
+import numpy as np
 import matplotlib.pyplot as plt
 from xopt import VOCS, Evaluator, Xopt
 from xopt.generators.bayesian import ExpectedImprovementGenerator
@@ -104,6 +105,13 @@ def get_evaluator_wave8(
     return Evaluator(function=evaluate)
 
 
+def get_yag_key(yag: str):
+    if yag == 'xcs1':
+        return "xcs_yag1"
+    else:
+        return f"mfx_{yag}_yag"
+
+
 def get_evaluator_yag(
     yag: str = "dg1",
     yag_xpos: float | None = None,
@@ -126,10 +134,7 @@ def get_evaluator_yag(
         print(f"Trying {input['mirror_pitch']}")
         devices = init_devices()
         devices["mr1l4_homs"].pitch.set(input["mirror_pitch"]).wait(timeout=20)
-        if yag == 'xcs1':
-            image_device = devices["xcs_yag1"].image1.shaped_image
-        else:
-            image_device = devices[f"mfx_{yag}_yag"].image1.shaped_image
+        image_device = devices[get_yag_key(yag)].image1.shaped_image
         image_device.trigger().wait(timeout=10)
         image = image_device.get()
         print(f"image shape: {image.shape}")
@@ -142,6 +147,53 @@ def get_evaluator_yag(
         results["rms_size_y"] = fit_result.rms_size[1]
         results["total_intensity"] = fit_result.total_intensity
         results["objective"] = abs(fit_result.centroid[0] - yag_xpos)
+        print(f"Distance from goal is {results['objective']}")
+        return results
+
+    return Evaluator(function=evaluate)
+
+
+def get_evaluator_yag_2d(
+    yag: str = "dg1",
+    goal: tuple[float, float] | None = None,
+):
+    """
+    Alternate evaluator in 2d space.
+
+    As a default, uses the automatic selection of goal position from the
+    user marker PVs.
+    """
+    yag = yag.lower()
+    if yag not in ("xcs1", "dg1", "dg2", "ip"):
+        raise ValueError("Can only use xcs1, dg1, dg2, ip yags.")
+    devices = init_devices()
+    imager = devices[get_yag_key(yag)]
+    image_device = imager.image1.shaped_image
+    mirror = devices["mr1l4_homs"]
+
+    if goal is None:
+        goal = imager.coords.standard_two_corners_target()
+        print(f"Goal is {goal} from camviewer markers")
+    else:
+        print(f"Goal is {goal} from function input")
+
+    fit = ImageProjectionFit()
+
+    def evaluate(input: dict[str, float]) -> dict[str, float]:
+        print(f"Trying {input['mirror_pitch']}")
+        mirror.pitch.set(input["mirror_pitch"]).wait(timeout=20)
+        image_device.trigger().wait(timeout=10)
+        image = image_device.get()
+        print(f"image shape: {image.shape}")
+        # NOTE/TODO: consider adding an averaging step here before fitting
+        fit_result = fit.fit_image(image)
+        results = {}
+        results["centroid_x"] = fit_result.centroid[0]
+        results["centroid_y"] = fit_result.centroid[1]
+        results["rms_size_x"] = fit_result.rms_size[0]
+        results["rms_size_y"] = fit_result.rms_size[1]
+        results["total_intensity"] = fit_result.total_intensity
+        results["objective"] = np.sqrt((fit_result.centroid[0] - goal[0])**2 + (fit_result.centroid[1] - goal[1]))
         print(f"Distance from goal is {results['objective']}")
         return results
 
@@ -252,6 +304,67 @@ def get_xopt_obj(
     )
 
 
+def get_xopt_obj_2d_markers(
+    location: str,
+    mirror_nominal: float = MIRROR_NOMINAL,
+    search_delta: float = 5,
+    yag_size_min: float | None = None,
+    yag_size_max: float | None = None,
+    yag_intensity_min: float | None = None,
+    yag_intensity_max: float | None = None,
+    centroid_x_min: float = None,
+    centroid_x_max: float = None,
+    centroid_y_min: float = None,
+    centroid_y_max: float = None,
+    xopt_generator_turbo_controller: str | None = None,
+) -> Xopt:
+    """
+    Create an appropriate xopt optimization object for a 2D YAG optimization.
+
+    Uses the camviewer markers as a goal only by using the default goal
+    argument in get_evaluator_yag_2d.
+
+    Parameters
+    ----------
+    location : str
+        One of "xcs1", "dg1", "dg2", "ip"
+    mirror_nominal : float
+        The starting mirror pitch position and midpoint of the optimization search.
+    search_delta : float
+        How far +/- we check away from the mirror nominal pitch position
+    """
+    if location not in ("xcs1", "dg1", "dg2", "ip"):
+        raise ValueError("location must be one of xcs1, dg1, dg2, or ip")
+
+    centroid_x_min = centroid_x_min or YAG_CENTROID_X_MIN_MAX[0]
+    centroid_x_max = centroid_x_max or YAG_CENTROID_X_MIN_MAX[1]
+    centroid_y_min = centroid_y_min or YAG_CENTROID_Y_MIN_MAX[0]
+    centroid_y_max = centroid_y_max or YAG_CENTROID_Y_MIN_MAX[1]
+
+    vocs = get_vocs(
+        mirror_nominal=mirror_nominal,
+        search_delta=search_delta,
+        yag_size_min=yag_size_min,
+        yag_size_max=yag_size_max,
+        yag_intensity_min=yag_intensity_min,
+        yag_intensity_max=yag_intensity_max,
+        centroid_x_min=centroid_x_min,
+        centroid_x_max=centroid_x_max,
+        centroid_y_min=centroid_y_min,
+        centroid_y_max=centroid_y_max,
+    )
+    print(vocs)
+    evaluator = get_evaluator_yag_2d(yag=location)
+
+    generator = ExpectedImprovementGenerator(vocs=vocs, turbo_controller=xopt_generator_turbo_controller)
+    generator.gp_constructor.use_low_noise_prior = False
+    return Xopt(
+        vocs=vocs,
+        generator=generator,
+        evaluator=evaluator,
+    )
+
+
 def setup_sim_test() -> None:
     """
     Prep offline test without using mfx hardware or mfx3 startup script
@@ -314,9 +427,39 @@ def run_sim_test_yag() -> Xopt:
     print("Generating plots")
     xopt.data.plot(y=xopt.vocs.objective_names)
     imager = init_devices()["mfx_dg1_yag"]
-    imager.shaped_image.trigger()
+    imager.image1.shaped_image.trigger()
     fit = ImageProjectionFit()
-    fit_result = fit.fit_image(imager.shaped_image.get())
+    fit_result = fit.fit_image(imager.image1.shaped_image.get())
+    plot_image_projection_fit(fit_result)
+    plt.show()
+    return xopt
+
+
+def run_sim_test_yag_2d() -> Xopt:
+    print("Create Xopt")
+    xopt = get_xopt_obj_2d_markers(
+        location="dg1",
+    )
+    print("Randomly evaluate 3 points")
+    xopt.random_evaluate(3)
+    print("Step xopt object 10 times")
+    for num in range(10):
+        print(f"Step {num + 1}")
+        xopt.step()
+    print("Get best point")
+    _, val, params = xopt.vocs.select_best(xopt.data)
+    print(f"Best objective value {val}")
+    print(f"Best point {params}")
+    print("Move to best point")
+    mirror_pitch = init_devices()["mr1l4_homs"].pitch
+    mirror_pitch.set(params["mirror_pitch"]).wait(timeout=20)
+    print(f"pitch is at {mirror_pitch.position}")
+    print("Generating plots")
+    xopt.data.plot(y=xopt.vocs.objective_names)
+    imager = init_devices()["mfx_dg1_yag"]
+    imager.image1.shaped_image.trigger()
+    fit = ImageProjectionFit()
+    fit_result = fit.fit_image(imager.image1.shaped_image.get())
     plot_image_projection_fit(fit_result)
     plt.show()
     return xopt


### PR DESCRIPTION
## Major Changes
- Implements some Ophyd devices for using the camviewer global marker PVs to get coordinate goals for alignment.
- Implement a separate 2d YAG alignment branch of the xopt setup.
  - Rather than aim for a specific X position, this aims for 2d distance from the goal coordinates
  - I needed to implement this because the alignment routine doesn't have any conception of camera orientation. The user will be selecting points by putting down markers on their GUI. The user's visual coordinates are not necessarily rotated to be the same direction as the raw coordinates, but the underlying marker coordinates are always in the original coordinates of the raw image, so we can take these coordinates and apply them in the context of the raw camera image. Rather than try to pick which one to use out of the x and y axes, use both!
  - Note that since the mirrors only align in x, we won't typically be able to get the distance close to zero, but we should still be able to find a minimum.
  - Possibly more generalized 2d goals can be re-used more easily for vertical alignment given interfaces to ACR pointing
  
Side thought: I think having more functions like this 2d xopt builder I added will be more sustainable compared to expanding the existing xopt assembler until it has a million arguments. It makes me want to break this function down even more. (That being said, I probably didn't deduplicate as much as I could have here...)

## Minor Changes

- Implements some overly basic simulated hardware for the above for surface-level testing.
- Refactors a bit of how we were setting up these simulated devices so I could include all the test/sim elements in one place.
- Expand the camera classes a bit in general, so that we can include images and other area detector plugins in the same class object. This breaks a bunch of downstream code that I subsequently fix here.
- Update the simulated imagers to be the same apparent size as the new imagers that are being installed.

closes #122 

## Misc

- Update the PVs for the DG1 and DG2 yags to match the new gige cameras.

closes #143 

## Todo before merge or in separate PR
- [ ] Include some of the techniques from #133 after we merge it for consistent validation and type checking in the items added here.

## Testing
To test this, I've been running a one-liner in ipython
```
In [1]: %matplotlib qt
In [2]: from mfx.optimize.xopt_scans import setup_sim_test, run_sim_test_yag_2d; setup_sim_test(); run_sim_test_yag_2d()
```

![image](https://github.com/user-attachments/assets/927379d1-1536-46a4-b039-519599edac74)


Sample output:

<details>

```
(pcds-5.9.1)zlentz@psbuild-rhel7-02:~/github/mfx(122-camviewer-targets +)$ ipython
Python 3.9.19 | packaged by conda-forge | (main, Mar 20 2024, 12:50:21)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.4.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: %matplotlib qt

In [2]: from mfx.optimize.xopt_scans import setup_sim_test, run_sim_test_yag_2d; setup_sim_test(); run_sim_test_yag_2d()
Creating sim devices
Generated fake dg1 and dg2 signals and images
Expected: 1:1 linear relationship between x and pitch
Expected: dg1 wave8 reads 8.747835816703216 + noise when pitch is -548
Expected: dg2 wave8 reads 41.36762704526856 + noise when pitch is -548
Expected: dg1 yag reads 189.01864230951958 + noise when pitch is -548
Expected: dg2 yag reads 194.1957695972984 + noise when pitch is -548
Expected: dg2 yag reads 298.18177783017677 + noise when pitch is -548
default alignment on dg1 wave8 should pick -548.7478358167032
default alignment on dg2 wave8 should pick -548.3676270452686
default alignment on dg1 yag should pick -546.0186423095196
default alignment on dg2 yag should pick -551.1957695972984
default alignment on ip yag should pick -502.18177783017677
devices: ['mr1l4_homs', 'mfx_dg1_ipm', 'mfx_dg2_ipm', 'mfx_dg1_wave8', 'mfx_dg2_wave8', 'mfx_dg1_yag', 'mfx_dg2_yag', 'xcs_yag1', 'mfx_ip_yag']
Xopt factory: get_xopt_obj
Canned tests: run_sim_test_wave8, run_sim_test_yag
Create Xopt
variables={'mirror_pitch': [-553.0, -543.0]} constraints={'centroid_x': ['LESS_THAN', 430.0], 'centroid_y': ['LESS_THAN', 600.0]} objectives={'objective': 'MINIMIZE'} constants={} observables=[]
Goal is (300.0, 300.0) from camviewer markers
Randomly evaluate 3 points
Trying -543.1628975491434
image shape: (1038, 1388)
/cds/home/z/zlentz/github/mfx/dev/devpath/lcls_tools/common/data/fit/projection.py:82: OptimizeWarning: Initial guess is not within the specified bounds
  res = scipy.optimize.minimize(
Distance from goal is 183.12936339532354
Trying -547.6627349833389
image shape: (1038, 1388)
Distance from goal is 86.48695418824084
Trying -549.4220442271788
image shape: (1038, 1388)
Distance from goal is 200.45749518838213
Step xopt object 10 times
Step 1
Trying -546.2997525605696
image shape: (1038, 1388)
/cds/home/z/zlentz/github/mfx/dev/devpath/lcls_tools/common/data/fit/projection.py:82: OptimizeWarning: Initial guess is not within the specified bounds
  res = scipy.optimize.minimize(
Distance from goal is 16.254561023908405
Step 2
Trying -545.7903627986207
image shape: (1038, 1388)
/cds/home/z/zlentz/github/mfx/dev/devpath/lcls_tools/common/data/fit/projection.py:82: OptimizeWarning: Initial guess is not within the specified bounds
  res = scipy.optimize.minimize(
Distance from goal is 29.994124211881786
Step 3
Trying -553.0
image shape: (1038, 1388)
/cds/home/z/zlentz/github/mfx/dev/devpath/lcls_tools/common/data/fit/projection.py:82: OptimizeWarning: Initial guess is not within the specified bounds
  res = scipy.optimize.minimize(
Distance from goal is 286.418731763571
Step 4
Trying -546.3359286509636
image shape: (1038, 1388)
/cds/home/z/zlentz/github/mfx/dev/devpath/lcls_tools/common/data/fit/projection.py:82: OptimizeWarning: Initial guess is not within the specified bounds
  res = scipy.optimize.minimize(
Distance from goal is 22.387417210221056
Step 5
Trying -546.3472274180754
image shape: (1038, 1388)
/cds/home/z/zlentz/github/mfx/dev/devpath/lcls_tools/common/data/fit/projection.py:82: OptimizeWarning: Initial guess is not within the specified bounds
  res = scipy.optimize.minimize(
Distance from goal is 20.935464439560395
Step 6
Trying -546.3867884448414
image shape: (1038, 1388)
/cds/home/z/zlentz/github/mfx/dev/devpath/lcls_tools/common/data/fit/projection.py:82: OptimizeWarning: Initial guess is not within the specified bounds
  res = scipy.optimize.minimize(
Distance from goal is 23.76217051618352
Step 7
Trying -546.1507796079177
image shape: (1038, 1388)
/cds/home/z/zlentz/github/mfx/dev/devpath/lcls_tools/common/data/fit/projection.py:82: OptimizeWarning: Initial guess is not within the specified bounds
  res = scipy.optimize.minimize(
Distance from goal is 15.050159742869509
Step 8
Trying -546.1229262977898
image shape: (1038, 1388)
/cds/home/z/zlentz/github/mfx/dev/devpath/lcls_tools/common/data/fit/projection.py:82: OptimizeWarning: Initial guess is not within the specified bounds
  res = scipy.optimize.minimize(
Distance from goal is 14.814097603310016
Step 9
Trying -546.1222079860487
image shape: (1038, 1388)
/cds/home/z/zlentz/github/mfx/dev/devpath/lcls_tools/common/data/fit/projection.py:82: OptimizeWarning: Initial guess is not within the specified bounds
  res = scipy.optimize.minimize(
Distance from goal is 14.84196525197746
Step 10
Trying -546.1263043473085
image shape: (1038, 1388)
/cds/home/z/zlentz/github/mfx/dev/devpath/lcls_tools/common/data/fit/projection.py:82: OptimizeWarning: Initial guess is not within the specified bounds
  res = scipy.optimize.minimize(
Distance from goal is 14.925470008559586
Get best point
Best objective value [14.8140976]
Best point {'mirror_pitch': -546.1229262977898}
Move to best point
pitch is at -546.1229262977898
Generating plots
/cds/home/z/zlentz/github/mfx/dev/devpath/lcls_tools/common/data/fit/projection.py:82: OptimizeWarning: Initial guess is not within the specified bounds
  res = scipy.optimize.minimize(
Out[2]:

            Xopt
________________________________
Version: 2.3.0
Data size: 13
Config as YAML:
dump_file: null
evaluator:
  function: mfx.optimize.xopt_scans.get_evaluator_yag_2d.<locals>.evaluate
  function_kwargs: {}
  max_workers: 1
  vectorized: false
generator:
  computation_time:
    acquisition_optimization:
      '0': 10.8157509379
      '1': 1.7106739208
      '2': 1.2340028472
      '3': 1.7268066183
      '4': 2.1338655204
      '5': 1.7138395794
      '6': 1.3365198001
      '7': 1.5216996334
      '8': 15.9435508028
      '9': 18.9231728576
    training:
      '0': 0.8586046733
      '1': 0.4589799084
      '2': 0.5897868313
      '3': 0.4585391879
      '4': 0.4614436738
      '5': 0.5629731491
      '6': 0.4213199057
      '7': 0.5092778802
      '8': 0.4578539468
      '9': 0.415383365
  custom_objective: null
  fixed_features: null
  gp_constructor:
    covar_modules: {}
    custom_noise_prior: null
    mean_modules: {}
    name: standard
    trainable_mean_keys: []
    transform_inputs: true
    use_low_noise_prior: false
  log_transform_acquisition_function: false
  max_travel_distances: null
  n_candidates: 1
  n_interpolate_points: null
  n_monte_carlo_samples: 128
  name: expected_improvement
  numerical_optimizer:
    max_iter: 2000
    max_time: null
    n_restarts: 20
    name: LBFGS
  supports_batch_generation: true
  turbo_controller: null
  use_cuda: false
max_evaluations: null
serialize_inline: false
serialize_torch: false
strict: true
vocs:
  constants: {}
  constraints:
    centroid_x:
    - LESS_THAN
    - 430.0
    centroid_y:
    - LESS_THAN
    - 600.0
  objectives:
    objective: MINIMIZE
  observables: []
  variables:
    mirror_pitch:
    - -553.0
    - -543.0


In [3]:
```

</details>