### PR TITLE
Added beam scan attribute.

### DIFF
--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -165,7 +165,7 @@ class Beam:
             num_events_per_step: int = 120,
             record: bool = True
             ):
-        """Perform Beam Alignment
+        """Perform Beam Scan
 
         Parameters
         ----------

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -151,3 +151,57 @@ class Beam:
             return agent
         else:
             raise ValueError("Only 'xopt' and 'blop' methods are supported.")
+
+    @validate_w_lowercase_args
+    def scan(
+            self,
+            on_diagnostic: Diagnostics = "dg1",
+            using_device: Devices = "yag",
+            mirror_pitch_start = self.mirror_pitch[0],
+            mirror_pitch_end = self.mirror_pitch[1],
+            num_steps: int = 51,
+            sequencer_fps: int = 120,
+            num_events_per_step: int = 120,
+            record=True
+            ):
+        """Perform Beam Alignment
+
+        Parameters
+        ----------
+        on_diagnostic : str, optional
+            Diagnostic to use for alignment. Options: "xcs1, dg1, dg2". Default is "dg1".
+        using_device : str, optional
+            Device to use for alignment. Options: "yag, wave8". Default is "yag".
+        mirror_pitch_start : int, optional
+            Starting mirror pitch for scan.
+        mirror_pitch_end : int, optional
+            Final mirror pitch for scan.
+        num_steps : int, optional
+            Number of steps in scan.
+        sequencer_fps : int, optional
+            Sequencer rate in fps.
+        num_events_per_step : int, optional
+            Number of events to record per step.
+        record : bool, optional
+            Whether to record or not.
+        """
+        from .xopt_scans import get_xopt_obj, init_devices
+
+        if using_device == "yag":
+            from mfx.autorun import ioc_cam_recorder
+            cam_record_length = 1.5 * num_steps * num_events_per_step / sequencer_fps
+            ioc_cam_recorder(f"MFX:GIGE:{on_diagnostic.upper()}:YAG:",
+                             cam_record_length,
+                             tag=f"{on_diagnostic}_mr1l4_scan")
+
+        RE(
+            daq_scan(
+                [],
+                init_devices()["mr1l4_homs"].pitch,
+                mirror_pitch_start,
+                mirror_pitch_end,
+                num_steps,
+                events=num_events_per_step,
+                record=record
+            )
+        )

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -210,7 +210,7 @@ class Beam:
 
         RE(
             bp.scan(
-                daq,
+                [daq],
                 init_devices()["mr1l4_homs"].pitch,
                 mirror_pitch_start,
                 mirror_pitch_end,

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -2,6 +2,7 @@ import traceback
 from typing import Literal
 from pydantic import validate_call, ConfigDict
 from bluesky import RunEngine
+from mfx.db import daq
 
 
 Diagnostics = Literal["xcs1", "dg1", "dg2"]
@@ -185,6 +186,16 @@ class Beam:
         record : bool, optional
             Whether to record or not.
         """
+        try:
+            from mfx.db import RE
+        except ImportError:
+            RE = RunEngine({})
+
+        try:
+            from mfx.db import daq
+        except ImportError:
+            print("> access to the daq is required to scan the beam.")
+
         from .xopt_scans import init_devices
 
         if using_device == "yag":
@@ -198,8 +209,8 @@ class Beam:
             print(f"beam.scan: writing {tag} to /cds/data/iocData while scanning...")
 
         RE(
-            daq_scan(
-                [],
+            bp.scan(
+                daq,
                 init_devices()["mr1l4_homs"].pitch,
                 mirror_pitch_start,
                 mirror_pitch_end,

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -185,14 +185,17 @@ class Beam:
         record : bool, optional
             Whether to record or not.
         """
-        from .xopt_scans import get_xopt_obj, init_devices
+        from .xopt_scans import init_devices
 
         if using_device == "yag":
             from mfx.autorun import ioc_cam_recorder
+            cam_pv = f"MFX:GIGE:{on_diagnostic.upper()}:YAG:"
             cam_record_length = 1.5 * num_steps * num_events_per_step / sequencer_fps
-            ioc_cam_recorder(f"MFX:GIGE:{on_diagnostic.upper()}:YAG:",
+            tag = f"{on_diagnostic}_mr1l4_scan"
+            ioc_cam_recorder(cam_pv,
                              cam_record_length,
-                             tag=f"{on_diagnostic}_mr1l4_scan")
+                             tag=tag)
+            print(f"beam.scan: writing {tag} to /cds/data/iocData while scanning...")
 
         RE(
             daq_scan(

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -162,7 +162,7 @@ class Beam:
             num_steps: int = 51,
             sequencer_fps: int = 120,
             num_events_per_step: int = 120,
-            record=True
+            record: bool = True
             ):
         """Perform Beam Alignment
 

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -174,17 +174,17 @@ class Beam:
         using_device : str, optional
             Device to use for alignment. Options: "yag, wave8". Default is "yag".
         mirror_pitch_start : int, optional
-            Starting mirror pitch for scan.
+            Starting mirror pitch for scan. Default is mirror_pitch[0].
         mirror_pitch_end : int, optional
-            Final mirror pitch for scan.
+            Final mirror pitch for scan. Default is mirror_pitch[1]/
         num_steps : int, optional
-            Number of steps in scan.
+            Number of steps in scan. Default is 51.
         sequencer_fps : int, optional
-            Sequencer rate in fps.
+            Sequencer rate in fps. Default is 120.
         num_events_per_step : int, optional
-            Number of events to record per step.
+            Number of events to record per step. Default is 120.
         record : bool, optional
-            Whether to record or not.
+            Whether to record or not. Default is True.
         """
         try:
             from mfx.db import RE


### PR DESCRIPTION
Untested.

# Expected behavior
`beam.scan()` will carry out a mirror scan with a Bluesky plan, optionally recording in the DAQ and through an IOC recorder (in the case of PIM scans).
 
## Initialization
The desired mirror pitch range can be defined when the `beam` object is created.
```python
from mfx.optimize.beam import Beam
beam = Beam(mirror_pitch=[-549.0, -546.0])
```
## Usage
```python
beam.scan()

        """Perform Beam Scan

        Parameters
        ----------
        on_diagnostic : str, optional
            Diagnostic to use for alignment. Options: "xcs1, dg1, dg2". Default is "dg1".
        using_device : str, optional
            Device to use for alignment. Options: "yag, wave8". Default is "yag".
        mirror_pitch_start : int, optional
            Starting mirror pitch for scan. Default is mirror_pitch[0].
        mirror_pitch_end : int, optional
            Final mirror pitch for scan. Default is mirror_pitch[1]/
        num_steps : int, optional
            Number of steps in scan. Default is 51.
        sequencer_fps : int, optional
            Sequencer rate in fps. Default is 120.
        num_events_per_step : int, optional
            Number of events to record per step. Default is 120.
        record : bool, optional
            Whether to record or not. Default is True.
        """
```