### PR TITLE
Refactor centroid path plots for re-use and improvement

### DIFF
--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -1,11 +1,10 @@
 import traceback
 import datetime
-from typing import Literal
+from typing import Literal, Optional
 import matplotlib.pyplot as plt
 from pydantic import validate_call, ConfigDict
 from bluesky import RunEngine
 from xopt import Xopt
-from mfx.db import daq
 
 
 Diagnostics = Literal["xcs1", "dg1", "dg2"]
@@ -55,7 +54,7 @@ class Beam:
     @validate_w_lowercase_args
     def align(
             self,
-            with_goal: float | None = None,
+            with_goal: Optional[float] = None,
             on_diagnostic: Diagnostics = "dg1",
             with_method: Methods = "xopt",
             using_device: Devices = "yag",
@@ -66,8 +65,8 @@ class Beam:
             blop_qei_n: int = 16,
             blop_qei_iterations: int = 5,
             use_2d_markers: bool = False,
-            with_goal_2d: tuple[float, float] | None = None,
-            xopt_obj: Xopt | None = None,
+            with_goal_2d: Optional[tuple[float, float]] = None,
+            xopt_obj: Optional[Xopt] = None,
             save_run: bool = True
             ):
         """Perform Beam Alignment
@@ -198,8 +197,8 @@ class Beam:
             self,
             on_diagnostic: Diagnostics = "dg1",
             using_device: Devices = "yag",
-            mirror_pitch_start = self.mirror_pitch[0],
-            mirror_pitch_end = self.mirror_pitch[1],
+            mirror_pitch_start = None,
+            mirror_pitch_end = None,
             num_steps: int = 51,
             sequencer_fps: int = 120,
             num_events_per_step: int = 120,
@@ -226,6 +225,8 @@ class Beam:
         record : bool, optional
             Whether to record or not. Default is True.
         """
+        mirror_pitch_start = mirror_pitch_start or self.mirror_pitch[0]
+        mirror_pitch_end = mirror_pitch_end or self.mirror_pitch[1]
         try:
             from mfx.db import RE
         except ImportError:

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -225,8 +225,6 @@ class Beam:
         record : bool, optional
             Whether to record or not. Default is True.
         """
-        mirror_pitch_start = mirror_pitch_start or self.mirror_pitch[0]
-        mirror_pitch_end = mirror_pitch_end or self.mirror_pitch[1]
         try:
             from mfx.db import RE
         except ImportError:

--- a/mfx/optimize/beamline_hw.py
+++ b/mfx/optimize/beamline_hw.py
@@ -119,7 +119,7 @@ def sim_devices() -> dict[str, Device]:
         cam.sim_set_image(
             size=(1388, 1038),
             centroid=((pitch - MIRROR_NOMINAL) * 60 + DG1_YAG_XPOS + dg1_yag_offset + random.uniform(-6, 6), 519 + random.uniform(-3, 3)),
-            fwhm=30,
+            fwhm=100,
             peak=255,
         )
 
@@ -128,7 +128,7 @@ def sim_devices() -> dict[str, Device]:
         cam.sim_set_image(
             size=(1388, 1038),
             centroid=((pitch - MIRROR_NOMINAL) * 80 + DG2_YAG_XPOS + dg2_yag_offset + random.uniform(-8, 8), 519 + random.uniform(-5, 5)),
-            fwhm=50,
+            fwhm=150,
             peak=255,
         )
 
@@ -137,7 +137,7 @@ def sim_devices() -> dict[str, Device]:
         cam.sim_set_image(
             size=(728, 544),
             centroid=((pitch - MIRROR_NOMINAL) * 70 + XCS_YAG_XPOS + ip_yag_offset + random.uniform(-7, 7), 274 + random.uniform(-7, 7)),
-            fwhm=70,
+            fwhm=200,
             peak=255,
         )
 
@@ -146,7 +146,7 @@ def sim_devices() -> dict[str, Device]:
         cam.sim_set_image(
             size=(688, 538),
             centroid=((pitch - MIRROR_NOMINAL) * 70 + IP_YAG_XPOS + ip_yag_offset + random.uniform(-7, 7), 269 + random.uniform(-7, 7)),
-            fwhm=70,
+            fwhm=200,
             peak=255,
         )
 
@@ -157,10 +157,10 @@ def sim_devices() -> dict[str, Device]:
 
     # Aim vaguely toward 300, 300 for the 2d camviewer marker test
     for name in ("mfx_dg1_yag", "mfx_dg2_yag", "xcs_yag1", "mfx_ip_yag"):
-        devices[name].coords.marker1.xpos.put(100)
-        devices[name].coords.marker1.ypos.put(100)
-        devices[name].coords.marker2.xpos.put(500)
-        devices[name].coords.marker2.ypos.put(950)
+        devices[name].coords.marker1.xpos.put(200)
+        devices[name].coords.marker1.ypos.put(425)
+        devices[name].coords.marker2.xpos.put(400)
+        devices[name].coords.marker2.ypos.put(625)
 
     devices["mfx_dg1_wave8"].kind = "hinted"
     devices["mfx_dg2_wave8"].kind = "hinted"

--- a/mfx/optimize/interactive.py
+++ b/mfx/optimize/interactive.py
@@ -77,16 +77,20 @@ def misc_setup(autoreload: bool = False):
     """
     Other setup actions that don't create objects
     """
+    from IPython import get_ipython
+    ip = get_ipython()
+
     if autoreload:
         print("Enabling autoreload...")
-        from IPython import get_ipython
-        ip = get_ipython()
         if ip is None:
             raise RuntimeError("Not in an IPython shell, can't setup autoreload!")
         ip.run_line_magic("load_ext", "autoreload")
         ip.run_line_magic("autoreload", "1")
-        line = [f"mfx.optimize.{imp}" for imp in ("beam", "beamline_hw", "blop_scans", "devices", "xopt_scans")]
+        line = [f"mfx.optimize.{imp}" for imp in ("beam", "beamline_hw", "blop_scans", "devices", "plots", "xopt_scans")]
         ip.run_line_magic("aimport", ",".join(line))
+
+    if ip is not None:
+        ip.run_line_magic("matplotlib", "qt")
 
 
 if __name__ == "__main__":

--- a/mfx/optimize/interactive.py
+++ b/mfx/optimize/interactive.py
@@ -50,7 +50,7 @@ def get_objects(sim: bool = False):
     from mfx.optimize.beam import Beam
     from mfx.optimize.beamline_hw import init_devices, sim_devices
     from mfx.optimize.blop_scans import get_blop_agent
-    from mfx.optimize.xopt_scans import get_xopt_obj, get_xopt_obj_2d_markers
+    from mfx.optimize.xopt_scans import get_xopt_obj
 
     if sim:
         print("Creating sim device objects...")
@@ -65,7 +65,6 @@ def get_objects(sim: bool = False):
         "beam": Beam(),
         "get_blop_agent": get_blop_agent,
         "get_xopt_obj": get_xopt_obj,
-        "get_xopt_obj_2d_markers": get_xopt_obj_2d_markers,
     }
     print(f"Available optimizers are {list(optimizers)}")
 

--- a/mfx/optimize/plots.py
+++ b/mfx/optimize/plots.py
@@ -17,6 +17,27 @@ def centroid_path_plot(
     centroids: list[tuple[float, float]],
     figure: Optional[matplotlib.figure.Figure] = None,
 ) -> matplotlib.figure.Figure:
+    """
+    Plot the path of a centroid alignment.
+
+    The will include:
+    - The YAG image in the background
+    - The goal as a red x
+    - The measured centroids as white dots
+    - The camviewer markers as green + marks
+
+    This is intended to help verify that the alignment
+    is doing something useful and to debug when it does
+    something unexpected. For example, if our coordinate
+    system has an issue or the markers are set strangely
+    it will become more obvious using this plot.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        The actual image of the YAG as a background.
+    
+    """
     fig = plt.figure(figure)
     plt.clf()
     plt.imshow(image, "cividis")
@@ -31,6 +52,19 @@ def centroid_path_plot(
 
 
 class UpdatingDeviceCentroidPathPlot:
+    """
+    Helper class for maintaining state and getting data for the path plot.
+
+    This is intended to help us create a useful plot that updates
+    as the scan proceeds.
+
+    Parameters
+    ----------
+    imager : YagCamera
+        The camera device instance.
+    goal : tuple[float, float]
+        The position we'd like the centroid to reach.
+    """
     def __init__(self, imager: YagCamera, goal: tuple[float, float]):
         self.fig = None
         self.imager = imager
@@ -38,6 +72,7 @@ class UpdatingDeviceCentroidPathPlot:
         self.points = []
 
     def get_markers(self) -> list[tuple[int, int]]:
+        """Helper to get the relevant global marker positions from the imager."""
         markers = []
         for num in range(4):
             try:
@@ -48,10 +83,21 @@ class UpdatingDeviceCentroidPathPlot:
         return markers
 
     def add_point(self, centroid: tuple[float, float]):
+        """
+        Add a new centroid to the plot and re-render.
+
+        Parameters
+        ----------
+        centroid : tuple[float, float]
+            The point to add.
+        """
         self.points.append(centroid)
         self.refresh()
 
     def refresh(self):
+        """
+        Re-render without adding any points, e.g. to update the YAG image.
+        """
         self.fig = centroid_path_plot(
             image=self.imager.image1.image,
             goal=self.goal,

--- a/mfx/optimize/plots.py
+++ b/mfx/optimize/plots.py
@@ -1,0 +1,19 @@
+"""
+Matplotlib plotting utilities for tracking the optimizer's decisions.
+"""
+import matplotlib.figure
+import matplotlib.pyplot as plt
+import numpy as np
+
+def centroid_path_plot(
+    image: np.ndarray,
+    goal: tuple[float, float],
+    centroids: list[tuple[float, float]],
+) -> matplotlib.figure.Figure:
+    fig = plt.figure()
+    plt.imshow(image)
+    plt.plot(*goal, marker="o", color="red")
+    for pt in centroids:
+        plt.plot(*pt, marker=".", color="white")
+    plt.show()
+    return fig

--- a/mfx/optimize/plots.py
+++ b/mfx/optimize/plots.py
@@ -1,19 +1,61 @@
 """
 Matplotlib plotting utilities for tracking the optimizer's decisions.
 """
+from typing import Optional
+
 import matplotlib.figure
 import matplotlib.pyplot as plt
 import numpy as np
 
+from .devices import YagCamera
+
+
 def centroid_path_plot(
     image: np.ndarray,
     goal: tuple[float, float],
+    markers: list[tuple[float, float]],
     centroids: list[tuple[float, float]],
+    figure: Optional[matplotlib.figure.Figure] = None,
 ) -> matplotlib.figure.Figure:
-    fig = plt.figure()
-    plt.imshow(image)
-    plt.plot(*goal, marker="o", color="red")
+    fig = plt.figure(figure)
+    plt.clf()
+    plt.imshow(image, "cividis")
     for pt in centroids:
         plt.plot(*pt, marker=".", color="white")
-    plt.show()
+    for mk in markers:
+        plt.plot(*mk, marker="+", color="lime")
+    plt.plot(*goal, marker="x", color="red")
+    plt.show(block=False)
+    plt.pause(0.01)
     return fig
+
+
+class UpdatingDeviceCentroidPathPlot:
+    def __init__(self, imager: YagCamera, goal: tuple[float, float]):
+        self.fig = None
+        self.imager = imager
+        self.goal = goal
+        self.points = []
+
+    def get_markers(self) -> list[tuple[int, int]]:
+        markers = []
+        for num in range(4):
+            try:
+                coord = getattr(self.imager.coords, f"marker{num+1}").get_coordinate()
+            except RuntimeError:
+                continue
+            markers.append(coord)
+        return markers
+
+    def add_point(self, centroid: tuple[float, float]):
+        self.points.append(centroid)
+        self.refresh()
+
+    def refresh(self):
+        self.fig = centroid_path_plot(
+            image=self.imager.image1.image,
+            goal=self.goal,
+            markers=self.get_markers(),
+            centroids=self.points,
+            figure=self.fig,
+        )

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -32,7 +32,7 @@ from .beamline_hw import (
     WAVE8_CENTROID_X_MIN_MAX,
     WAVE8_CENTROID_Y_MIN_MAX
 )
-from .plots import centroid_path_plot
+from .plots import UpdatingDeviceCentroidPathPlot
 
 
 def get_vocs(
@@ -504,11 +504,17 @@ def run_sim_test_yag_2d() -> Xopt:
     xopt.random_evaluate(3)
     print("Step xopt object 10 times")
     imager = init_devices()["mfx_dg1_yag"]
-    centroids = [imager.image1.get_centroid()]
+    path_plot = UpdatingDeviceCentroidPathPlot(
+        imager=imager,
+        goal=imager.coords.standard_two_corners_target(),
+    )
+    imager.image1.shaped_image.trigger()
+    path_plot.add_point(imager.image1.get_centroid())
     for num in range(10):
         print(f"Step {num + 1}")
         xopt.step()
-        centroids.append(imager.image1.get_centroid())
+        imager.image1.shaped_image.trigger()
+        path_plot.add_point(imager.image1.get_centroid())
     print("Get best point")
     try:
         _, val, params = xopt.vocs.select_best(xopt.data)
@@ -531,16 +537,11 @@ def run_sim_test_yag_2d() -> Xopt:
     print("Generating plots")
     xopt.data.plot(y=xopt.vocs.objective_names)
 
-    imager.image1.shaped_image.trigger()
     fit = ImageProjectionFit()
     image = imager.image1.shaped_image.get()
     fit_result = fit.fit_image(image)
     plot_image_projection_fit(fit_result)
-    centroid_path_plot(
-        image=image,
-        goal=goal,
-        centroids=centroids,
-    )
+    path_plot.refresh()
     return xopt
 
 

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -221,9 +221,9 @@ def get_xopt_obj(
     centroid_x_max: Optional[float]  = None,
     centroid_y_min: Optional[float]  = None,
     centroid_y_max: Optional[float]  = None,
-    xopt_generator_turbo_controller: Turbo | None = None,
+    xopt_generator_turbo_controller: Optional[Turbo] = None,
     use_2d_markers: bool = False,
-    goal_2d: tuple[float, float] | None = None
+    goal_2d: Optional[tuple[float, float]] = None
 ) -> Xopt:
     """
     Create an appropriate xopt optimization object.
@@ -432,8 +432,10 @@ def run_sim_test_yag() -> Xopt:
 
 def run_sim_test_yag_2d() -> Xopt:
     print("Create Xopt")
-    xopt = get_xopt_obj_2d_markers(
+    xopt = get_xopt_obj(
+        device_type="yag",
         location="dg1",
+        use_2d_markers=True,
     )
     print("Randomly evaluate 3 points")
     xopt.random_evaluate(3)

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -5,6 +5,8 @@ Or python -m mfx.optimize.xopt_scans for a default sim run-through
 """
 from __future__ import annotations
 
+from typing import Optional
+
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -30,6 +32,7 @@ from .beamline_hw import (
     WAVE8_CENTROID_X_MIN_MAX,
     WAVE8_CENTROID_Y_MIN_MAX
 )
+from .plots import centroid_path_plot
 
 
 def get_vocs(
@@ -209,15 +212,15 @@ def get_xopt_obj(
     goal: float,
     mirror_nominal: float = MIRROR_NOMINAL,
     search_delta: float = 5,
-    wave8_max_value: float | None = None,
-    yag_size_min: float | None = None,
-    yag_size_max: float | None = None,
-    yag_intensity_min: float | None = None,
-    yag_intensity_max: float | None = None,
-    centroid_x_min: float | None = None,
-    centroid_x_max: float | None = None,
-    centroid_y_min: float | None = None,
-    centroid_y_max: float | None = None,
+    wave8_max_value: Optional[float] = None,
+    yag_size_min: Optional[float]  = None,
+    yag_size_max: Optional[float]  = None,
+    yag_intensity_min: Optional[float]  = None,
+    yag_intensity_max: Optional[float]  = None,
+    centroid_x_min: Optional[float]  = None,
+    centroid_x_max: Optional[float]  = None,
+    centroid_y_min: Optional[float]  = None,
+    centroid_y_max: Optional[float]  = None,
     xopt_generator_turbo_controller: Turbo | None = None,
 ) -> Xopt:
     """
@@ -331,15 +334,15 @@ def get_xopt_obj_2d_markers(
     location: Diagnostics,
     mirror_nominal: float = MIRROR_NOMINAL,
     search_delta: float = 5,
-    yag_size_min: float | None = None,
-    yag_size_max: float | None = None,
-    yag_intensity_min: float | None = None,
-    yag_intensity_max: float | None = None,
-    centroid_x_min: float | None = None,
-    centroid_x_max: float | None = None,
-    centroid_y_min: float | None = None,
-    centroid_y_max: float | None = None,
-    xopt_generator_turbo_controller: str | None = None,
+    yag_size_min: Optional[float]  = None,
+    yag_size_max: Optional[float]  = None,
+    yag_intensity_min: Optional[float]  = None,
+    yag_intensity_max: Optional[float]  = None,
+    centroid_x_min: Optional[float]  = None,
+    centroid_x_max: Optional[float]  = None,
+    centroid_y_min: Optional[float]  = None,
+    centroid_y_max: Optional[float]  = None,
+    xopt_generator_turbo_controller: Optional[float]  = None,
 ) -> Xopt:
     """
     Create an appropriate xopt optimization object for a 2D YAG optimization.
@@ -533,12 +536,11 @@ def run_sim_test_yag_2d() -> Xopt:
     image = imager.image1.shaped_image.get()
     fit_result = fit.fit_image(image)
     plot_image_projection_fit(fit_result)
-    plt.figure()
-    plt.imshow(image)
-    plt.plot(*goal, marker="o", color="red")
-    for pt in centroids:
-        plt.plot(*pt, marker=".", color="white")
-    plt.show()
+    centroid_path_plot(
+        image=image,
+        goal=goal,
+        centroids=centroids,
+    )
     return xopt
 
 


### PR DESCRIPTION
See #163 

The new plot updates as it goes, shows the markers, and should be useful for auditing what the alignment is doing (to see if it makes sense)

Main Goals:
- [x] Decouple the centroid path plots from the inner sim test function
- [x] Improve the path plots to make them more useful in prod 
- [ ] Include the path plots in the beam alignments (defer to next PR)

Incidentals:
- [x] Fix bad interaction between pydantic type validation and pipe `|`  on Python 3.9
- [x] Adjust the sim for larger fake yag images (closer to reality)
- [x] Adjust the sim for more realistic marker positions (closer to reality)
- [x] Setup the qt plotting backend for matplotlib automatically


Path plots look like this (with some variations) before improving:
![image](https://github.com/user-attachments/assets/9d9acb68-b653-4518-a94c-963f5f416e24)

And this after improvements:
![image](https://github.com/user-attachments/assets/0f823f52-aec2-4b28-b2ab-9bba11b65f64)
