### PR TITLE
Adjust xopt options in align.beam and consolidate get_xopt_obj

### DIFF
--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -1,7 +1,9 @@
 import traceback
+import datetime
 from typing import Literal
 from pydantic import validate_call, ConfigDict
 from bluesky import RunEngine
+from xopt import Xopt
 
 
 Diagnostics = Literal["xcs1", "dg1", "dg2"]
@@ -51,7 +53,7 @@ class Beam:
     @validate_w_lowercase_args
     def align(
             self,
-            with_goal: float,
+            with_goal: float | None = None,
             on_diagnostic: Diagnostics = "dg1",
             with_method: Methods = "xopt",
             using_device: Devices = "yag",
@@ -60,14 +62,18 @@ class Beam:
             xopt_steps: int = 10,
             blop_qr_n: int = 16,
             blop_qei_n: int = 16,
-            blop_qei_iterations: int = 5
+            blop_qei_iterations: int = 5,
+            use_2d_markers: bool = False,
+            with_goal_2d: tuple[float, float] | None = None,
+            xopt_obj: Xopt | None = None,
+            save_run: bool = True
             ):
         """Perform Beam Alignment
 
         Parameters
         ----------
-        with_goal : float
-            Goal to align to.
+        with_goal : float or tuple[float, float], optional
+            Goal to align to. A float for regular optimization, a tuple for using 2D YAG optimization.
         on_diagnostic : str, optional
             Diagnostic to use for alignment. Options: "xcs1, dg1, dg2". Default is "dg1".
         with_method : str, optional
@@ -86,17 +92,34 @@ class Beam:
             Number of qei iterations to perform in blop. Default is 16.
         blop_qei_iterations : int, optional
             Number of iterations to perform in blop. Default is 5.
+        use_2d_markers: bool, optional
+            Run a 2D YAG optimization using camera markers. Default is False.
+        with_goal_2d: tuple(float, float), optional
+            The 2D optimization goal if running a 2D YAG optimization. Default is False.
+        save_run: bool, optional
+            Save the Xopt run to YAML. Default is True.
         """
+        # Validate goal with not doing 2d optimization using camera markers
+        if (using_device=="wave8" or not use_2d_markers) and not with_goal:
+            raise ValueError("Must provide parameter with_goal (float) for running YAG or wave8 optimization.")
+
         if with_method == "xopt":
             from .xopt_scans import get_xopt_obj, init_devices
-            xopt = get_xopt_obj(
-                device_type=using_device,
-                location=on_diagnostic,
-                goal=with_goal,
-                xopt_generator_turbo_controller=xopt_turbo_option,
-            )
-            customized_boundaries = {"mirror_pitch": self.mirror_pitch}
-            xopt.random_evaluate(xopt_rand_evaluate, custom_bounds=customized_boundaries)
+            # Allow the loading of an already instantiated xopt object, e.g. to take more steps
+            if xopt_obj:
+                xopt = xopt_obj
+                print("Loading Xopt object.")
+            else:
+                xopt = get_xopt_obj(
+                    device_type=using_device,
+                    location=on_diagnostic,
+                    goal=with_goal,
+                    xopt_generator_turbo_controller=xopt_turbo_option,
+                    use_2d_markers=use_2d_markers,
+                    goal_2d=with_goal_2d
+                )
+                customized_boundaries = {"mirror_pitch": self.mirror_pitch}
+                xopt.random_evaluate(xopt_rand_evaluate, custom_bounds=customized_boundaries)
             print(xopt.data)
             for num in range(xopt_steps):
                 print(f"Step {num + 1}")
@@ -136,6 +159,11 @@ class Beam:
             mirror_pitch.set(params["mirror_pitch"]).wait(timeout=20)
             print(f"pitch is at {mirror_pitch.position}")
             xopt.data.plot(y=xopt.vocs.objective_names)
+            if save_run:
+                now = datetime.datetime.now()
+                formatted_string = now.strftime("%y-%m-%d-%H:%M:%S")
+                filename  = f"xopt_run_{on_diagnostic}_{using_device}_{formatted_string}.yaml"
+                xopt.dump(filename)
             return xopt
         elif with_method == "blop":
             from .blop_scans import get_blop_agent

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -116,20 +116,20 @@ def get_yag_key(yag: str):
 
 def get_evaluator_yag(
     yag: str = "dg1",
-    yag_xpos: float | None = None,
+    goal: float | None = None,
 ) -> Evaluator:
     yag = yag.lower()
     if yag not in ("xcs1", "dg1", "dg2", "ip"):
         raise ValueError("Can only use xcs1, dg1, dg2, ip yags.")
-    if yag_xpos is None:
+    if goal is None:
         if yag == 'xcs1':
-            yag_xpos = XCS_YAG_XPOS
+            goal = XCS_YAG_XPOS
         elif yag == "dg1":
-            yag_xpos = DG1_YAG_XPOS
+            goal = DG1_YAG_XPOS
         elif yag == "dg2":
-            yag_xpos = DG2_YAG_XPOS
+            goal = DG2_YAG_XPOS
         else:
-            yag_xpos = IP_YAG_XPOS
+            goal = IP_YAG_XPOS
     fit = ImageProjectionFit()
 
     def evaluate(input: dict[str, float]) -> dict[str, float]:
@@ -148,7 +148,7 @@ def get_evaluator_yag(
         results["rms_size_x"] = fit_result.rms_size[0]
         results["rms_size_y"] = fit_result.rms_size[1]
         results["total_intensity"] = fit_result.total_intensity
-        results["objective"] = abs(fit_result.centroid[0] - yag_xpos)
+        results["objective"] = abs(fit_result.centroid[0] - goal)
         print(f"Distance from goal is {results['objective']}")
         return results
 
@@ -206,9 +206,9 @@ def get_evaluator_yag_2d(
 def get_xopt_obj(
     device_type: Devices,
     location: Diagnostics,
-    goal: float,
     mirror_nominal: float = MIRROR_NOMINAL,
     search_delta: float = 5,
+    goal: float | None = None,
     wave8_max_value: float | None = None,
     yag_size_min: float | None = None,
     yag_size_max: float | None = None,
@@ -219,6 +219,8 @@ def get_xopt_obj(
     centroid_y_min: float | None = None,
     centroid_y_max: float | None = None,
     xopt_generator_turbo_controller: Turbo | None = None,
+    use_2d_markers: bool = False,
+    goal_2d: tuple[float, float] | None = None
 ) -> Xopt:
     """
     Create an appropriate xopt optimization object.
@@ -237,12 +239,12 @@ def get_xopt_obj(
         One of "yag" or "wave8"
     location : Diagnostics
         One of "xcs1", "dg1", "dg2", "ip"
-    goal : float
-        Either the wave8 xpos to aim for, or the x coordinate to aim for on a yag.
     mirror_nominal : float
         The starting mirror pitch position and midpoint of the optimization search.
     search_delta : float
         How far +/- we check away from the mirror nominal pitch position
+    goal : float, optional
+        Either the wave8 xpos to aim for, or the x coordinate to aim for on a yag.
     wave8_max_value : float, optional
         Constraint on maximum wave8 xpos for data to be valid
     yag_size_min : float, optional
@@ -263,7 +265,14 @@ def get_xopt_obj(
         Constraint on maximum centroid y value for data to be valid
     xopt_generator_turbo_controller : str, optional
         Which turbo controller to use. Options: "safety, optimize"
+    use_2d_markers: bool, optional
+        Run a 2D YAG optimization using camera markers
+    goal_2d: tuple[float, float] or None, optional
+        The 2D optimization goal if running a 2D YAG optimization
     """
+    if (device_type=="wave8" or not use_2d_markers) and not goal:
+        raise ValueError("Must provide a goal (float) for running YAG or wave8 optimization.")
+
     if device_type == "wave8":
         if location == "ip":
             raise ValueError("There is no wave8 at the ip.")
@@ -308,95 +317,21 @@ def get_xopt_obj(
     )
     print(vocs)
     if device_type == "yag":
-        evaluator = get_evaluator_yag(
-            yag=location,
-            yag_xpos=goal,
-        )
+        if use_2d_markers:
+            evaluator = get_evaluator_yag_2d(
+                yag=location,
+                goal=goal_2d,
+            )
+        else:
+            evaluator = get_evaluator_yag(
+                yag=location,
+                goal=goal,
+            )
     else:
         evaluator = get_evaluator_wave8(
             wave8=location,
             wave8_xpos=goal,
         )
-    generator = ExpectedImprovementGenerator(vocs=vocs, turbo_controller=xopt_generator_turbo_controller)
-    generator.gp_constructor.use_low_noise_prior = False
-    return Xopt(
-        vocs=vocs,
-        generator=generator,
-        evaluator=evaluator,
-    )
-
-
-@validate_w_lowercase_args
-def get_xopt_obj_2d_markers(
-    location: Diagnostics,
-    mirror_nominal: float = MIRROR_NOMINAL,
-    search_delta: float = 5,
-    yag_size_min: float | None = None,
-    yag_size_max: float | None = None,
-    yag_intensity_min: float | None = None,
-    yag_intensity_max: float | None = None,
-    centroid_x_min: float | None = None,
-    centroid_x_max: float | None = None,
-    centroid_y_min: float | None = None,
-    centroid_y_max: float | None = None,
-    xopt_generator_turbo_controller: str | None = None,
-) -> Xopt:
-    """
-    Create an appropriate xopt optimization object for a 2D YAG optimization.
-
-    Uses the camviewer markers as a goal only by using the default goal
-    argument in get_evaluator_yag_2d.
-
-    Parameters
-    ----------
-    location : Diagnostics
-        One of "xcs1", "dg1", "dg2", "ip"
-    mirror_nominal : float
-        The starting mirror pitch position and midpoint of the optimization search.
-    search_delta : float
-        How far +/- we check away from the mirror nominal pitch position
-        yag_size_min : float, optional
-        Constraint on minimum yag spot size (RMS) for data to be valid
-    yag_size_max : float, optional
-        Constraint on maximum yag spot size (RMS) for data to be valid
-    yag_intensity_min : float, optional
-        Constraint on minimum yag total intensity count for data to be valid
-    yag_intensity_max : float, optional
-        Constraint on maximum yag total intensity count for data to be valid
-    centroid_x_min : float, optional
-        Constraint on minimum centroid x value for data to be valid
-    centroid_x_max : float, optional
-        Constraint on maximum centroid x value for data to be valid
-    centroid_y_min : float, optional
-        Constraint on minimum centroid y value for data to be valid
-    centroid_y_max : float, optional
-        Constraint on maximum centroid y value for data to be valid
-    xopt_generator_turbo_controller : str, optional
-        Which turbo controller to use. Options: "safety, optimize"
-    """
-    if location not in ("xcs1", "dg1", "dg2", "ip"):
-        raise ValueError("location must be one of xcs1, dg1, dg2, or ip")
-
-    centroid_x_min = centroid_x_min or YAG_CENTROID_X_MIN_MAX[0]
-    centroid_x_max = centroid_x_max or YAG_CENTROID_X_MIN_MAX[1]
-    centroid_y_min = centroid_y_min or YAG_CENTROID_Y_MIN_MAX[0]
-    centroid_y_max = centroid_y_max or YAG_CENTROID_Y_MIN_MAX[1]
-
-    vocs = get_vocs(
-        mirror_nominal=mirror_nominal,
-        search_delta=search_delta,
-        yag_size_min=yag_size_min,
-        yag_size_max=yag_size_max,
-        yag_intensity_min=yag_intensity_min,
-        yag_intensity_max=yag_intensity_max,
-        centroid_x_min=centroid_x_min,
-        centroid_x_max=centroid_x_max,
-        centroid_y_min=centroid_y_min,
-        centroid_y_max=centroid_y_max,
-    )
-    print(vocs)
-    evaluator = get_evaluator_yag_2d(yag=location)
-
     generator = ExpectedImprovementGenerator(vocs=vocs, turbo_controller=xopt_generator_turbo_controller)
     generator.gp_constructor.use_low_noise_prior = False
     return Xopt(


### PR DESCRIPTION
Closes #167, closes #121

# Major changes:
- Consolidate `get_xopt_obj` and `get_xopt_obj_2d_markers`
- Adjust `beam.align` to run either regular or 2d yag optimization
    - This makes the goal parameter optional in the function signature but there is a check to raise an error if we are not running a 2d optimization and no goal is set
    - A separate 2d goal has to be passed if desired but it's optional (same as the 2d evaluator)
   
# Minor changes:
- Add ability to load an Xopt object instance instead of creating one when calling `beam.align`. My thinking here is if we run let's say 10 steps but we want to run more, this is one way to do it (we can also instead add on the previous data to a new object, or adjust the method itself to allow to rerun or something)
- Add saving of each run (each call to `beam.align`) to YAML, set to True by default