### PR TITLE
Add max iter for Xopt and clean up

### DIFF
--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -61,6 +61,7 @@ class Beam:
             xopt_turbo_option: Turbo = "safety",
             xopt_rand_evaluate: int = 3,
             xopt_steps: int = 10,
+            xopt_max_iter: int = 2000,
             blop_qr_n: int = 16,
             blop_qei_n: int = 16,
             blop_qei_iterations: int = 5,
@@ -87,6 +88,8 @@ class Beam:
             Number of random evaluations to perform in Xopt. Default is 3.
         xopt_steps : int, optional
             Number of steps to perform in Xopt. Default is 10.
+        xopt_max_iter: int, optional
+            Max number of steps for maximizing the acquisition function in Xopt. Default is 2000.
         blop_qr_n : int, optional
             Number of qr iterations to perform in blop. Default is 16.
         blop_qei_n : int, optional
@@ -117,7 +120,8 @@ class Beam:
                     goal=with_goal,
                     xopt_generator_turbo_controller=xopt_turbo_option,
                     use_2d_markers=use_2d_markers,
-                    goal_2d=with_goal_2d
+                    goal_2d=with_goal_2d,
+                    max_iter=xopt_max_iter
                 )
                 customized_boundaries = {"mirror_pitch": self.mirror_pitch}
                 xopt.random_evaluate(xopt_rand_evaluate, custom_bounds=customized_boundaries)

--- a/mfx/optimize/blop_scans.py
+++ b/mfx/optimize/blop_scans.py
@@ -4,6 +4,7 @@ To test with sim, ipython -i mfx/optimize/blop_scans.py
 Or python -m mfx.optimize.blop_scans for a default sim run-through
 """
 from __future__ import annotations
+from typing import Optional
 
 from blop import DOF, Agent, Objective
 from bluesky import RunEngine
@@ -97,7 +98,7 @@ def get_blop_agent(
     wave8: Diagnostics = "dg1",
     mirror_nominal: float = MIRROR_NOMINAL,
     search_delta: float = 5,
-    wave8_xpos: float | None = None,
+    wave8_xpos: Optional[float] = None,
     wave8_max_value: float = 10,
     setup_re: bool = True,
 ) -> Agent:

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -4,6 +4,7 @@ To test with sim, ipython -i mfx/optimize/xopt_scans.py for an interactive test
 Or python -m mfx.optimize.xopt_scans for a default sim run-through
 """
 from __future__ import annotations
+from typing import Optional
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -35,11 +36,11 @@ from .beamline_hw import (
 def get_vocs(
     mirror_nominal: float = MIRROR_NOMINAL,
     search_delta: float = 5,
-    wave8_max_value: float | None = None,
-    yag_size_min: float | None = None,
-    yag_size_max: float | None = None,
-    yag_intensity_min: float | None = None,
-    yag_intensity_max: float | None = None,
+    wave8_max_value: Optional[float] = None,
+    yag_size_min: Optional[float] = None,
+    yag_size_max: Optional[float] = None,
+    yag_intensity_min: Optional[float] = None,
+    yag_intensity_max: Optional[float] = None,
     centroid_x_min: float = None,
     centroid_x_max: float = None,
     centroid_y_min: float = None,
@@ -80,7 +81,7 @@ def get_vocs(
 
 def get_evaluator_wave8(
     wave8: str = "dg1",
-    wave8_xpos: float | None = None,
+    wave8_xpos: Optional[float] = None,
 ) -> Evaluator:
     if wave8_xpos is None:
         if wave8 == "dg1":
@@ -116,7 +117,7 @@ def get_yag_key(yag: str):
 
 def get_evaluator_yag(
     yag: str = "dg1",
-    goal: float | None = None,
+    goal: Optional[float] = None,
 ) -> Evaluator:
     yag = yag.lower()
     if yag not in ("xcs1", "dg1", "dg2", "ip"):
@@ -157,7 +158,7 @@ def get_evaluator_yag(
 
 def get_evaluator_yag_2d(
     yag: str = "dg1",
-    goal: tuple[float, float] | None = None,
+    goal: Optional[tuple[float, float]] = None,
 ) -> Evaluator:
     """
     Alternate evaluator in 2d space.
@@ -208,19 +209,20 @@ def get_xopt_obj(
     location: Diagnostics,
     mirror_nominal: float = MIRROR_NOMINAL,
     search_delta: float = 5,
-    goal: float | None = None,
-    wave8_max_value: float | None = None,
-    yag_size_min: float | None = None,
-    yag_size_max: float | None = None,
-    yag_intensity_min: float | None = None,
-    yag_intensity_max: float | None = None,
-    centroid_x_min: float | None = None,
-    centroid_x_max: float | None = None,
-    centroid_y_min: float | None = None,
-    centroid_y_max: float | None = None,
-    xopt_generator_turbo_controller: Turbo | None = None,
+    goal: Optional[float] = None,
+    wave8_max_value: Optional[float] = None,
+    yag_size_min: Optional[float] = None,
+    yag_size_max: Optional[float] = None,
+    yag_intensity_min: Optional[float] = None,
+    yag_intensity_max: Optional[float] = None,
+    centroid_x_min: Optional[float] = None,
+    centroid_x_max: Optional[float] = None,
+    centroid_y_min: Optional[float] = None,
+    centroid_y_max: Optional[float] = None,
+    xopt_generator_turbo_controller: Optional[Turbo] = None,
     use_2d_markers: bool = False,
-    goal_2d: tuple[float, float] | None = None
+    goal_2d: Optional[tuple[float, float]] = None,
+    max_iter: int = 2000
 ) -> Xopt:
     """
     Create an appropriate xopt optimization object.
@@ -269,6 +271,8 @@ def get_xopt_obj(
         Run a 2D YAG optimization using camera markers
     goal_2d: tuple[float, float] or None, optional
         The 2D optimization goal if running a 2D YAG optimization
+    max_iter: int, optional
+        Max number of steps for maximizing the acquisition function
     """
     if (device_type=="wave8" or not use_2d_markers) and not goal:
         raise ValueError("Must provide a goal (float) for running YAG or wave8 optimization.")
@@ -334,6 +338,7 @@ def get_xopt_obj(
         )
     generator = ExpectedImprovementGenerator(vocs=vocs, turbo_controller=xopt_generator_turbo_controller)
     generator.gp_constructor.use_low_noise_prior = False
+    generator.numerical_optimizer.max_iter = max_iter
     return Xopt(
         vocs=vocs,
         generator=generator,

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -434,8 +434,10 @@ def run_sim_test_yag() -> Xopt:
 
 def run_sim_test_yag_2d() -> Xopt:
     print("Create Xopt")
-    xopt = get_xopt_obj_2d_markers(
+    xopt = get_xopt_obj(
+        device_type="yag",
         location="dg1",
+        use_2d_markers=True
     )
     print("Randomly evaluate 3 points")
     xopt.random_evaluate(3)
@@ -453,7 +455,7 @@ def run_sim_test_yag_2d() -> Xopt:
         # Make error more user-friendly/readable
         raise FeasibilityError(
             f"No feasible points within acceptable region. "
-            f"Try adjusting constraints in 'xopt_scans.get_xopt_obj_2d_markers'.\n"
+            f"Try adjusting constraints in 'xopt_scans.get_xopt_obj'.\n"
             f"Current constraints: {xopt.vocs.constraints}"
         )
     print(f"Best objective value {val}")


### PR DESCRIPTION
- Makes it easier to adjust the number of steps for maximizing the acquisition for Xopt on the fly
- Fix more typing syntax for Python 3.9
- Clean up some references of the old `get_xopt_obj_2d_markers`