### PR TITLE
ENH: Include the path plot in align.beam, make some internals re-usable

### DIFF
--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -6,7 +6,7 @@ from pydantic import validate_call
 from bluesky import RunEngine
 from xopt import Xopt
 from .errors import FeasibilityError
-from .plots import UpdatingDeviceCentroidPathPlot
+from .plots import UpdatingDeviceCentroidPathPlot, refresh_mpl_plots
 from .type_checking import validate_w_lowercase_args, Diagnostics, Methods, Devices, Turbo
 from .user_select import select_diagnostic, select_goal
 
@@ -118,6 +118,7 @@ class Beam:
                 x_series = xopt.data.get("centroid_x")
                 y_series = xopt.data.get("centroid_y")
                 path_plot.add_points([(xpt, ypt) for xpt, ypt in zip(x_series, y_series)])
+                refresh_mpl_plots()
 
             for num in range(xopt_steps):
                 print(f"Step {num + 1}")
@@ -128,7 +129,7 @@ class Beam:
                         path_plot.add_point(
                             (xopt.data.get("centroid_x").iat[-1], xopt.data.get("centroid_y").iat[-1])
                         )
-                    plt.show()
+                    refresh_mpl_plots()
                 except RuntimeError:
                     trb = traceback.format_exc()
                     if "turbo requires at least one valid point in the training dataset" in str(trb):
@@ -178,7 +179,8 @@ class Beam:
             ax.set_ylabel("mirror pitch")
             xopt.generator.visualize_model()
             if path_plot is not None:
-                path_plot.refresh()
+                path_plot.update_plot()
+            refresh_mpl_plots()
             return xopt
         elif with_method == "blop":
             from .blop_scans import get_blop_agent

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -1,49 +1,14 @@
 import traceback
 import datetime
-from typing import Literal, Optional
+from typing import Optional
 import matplotlib.pyplot as plt
-from pydantic import validate_call, ConfigDict
+from pydantic import validate_call
 from bluesky import RunEngine
 from xopt import Xopt
-
-
-Diagnostics = Literal["xcs1", "dg1", "dg2"]
-Methods = Literal["xopt", "blop"]
-Devices = Literal["yag", "wave8"]
-Turbo = Literal["safety", "optimize"]
-
-
-def validate_w_lowercase_args(func):
-    """
-    Decorator to make string inputs lowercase, and then validate.
-
-    Parameters:
-    -----------
-    func (Callable): 
-        The function to decorate.
-
-    Returns:
-    --------
-    Callable: 
-        The decorated function with string arguments converted to lowercase.
-    """
-    def wrapper(*args, **kwargs):
-        # Convert all string arguments to lowercase
-        new_args = tuple(arg.lower() if isinstance(arg, str) else arg for arg in args)
-        new_kwargs = {k: v.lower() if isinstance(v, str) else v for k, v in kwargs.items()}
-
-        # Call the original function with the modified arguments, validated by Pydantic
-        validated_func = validate_call(func, config=ConfigDict(validate_default=True))
-        return validated_func(*new_args, **new_kwargs)
-
-    return wrapper
-
-class FeasibilityError(Exception):
-    """
-    A custom exception class to tell users when no Xopt sample points are feasible,
-    e.g. due to the constraints being too tight.
-    """
-    pass
+from .beamline_hw import select_diagnostic
+from .errors import FeasibilityError
+from .plots import UpdatingDeviceCentroidPathPlot
+from .type_checking import validate_w_lowercase_args, Diagnostics, Methods, Devices, Turbo
 
 
 class Beam:
@@ -104,13 +69,25 @@ class Beam:
         if (using_device=="wave8" or not use_2d_markers) and not with_goal:
             raise ValueError("Must provide parameter with_goal (float) for running YAG or wave8 optimization.")
 
+        path_plot = None
         if with_method == "xopt":
             from .xopt_scans import get_xopt_obj, init_devices
             # Allow the loading of an already instantiated xopt object, e.g. to take more steps
             if xopt_obj:
+                print("Using existing Xopt object.")
                 xopt = xopt_obj
-                print("Loading Xopt object.")
+                try:
+                    old_path_plot = xopt._cached_path_plot
+                except AttributeError:
+                    ...
+                else:
+                    print("Generating new path plot from cached settings")
+                    path_plot = UpdatingDeviceCentroidPathPlot(
+                        imager=old_path_plot.imager,
+                        goal=old_path_plot.goal,
+                    )
             else:
+                print("Loading Xopt object.")
                 xopt = get_xopt_obj(
                     device_type=using_device,
                     location=on_diagnostic,
@@ -120,13 +97,30 @@ class Beam:
                     goal_2d=with_goal_2d
                 )
                 customized_boundaries = {"mirror_pitch": self.mirror_pitch}
+                if using_device == "yag":
+                    print("Generating path plot")
+                    path_plot = UpdatingDeviceCentroidPathPlot(
+                        imager=select_diagnostic("yag", on_diagnostic),
+                        goal=(1, 1),
+                    )
+                    xopt._cached_path_plot = path_plot
                 xopt.random_evaluate(xopt_rand_evaluate, custom_bounds=customized_boundaries)
             print(xopt.data)
+
+            # Seed the path plot with all the random points
+            if path_plot is not None:
+                x_series = xopt.data.get("centroid_x")
+                y_series = xopt.data.get("centroid_y")
+                path_plot.add_points([(xpt, ypt) for xpt, ypt in zip(x_series, y_series)])
+
             for num in range(xopt_steps):
                 print(f"Step {num + 1}")
                 try:
                     xopt.step()
                     xopt.generator.visualize_model(show_acquisition=False)
+                    path_plot.add_point(
+                        (xopt.data.get("centroid_x").iat[-1], xopt.data.get("centroid_y").iat[-1])
+                    )
                     plt.show()
                 except RuntimeError:
                     trb = traceback.format_exc()

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -8,7 +8,7 @@ from xopt import Xopt
 from .errors import FeasibilityError
 from .plots import UpdatingDeviceCentroidPathPlot
 from .type_checking import validate_w_lowercase_args, Diagnostics, Methods, Devices, Turbo
-from .user_select import select_diagnostic
+from .user_select import select_diagnostic, select_goal
 
 
 class Beam:
@@ -101,7 +101,13 @@ class Beam:
                     print("Generating path plot")
                     path_plot = UpdatingDeviceCentroidPathPlot(
                         imager=select_diagnostic("yag", on_diagnostic),
-                        goal=(1, 1),
+                        goal=select_goal(
+                            device_type=using_device,
+                            location=on_diagnostic,
+                            goal=with_goal,
+                            goal_2d=with_goal_2d,
+                            use_2d_markers=use_2d_markers,
+                        ),
                     )
                     xopt._cached_path_plot = path_plot
                 xopt.random_evaluate(xopt_rand_evaluate, custom_bounds=customized_boundaries)
@@ -118,9 +124,10 @@ class Beam:
                 try:
                     xopt.step()
                     xopt.generator.visualize_model(show_acquisition=False)
-                    path_plot.add_point(
-                        (xopt.data.get("centroid_x").iat[-1], xopt.data.get("centroid_y").iat[-1])
-                    )
+                    if path_plot is not None:
+                        path_plot.add_point(
+                            (xopt.data.get("centroid_x").iat[-1], xopt.data.get("centroid_y").iat[-1])
+                        )
                     plt.show()
                 except RuntimeError:
                     trb = traceback.format_exc()
@@ -170,6 +177,8 @@ class Beam:
             ax.set_xlabel("steps")
             ax.set_ylabel("mirror pitch")
             xopt.generator.visualize_model()
+            if path_plot is not None:
+                path_plot.refresh()
             return xopt
         elif with_method == "blop":
             from .blop_scans import get_blop_agent

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -5,10 +5,10 @@ import matplotlib.pyplot as plt
 from pydantic import validate_call
 from bluesky import RunEngine
 from xopt import Xopt
-from .beamline_hw import select_diagnostic
 from .errors import FeasibilityError
 from .plots import UpdatingDeviceCentroidPathPlot
 from .type_checking import validate_w_lowercase_args, Diagnostics, Methods, Devices, Turbo
+from .user_select import select_diagnostic
 
 
 class Beam:
@@ -38,8 +38,8 @@ class Beam:
 
         Parameters
         ----------
-        with_goal : float or tuple[float, float], optional
-            Goal to align to. A float for regular optimization, a tuple for using 2D YAG optimization.
+        with_goal : float, optional
+            1D Goal to align to. This can be omitted if other goal arguments are used.
         on_diagnostic : str, optional
             Diagnostic to use for alignment. Options: "xcs1, dg1, dg2". Default is "dg1".
         with_method : str, optional

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -6,7 +6,7 @@ from pydantic import validate_call
 from bluesky import RunEngine
 from xopt import Xopt
 from .errors import FeasibilityError
-from .plots import UpdatingDeviceCentroidPathPlot, refresh_mpl_plots
+from .plots import UpdatingDeviceCentroidPathPlot, UpdatingXoptVisualizeModelPlot, refresh_mpl_plots
 from .type_checking import validate_w_lowercase_args, Diagnostics, Methods, Devices, Turbo
 from .user_select import select_diagnostic, select_goal
 
@@ -112,24 +112,23 @@ class Beam:
                     xopt._cached_path_plot = path_plot
                 xopt.random_evaluate(xopt_rand_evaluate, custom_bounds=customized_boundaries)
             print(xopt.data)
+            xopt_eval_plot = UpdatingXoptVisualizeModelPlot(xopt)
 
             # Seed the path plot with all the random points
             if path_plot is not None:
                 x_series = xopt.data.get("centroid_x")
                 y_series = xopt.data.get("centroid_y")
                 path_plot.add_points([(xpt, ypt) for xpt, ypt in zip(x_series, y_series)])
-                refresh_mpl_plots()
 
             for num in range(xopt_steps):
                 print(f"Step {num + 1}")
                 try:
                     xopt.step()
-                    xopt.generator.visualize_model(show_acquisition=False)
+                    xopt_eval_plot.refresh()
                     if path_plot is not None:
                         path_plot.add_point(
                             (xopt.data.get("centroid_x").iat[-1], xopt.data.get("centroid_y").iat[-1])
                         )
-                    refresh_mpl_plots()
                 except RuntimeError:
                     trb = traceback.format_exc()
                     if "turbo requires at least one valid point in the training dataset" in str(trb):
@@ -177,10 +176,9 @@ class Beam:
             ax = xopt.data.plot(y=xopt.vocs.objective_names)
             ax.set_xlabel("steps")
             ax.set_ylabel("mirror pitch")
-            xopt.generator.visualize_model()
+            xopt_eval_plot.refresh()
             if path_plot is not None:
-                path_plot.update_plot()
-            refresh_mpl_plots()
+                path_plot.refresh()
             return xopt
         elif with_method == "blop":
             from .blop_scans import get_blop_agent

--- a/mfx/optimize/beamline_hw.py
+++ b/mfx/optimize/beamline_hw.py
@@ -3,7 +3,6 @@ Initialize hardware for blop_scans and xopt_scans
 """
 import random
 from types import SimpleNamespace
-from typing import Union
 
 from happi import Client
 from ophyd.device import Device
@@ -11,7 +10,7 @@ from ophyd.sim import SynAxis, SynSignal
 from pcdsdevices.ipm import Wave8
 
 from .devices import FakeLCLSImagePlugin, FakeYagCamera, YagCamera
-from .type_checking import Diagnostics, Devices, validate_w_lowercase_args
+
 
 HAPPI_NAMES = (
     "mr1l4_homs",
@@ -185,36 +184,3 @@ def sim_devices() -> dict[str, Device]:
     print(f"default alignment on ip yag should pick {MIRROR_NOMINAL - ip_yag_offset}")
 
     return devices
-
-
-@validate_w_lowercase_args
-def select_diagnostic(
-    device_type: Devices,
-    location: Diagnostics,
-) -> Union[YagCamera, Wave8]:
-    """
-    Standard selector used to assemble the blop/xopt scans.
-
-    From some standard set of options, return the
-    diagnostic device we'll be use using in the optimization.
-
-    Parameters
-    ----------
-    device_type : Devices
-        One of "yag" or "wave8"
-    location : Diagnostics
-        One of "xcs1", "dg1", "dg2", "ip"
-    """
-    devices = init_devices()
-    if device_type == "yag":
-        if location == "xcs1":
-            return devices["xcs_yag1"]
-        else:
-            return devices[f"mfx_{location}_yag"]
-    elif device_type == "wave8":
-        if location in ("dg1", "dg2"):
-            return devices[f"mfx_{location}_wave8"]
-        else:
-            raise ValueError(f"Invalid wave8 {location}, expected dg1 or dg2")
-    else:
-        raise RuntimeError(f"Invalid device_type {device_type} selected, pydantic broke?")

--- a/mfx/optimize/beamline_hw.py
+++ b/mfx/optimize/beamline_hw.py
@@ -3,6 +3,7 @@ Initialize hardware for blop_scans and xopt_scans
 """
 import random
 from types import SimpleNamespace
+from typing import Union
 
 from happi import Client
 from ophyd.device import Device
@@ -10,6 +11,7 @@ from ophyd.sim import SynAxis, SynSignal
 from pcdsdevices.ipm import Wave8
 
 from .devices import FakeLCLSImagePlugin, FakeYagCamera, YagCamera
+from .type_checking import Diagnostics, Devices, validate_w_lowercase_args
 
 HAPPI_NAMES = (
     "mr1l4_homs",
@@ -184,3 +186,35 @@ def sim_devices() -> dict[str, Device]:
 
     return devices
 
+
+@validate_w_lowercase_args
+def select_diagnostic(
+    device_type: Devices,
+    location: Diagnostics,
+) -> Union[YagCamera, Wave8]:
+    """
+    Standard selector used to assemble the blop/xopt scans.
+
+    From some standard set of options, return the
+    diagnostic device we'll be use using in the optimization.
+
+    Parameters
+    ----------
+    device_type : Devices
+        One of "yag" or "wave8"
+    location : Diagnostics
+        One of "xcs1", "dg1", "dg2", "ip"
+    """
+    devices = init_devices()
+    if device_type == "yag":
+        if location == "xcs1":
+            return devices["xcs_yag1"]
+        else:
+            return devices[f"mfx_{location}_yag"]
+    elif device_type == "wave8":
+        if location in ("dg1", "dg2"):
+            return devices[f"mfx_{location}_wave8"]
+        else:
+            raise ValueError(f"Invalid wave8 {location}, expected dg1 or dg2")
+    else:
+        raise RuntimeError(f"Invalid device_type {device_type} selected, pydantic broke?")

--- a/mfx/optimize/devices.py
+++ b/mfx/optimize/devices.py
@@ -56,7 +56,7 @@ class CamViewerCoords(Device):
 
     def average_marker_target(
         self, marker_nums: tuple[int, ...] | list[int]
-    ) -> tuple[int, int]:
+    ) -> tuple[float, float]:
         """
         Get the coordinate of the average position of the numbered markers.
         """
@@ -65,7 +65,7 @@ class CamViewerCoords(Device):
         tot = sum(np.array(self.specific_marker_target(num)) for num in marker_nums)
         return tuple(tot / len(marker_nums))
 
-    def standard_two_corners_target(self) -> tuple[int, int]:
+    def standard_two_corners_target(self) -> tuple[float, float]:
         """
         Get the coordinate defined by markers 1 and 2 placed at the corners.
 
@@ -75,7 +75,7 @@ class CamViewerCoords(Device):
         """
         return self.average_marker_target((1, 2))
 
-    def standard_box_target(self) -> tuple[int, int]:
+    def standard_box_target(self) -> tuple[float, float]:
         """
         Get the coordinate defined by all four markers placed at the corners.
 

--- a/mfx/optimize/errors.py
+++ b/mfx/optimize/errors.py
@@ -1,0 +1,12 @@
+"""
+Custom exception classes.
+
+Keep this separate to avoid circular imports.
+"""
+
+class FeasibilityError(Exception):
+    """
+    A custom exception class to tell users when no Xopt sample points are feasible,
+    e.g. due to the constraints being too tight.
+    """
+    pass

--- a/mfx/optimize/interactive.py
+++ b/mfx/optimize/interactive.py
@@ -75,6 +75,8 @@ def get_objects(sim: bool = False):
 def misc_setup(autoreload: bool = False):
     """
     Other setup actions that don't create objects
+
+    This wraps imports, etc. to avoid polluting the global namespace.
     """
     from IPython import get_ipython
     ip = get_ipython()
@@ -83,9 +85,13 @@ def misc_setup(autoreload: bool = False):
         print("Enabling autoreload...")
         if ip is None:
             raise RuntimeError("Not in an IPython shell, can't setup autoreload!")
+
+        import pkgutil
+        from pathlib import Path
+
         ip.run_line_magic("load_ext", "autoreload")
         ip.run_line_magic("autoreload", "1")
-        line = [f"mfx.optimize.{imp}" for imp in ("beam", "beamline_hw", "blop_scans", "devices", "plots", "xopt_scans")]
+        line = [f"mfx.optimize.{info.name}" for info in pkgutil.iter_modules([Path(__file__).parent]) if info.name != "interactive"]
         ip.run_line_magic("aimport", ",".join(line))
 
     if ip is not None:

--- a/mfx/optimize/plots.py
+++ b/mfx/optimize/plots.py
@@ -20,11 +20,8 @@ def refresh_mpl_plots():
     - Show all open figures that haven't been shown yet
     - Make the active figure update in place right away
 
-    Do this outside of the plotting logic so we can
-    decide when to draw updates and when not to.
-
-    For example, you can do this once to update all
-    four of your plots.
+    To make something the "active figure", you simply
+    need to call plt.figure(figure) on it.
     """
     plt.show(block=False)
     plt.pause(0.01)

--- a/mfx/optimize/plots.py
+++ b/mfx/optimize/plots.py
@@ -2,11 +2,14 @@
 Matplotlib plotting utilities for tracking the optimizer's decisions.
 """
 
-from typing import Optional
+from typing import Optional, Union
 
+import matplotlib.axes
 import matplotlib.figure
 import matplotlib.pyplot as plt
 import numpy as np
+
+from xopt import Xopt
 
 from .devices import YagCamera
 
@@ -15,7 +18,7 @@ def refresh_mpl_plots():
     """
     Call the required magic incantations to:
     - Show all open figures that haven't been shown yet
-    - Make every figure do a draw update right away.
+    - Make the active figure update in place right away
 
     Do this outside of the plotting logic so we can
     decide when to draw updates and when not to.
@@ -29,7 +32,7 @@ def refresh_mpl_plots():
 
 def centroid_path_plot(
     image: np.ndarray,
-    goal: tuple[float, float],
+    goal: Union[float, tuple[float, float]],
     markers: list[tuple[float, float]],
     centroids: list[tuple[float, float]],
     figure: Optional[matplotlib.figure.Figure] = None,
@@ -39,7 +42,7 @@ def centroid_path_plot(
 
     The will include:
     - The YAG image in the background
-    - The goal as a red x
+    - The goal as a red x (or a vertical line)
     - The measured centroids as white dots
     - The camviewer markers as green + marks
 
@@ -56,7 +59,14 @@ def centroid_path_plot(
     ----------
     image : np.ndarray
         The actual image of the YAG as a background.
-
+    goal : float or tuple of floats
+        The 1d goal (x) or 2d goal (x, y)
+    markers : list of tuples of floats
+        The locations of the markers to plot
+    centroids : list of tuples of floats
+        The locations of the centroids to plot
+    figure : Figure, optional
+        A figure to re-use (instead of making a new figure).
     """
     fig = plt.figure(figure)
     plt.clf()
@@ -65,7 +75,11 @@ def centroid_path_plot(
         plt.plot(*pt, marker=".", color="white")
     for mk in markers:
         plt.plot(*mk, marker="+", color="lime")
-    plt.plot(*goal, marker="x", color="red")
+    if isinstance(goal, float):
+        plt.axvline(goal, color="red")
+    else:
+        plt.plot(*goal, marker="x", color="red")
+
     return fig
 
 
@@ -111,7 +125,7 @@ class UpdatingDeviceCentroidPathPlot:
             The point to add.
         """
         self.points.append(centroid)
-        self.update_plot()
+        self.refresh()
 
     def add_points(self, centroids: list[tuple[float, float]]):
         """
@@ -123,14 +137,11 @@ class UpdatingDeviceCentroidPathPlot:
             The points to add.
         """
         self.points.extend(centroids)
-        self.update_plot()
+        self.refresh()
 
-    def update_plot(self):
+    def refresh(self):
         """
         Update plots without adding any points, e.g. to update the YAG image.
-
-        Note: you still need to call refresh_mpl_plots or self.refresh to
-        display the updated image.
         """
         self.fig = centroid_path_plot(
             image=self.imager.image1.image,
@@ -139,10 +150,29 @@ class UpdatingDeviceCentroidPathPlot:
             centroids=self.points,
             figure=self.fig,
         )
+        refresh_mpl_plots()
+
+
+class UpdatingXoptVisualizeModelPlot:
+    """
+    Helpers for updating XOpt model plots in place.
+    """
+
+    def __init__(self, xopt: Xopt):
+        self.xopt = xopt
+        self.fig: Optional[matplotlib.figure.Figure] = None
+        self.axes: Optional[list[matplotlib.axes.Axes]] = None
 
     def refresh(self):
         """
-        Convenience helper if this is the only updating plot you have.
+        Re-render the new plot in place.
         """
-        self._plot_updates()
+        if self.axes is not None:
+            for ax in self.axes:
+                ax.clear()
+        self.fig, self.axes = self.xopt.generator.visualize_model(
+            show_acquisition=False,
+            axes=self.axes
+        )
+        plt.figure(self.fig)
         refresh_mpl_plots()

--- a/mfx/optimize/plots.py
+++ b/mfx/optimize/plots.py
@@ -1,6 +1,7 @@
 """
 Matplotlib plotting utilities for tracking the optimizer's decisions.
 """
+
 from typing import Optional
 
 import matplotlib.figure
@@ -36,7 +37,7 @@ def centroid_path_plot(
     ----------
     image : np.ndarray
         The actual image of the YAG as a background.
-    
+
     """
     fig = plt.figure(figure)
     plt.clf()
@@ -65,6 +66,7 @@ class UpdatingDeviceCentroidPathPlot:
     goal : tuple[float, float]
         The position we'd like the centroid to reach.
     """
+
     def __init__(self, imager: YagCamera, goal: tuple[float, float]):
         self.fig = None
         self.imager = imager
@@ -76,7 +78,7 @@ class UpdatingDeviceCentroidPathPlot:
         markers = []
         for num in range(4):
             try:
-                coord = getattr(self.imager.coords, f"marker{num+1}").get_coordinate()
+                coord = getattr(self.imager.coords, f"marker{num + 1}").get_coordinate()
             except RuntimeError:
                 continue
             markers.append(coord)
@@ -92,6 +94,18 @@ class UpdatingDeviceCentroidPathPlot:
             The point to add.
         """
         self.points.append(centroid)
+        self.refresh()
+
+    def add_points(self, centroids: list[tuple[float, float]]):
+        """
+        Add multiple centroids to the plot at once and re-render.
+
+        Parameters
+        ----------
+        centroids : list[tuple[float, float]]
+            The points to add.
+        """
+        self.points.extend(centroids)
         self.refresh()
 
     def refresh(self):

--- a/mfx/optimize/plots.py
+++ b/mfx/optimize/plots.py
@@ -11,6 +11,22 @@ import numpy as np
 from .devices import YagCamera
 
 
+def refresh_mpl_plots():
+    """
+    Call the required magic incantations to:
+    - Show all open figures that haven't been shown yet
+    - Make every figure do a draw update right away.
+
+    Do this outside of the plotting logic so we can
+    decide when to draw updates and when not to.
+
+    For example, you can do this once to update all
+    four of your plots.
+    """
+    plt.show(block=False)
+    plt.pause(0.01)
+
+
 def centroid_path_plot(
     image: np.ndarray,
     goal: tuple[float, float],
@@ -33,6 +49,9 @@ def centroid_path_plot(
     system has an issue or the markers are set strangely
     it will become more obvious using this plot.
 
+    Call refresh_mpl_plots afterwards if you'd like
+    an immediate redraw.
+
     Parameters
     ----------
     image : np.ndarray
@@ -47,8 +66,6 @@ def centroid_path_plot(
     for mk in markers:
         plt.plot(*mk, marker="+", color="lime")
     plt.plot(*goal, marker="x", color="red")
-    plt.show(block=False)
-    plt.pause(0.01)
     return fig
 
 
@@ -94,7 +111,7 @@ class UpdatingDeviceCentroidPathPlot:
             The point to add.
         """
         self.points.append(centroid)
-        self.refresh()
+        self.update_plot()
 
     def add_points(self, centroids: list[tuple[float, float]]):
         """
@@ -106,11 +123,14 @@ class UpdatingDeviceCentroidPathPlot:
             The points to add.
         """
         self.points.extend(centroids)
-        self.refresh()
+        self.update_plot()
 
-    def refresh(self):
+    def update_plot(self):
         """
-        Re-render without adding any points, e.g. to update the YAG image.
+        Update plots without adding any points, e.g. to update the YAG image.
+
+        Note: you still need to call refresh_mpl_plots or self.refresh to
+        display the updated image.
         """
         self.fig = centroid_path_plot(
             image=self.imager.image1.image,
@@ -119,3 +139,10 @@ class UpdatingDeviceCentroidPathPlot:
             centroids=self.points,
             figure=self.fig,
         )
+
+    def refresh(self):
+        """
+        Convenience helper if this is the only updating plot you have.
+        """
+        self._plot_updates()
+        refresh_mpl_plots()

--- a/mfx/optimize/type_checking.py
+++ b/mfx/optimize/type_checking.py
@@ -1,0 +1,43 @@
+"""
+Type checking utilities for use in other submodules.
+
+Keep this separate to avoid circular imports.
+"""
+
+from typing import Literal
+
+from pydantic import ConfigDict, validate_call
+
+Diagnostics = Literal["xcs1", "dg1", "dg2", "ip"]
+Methods = Literal["xopt", "blop"]
+Devices = Literal["yag", "wave8"]
+Turbo = Literal["safety", "optimize"]
+
+
+def validate_w_lowercase_args(func):
+    """
+    Decorator to make string inputs lowercase, and then validate.
+
+    Parameters:
+    -----------
+    func (Callable):
+        The function to decorate.
+
+    Returns:
+    --------
+    Callable:
+        The decorated function with string arguments converted to lowercase.
+    """
+
+    def wrapper(*args, **kwargs):
+        # Convert all string arguments to lowercase
+        new_args = tuple(arg.lower() if isinstance(arg, str) else arg for arg in args)
+        new_kwargs = {
+            k: v.lower() if isinstance(v, str) else v for k, v in kwargs.items()
+        }
+
+        # Call the original function with the modified arguments, validated by Pydantic
+        validated_func = validate_call(func, config=ConfigDict(validate_default=True))
+        return validated_func(*new_args, **new_kwargs)
+
+    return wrapper

--- a/mfx/optimize/type_checking.py
+++ b/mfx/optimize/type_checking.py
@@ -4,6 +4,7 @@ Type checking utilities for use in other submodules.
 Keep this separate to avoid circular imports.
 """
 
+import functools
 from typing import Literal
 
 from pydantic import ConfigDict, validate_call
@@ -28,7 +29,7 @@ def validate_w_lowercase_args(func):
     Callable:
         The decorated function with string arguments converted to lowercase.
     """
-
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         # Convert all string arguments to lowercase
         new_args = tuple(arg.lower() if isinstance(arg, str) else arg for arg in args)

--- a/mfx/optimize/user_select.py
+++ b/mfx/optimize/user_select.py
@@ -47,6 +47,7 @@ def select_diagnostic(
         )
 
 
+@validate_w_lowercase_args
 def select_goal(
     device_type: Devices,
     location: Diagnostics,
@@ -85,15 +86,9 @@ def select_goal(
     goal : float or tuple[float, float]
         The location to align to, given the settings.
     """
-    goal_count = 0
-    if goal is not None:
-        goal_count += 1
-    if goal_2d is not None:
-        goal_count += 1
-    if use_2d_markers:
-        goal_count += 1
+    goal_count = sum((goal is not None, goal_2d is not None, use_2d_markers))
     if goal_count != 1:
-        raise ValueError(f"Exactly one goal position be chosen! Recieved {goal_count} goals!")
+        raise ValueError(f"Exactly one goal position must be chosen! Recieved {goal_count} goals!")
 
     # goal is compatible with any hardware
     if goal is not None:
@@ -104,7 +99,10 @@ def select_goal(
         if device_type == "yag":
             return goal_2d
         else:
-            raise ValueError(f"goal_2d is only compatible with yag, not with {device_type}!")
+            raise ValueError(
+                f"goal_2d is only compatible with yag, not with {device_type}! "
+                "Try providing goal (float) instead."
+            )
 
     # use_2d_markers is compatible only with yags
     if use_2d_markers:
@@ -112,6 +110,9 @@ def select_goal(
             yag_camera = select_diagnostic(device_type=device_type, location=location)
             return yag_camera.coords.standard_two_corners_target()
         else:
-            raise ValueError(f"use_2d_markers is only compatible with yag, not with {device_type}!")
+            raise ValueError(
+                f"use_2d_markers is only compatible with yag, not with {device_type}! "
+                "Try providing goal (float) instead."
+            )
     
     raise RuntimeError("Invalid codepath in select_goal, how did you get here?")

--- a/mfx/optimize/user_select.py
+++ b/mfx/optimize/user_select.py
@@ -1,0 +1,117 @@
+"""
+Standard selectors for going from user inputs to various scan resources and settings.
+
+Re-usable in many different sorts of scans.
+"""
+from typing import Optional, Union
+
+from pcdsdevices.ipm import Wave8
+
+from .beamline_hw import init_devices
+from .devices import YagCamera
+from .type_checking import Devices, Diagnostics, validate_w_lowercase_args
+
+
+@validate_w_lowercase_args
+def select_diagnostic(
+    device_type: Devices,
+    location: Diagnostics,
+) -> Union[YagCamera, Wave8]:
+    """
+    Standard selector used to assemble the blop/xopt scans.
+
+    From some standard set of options, return the
+    diagnostic device we'll be use using in the optimization.
+
+    Parameters
+    ----------
+    device_type : Devices
+        One of "yag" or "wave8"
+    location : Diagnostics
+        One of "xcs1", "dg1", "dg2", "ip"
+    """
+    devices = init_devices()
+    if device_type == "yag":
+        if location == "xcs1":
+            return devices["xcs_yag1"]
+        else:
+            return devices[f"mfx_{location}_yag"]
+    elif device_type == "wave8":
+        if location in ("dg1", "dg2"):
+            return devices[f"mfx_{location}_wave8"]
+        else:
+            raise ValueError(f"Invalid wave8 {location}, expected dg1 or dg2")
+    else:
+        raise RuntimeError(
+            f"Invalid device_type {device_type} selected, pydantic broke?"
+        )
+
+
+def select_goal(
+    device_type: Devices,
+    location: Diagnostics,
+    goal: Optional[float] = None,
+    goal_2d: Optional[tuple[float, float]] = None,
+    use_2d_markers: bool = False,
+) -> Union[float, tuple[float, float]]:
+    """
+    Select a goal for the alignment.
+
+    The goal is either a specific point on a 2d plane or on
+    a 1d line.
+
+    Exactly one of goal, goal_2d, and use_2d_markers must be
+    provided.
+
+    Some other combinations of arguments are not allowed
+    and will raise ValueError.
+
+    Parameters
+    ----------
+    device_type : Devices
+        One of "yag" or "wave8"
+    location : Diagnostics
+        One of "xcs1", "dg1", "dg2", "ip"
+    goal : float, optional
+        1D goal to align to
+    goal_2d : tuple[float, float], optional
+        2D goal to align to
+    use_2d_markers : bool, optional
+        Set to True to automatically select the goal from the
+        camviewer makers.
+
+    Returns
+    -------
+    goal : float or tuple[float, float]
+        The location to align to, given the settings.
+    """
+    goal_count = 0
+    if goal is not None:
+        goal_count += 1
+    if goal_2d is not None:
+        goal_count += 1
+    if use_2d_markers:
+        goal_count += 1
+    if goal_count != 1:
+        raise ValueError(f"Exactly one goal position be chosen! Recieved {goal_count} goals!")
+
+    # goal is compatible with any hardware
+    if goal is not None:
+        return goal
+    
+    # goal_2d is compatible only with yags
+    if goal_2d is not None:
+        if device_type == "yag":
+            return goal_2d
+        else:
+            raise ValueError(f"goal_2d is only compatible with yag, not with {device_type}!")
+
+    # use_2d_markers is compatible only with yags
+    if use_2d_markers:
+        if device_type == "yag":
+            yag_camera = select_diagnostic(device_type=device_type, location=location)
+            return yag_camera.coords.standard_two_corners_target()
+        else:
+            raise ValueError(f"use_2d_markers is only compatible with yag, not with {device_type}!")
+    
+    raise RuntimeError("Invalid codepath in select_goal, how did you get here?")

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -449,13 +449,11 @@ def run_sim_test_yag_2d() -> Xopt:
     )
     imager.image1.shaped_image.trigger()
     path_plot.add_point(imager.image1.get_centroid())
-    path_plot.refresh()
     for num in range(10):
         print(f"Step {num + 1}")
         xopt.step()
         imager.image1.shaped_image.trigger()
         path_plot.add_point(imager.image1.get_centroid())
-        path_plot.refresh()
     print("Get best point")
     try:
         _, val, params = xopt.vocs.select_best(xopt.data)

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -139,7 +139,7 @@ def get_evaluator_yag(
         image = image_device.get()
         print(f"image shape: {image.shape}")
         # NOTE/TODO: consider adding an averaging step here before fitting
-        fit_result = fit.fit_image(image.T)
+        fit_result = fit.fit_image(image)
         results = {}
         results["centroid_x"] = fit_result.centroid[0]
         results["centroid_y"] = fit_result.centroid[1]

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -30,11 +30,11 @@ from .beamline_hw import (
     YAG_CENTROID_Y_MIN_MAX,
     WAVE8_CENTROID_X_MIN_MAX,
     WAVE8_CENTROID_Y_MIN_MAX,
-    select_diagnostic,
 )
 from .errors import FeasibilityError
 from .plots import UpdatingDeviceCentroidPathPlot
 from .type_checking import validate_w_lowercase_args, Devices, Diagnostics, Turbo
+from .user_select import select_diagnostic, select_goal
 
 
 def get_vocs(
@@ -268,8 +268,13 @@ def get_xopt_obj(
     goal_2d: tuple[float, float] or None, optional
         The 2D optimization goal if running a 2D YAG optimization
     """
-    if (device_type=="wave8" or not use_2d_markers) and not goal:
-        raise ValueError("Must provide a goal (float) for running YAG or wave8 optimization.")
+    goal_value = select_goal(
+        device_type=device_type,
+        location=location,
+        goal=goal,
+        goal_2d=goal_2d,
+        use_2d_markers=use_2d_markers,
+    )
 
     if device_type == "wave8":
         if any(v is not None for v in (yag_size_min, yag_size_max, yag_intensity_min, yag_intensity_max)):
@@ -313,20 +318,20 @@ def get_xopt_obj(
     )
     print(vocs)
     if device_type == "yag":
-        if use_2d_markers:
+        if isinstance(goal_value, tuple):
             evaluator = get_evaluator_yag_2d(
                 yag=location,
-                goal=goal_2d,
+                goal=goal_value,
             )
         else:
             evaluator = get_evaluator_yag(
                 yag=location,
-                goal=goal,
+                goal=goal_value,
             )
     else:
         evaluator = get_evaluator_wave8(
             wave8=location,
-            wave8_xpos=goal,
+            wave8_xpos=goal_value,
         )
     generator = ExpectedImprovementGenerator(vocs=vocs, turbo_controller=xopt_generator_turbo_controller)
     generator.gp_constructor.use_low_noise_prior = False
@@ -436,7 +441,11 @@ def run_sim_test_yag_2d() -> Xopt:
     imager = select_diagnostic("yag", "dg1")
     path_plot = UpdatingDeviceCentroidPathPlot(
         imager=imager,
-        goal=imager.coords.standard_two_corners_target(),
+        goal=select_goal(
+            device_type="yag",
+            location="dg1",
+            use_2d_markers=True,
+        ),
     )
     imager.image1.shaped_image.trigger()
     path_plot.add_point(imager.image1.get_centroid())

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -16,7 +16,6 @@ from xopt.generators.bayesian import ExpectedImprovementGenerator
 from lcls_tools.common.frontend.plotting.image import plot_image_projection_fit
 from lcls_tools.common.image.fit import ImageProjectionFit
 
-from .beam import Devices, Diagnostics, Turbo, validate_w_lowercase_args, FeasibilityError
 from .beamline_hw import (
     XCS_YAG_XPOS,
     DG1_WAVE8_XPOS,
@@ -30,9 +29,12 @@ from .beamline_hw import (
     YAG_CENTROID_X_MIN_MAX,
     YAG_CENTROID_Y_MIN_MAX,
     WAVE8_CENTROID_X_MIN_MAX,
-    WAVE8_CENTROID_Y_MIN_MAX
+    WAVE8_CENTROID_Y_MIN_MAX,
+    select_diagnostic,
 )
+from .errors import FeasibilityError
 from .plots import UpdatingDeviceCentroidPathPlot
+from .type_checking import validate_w_lowercase_args, Devices, Diagnostics, Turbo
 
 
 def get_vocs(
@@ -97,7 +99,7 @@ def get_evaluator_wave8(
         print(f"Trying {input['mirror_pitch']}")
         devices = init_devices()
         devices["mr1l4_homs"].pitch.set(input["mirror_pitch"]).wait(timeout=20)
-        xpos_device = devices[f"mfx_{wave8}_wave8"].xpos
+        xpos_device = select_diagnostic("wave8", wave8).xpos
         xpos_device.trigger().wait(timeout=10)
         xpos = xpos_device.get()
         results = {}
@@ -108,13 +110,6 @@ def get_evaluator_wave8(
         return results
 
     return Evaluator(function=evaluate)
-
-
-def get_yag_key(yag: str):
-    if yag == 'xcs1':
-        return "xcs_yag1"
-    else:
-        return f"mfx_{yag}_yag"
 
 
 def get_evaluator_yag(
@@ -139,7 +134,7 @@ def get_evaluator_yag(
         print(f"Trying {input['mirror_pitch']}")
         devices = init_devices()
         devices["mr1l4_homs"].pitch.set(input["mirror_pitch"]).wait(timeout=20)
-        image_device = devices[get_yag_key(yag)].image1.shaped_image
+        image_device = select_diagnostic("yag", yag).image1.shaped_image
         image_device.trigger().wait(timeout=10)
         image = image_device.get()
         print(f"image shape: {image.shape}")
@@ -172,7 +167,7 @@ def get_evaluator_yag_2d(
     if yag not in ("xcs1", "dg1", "dg2", "ip"):
         raise ValueError("Can only use xcs1, dg1, dg2, ip yags.")
     devices = init_devices()
-    imager = devices[get_yag_key(yag)]
+    imager = select_diagnostic("yag", yag)
     image_device = imager.image1.shaped_image
     mirror = devices["mr1l4_homs"]
 
@@ -277,8 +272,6 @@ def get_xopt_obj(
         raise ValueError("Must provide a goal (float) for running YAG or wave8 optimization.")
 
     if device_type == "wave8":
-        if location == "ip":
-            raise ValueError("There is no wave8 at the ip.")
         if any(v is not None for v in (yag_size_min, yag_size_max, yag_intensity_min, yag_intensity_max)):
             raise ValueError(
                 "Arguments yag_size_min, yag_size_max, yag_intensity_min, and yag_intensity_max "
@@ -421,7 +414,7 @@ def run_sim_test_yag() -> Xopt:
     print(f"pitch is at {mirror_pitch.position}")
     print("Generating plots")
     xopt.data.plot(y=xopt.vocs.objective_names)
-    imager = init_devices()["mfx_dg1_yag"]
+    imager = select_diagnostic("yag", "dg1")
     imager.image1.shaped_image.trigger()
     fit = ImageProjectionFit()
     fit_result = fit.fit_image(imager.image1.shaped_image.get())
@@ -440,7 +433,7 @@ def run_sim_test_yag_2d() -> Xopt:
     print("Randomly evaluate 3 points")
     xopt.random_evaluate(3)
     print("Step xopt object 10 times")
-    imager = init_devices()["mfx_dg1_yag"]
+    imager = select_diagnostic("yag", "dg1")
     path_plot = UpdatingDeviceCentroidPathPlot(
         imager=imager,
         goal=imager.coords.standard_two_corners_target(),

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -153,29 +153,18 @@ def get_evaluator_yag(
     return Evaluator(function=evaluate)
 
 
+@validate_w_lowercase_args
 def get_evaluator_yag_2d(
-    yag: str = "dg1",
-    goal: tuple[float, float] | None = None,
+    yag: Diagnostics,
+    goal: tuple[float, float],
 ) -> Evaluator:
     """
     Alternate evaluator in 2d space.
-
-    As a default, uses the automatic selection of goal position from the
-    user marker PVs.
     """
-    yag = yag.lower()
-    if yag not in ("xcs1", "dg1", "dg2", "ip"):
-        raise ValueError("Can only use xcs1, dg1, dg2, ip yags.")
     devices = init_devices()
     imager = select_diagnostic("yag", yag)
     image_device = imager.image1.shaped_image
     mirror = devices["mr1l4_homs"]
-
-    if goal is None:
-        goal = imager.coords.standard_two_corners_target()
-        print(f"Goal is {goal} from camviewer markers")
-    else:
-        print(f"Goal is {goal} from function input")
 
     fit = ImageProjectionFit()
 

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -449,11 +449,13 @@ def run_sim_test_yag_2d() -> Xopt:
     )
     imager.image1.shaped_image.trigger()
     path_plot.add_point(imager.image1.get_centroid())
+    path_plot.refresh()
     for num in range(10):
         print(f"Step {num + 1}")
         xopt.step()
         imager.image1.shaped_image.trigger()
         path_plot.add_point(imager.image1.get_centroid())
+        path_plot.refresh()
     print("Get best point")
     try:
         _, val, params = xopt.vocs.select_best(xopt.data)


### PR DESCRIPTION
Apologies in advance, I moved around a lot of code here.
But, I think separating it out like this makes it easier to re-use.

I started with the simple goal of including the path plot in `Beam.align` but then there wasn't enough information available in `Beam.align` to do this, so I started creating these selector functions to pull out the information getters and then I got a little carried away.

But I'm really happy with how this turned out.

I ended up creating the following new submodules:

- `errors`: I ended up only putting one exception here, but I wanted to get it out of `beam` because I wanted other modules to be able to use it without importing from `beam`. I think the structure is more clear if `beam` imports from other things but not vice versa and it avoids circular imports.
- `type_checking`: again, these useful bits were in `beam` and I wanted to import them in other submodules.
- `user_select`: this contains logic for going from a user's input args as defined in `beam.align` to the underlying devices, etc. that are to be used. By breaking out this logic we can consolidate some of the error handling and later re-use input handling for setting up the blop agent. So far I only broke out the two pieces of setup that the path plot needs to function.

closes #163 

Main goals:

- [x] Include the path plots from #173 in align.beam in a fully working state

Stretch goals:

- [x] Update the xopt evaluator plots from #172 to re-use the same canvas and display during plan execution

Others (some related to #164):

- [x] Automatically discover optimize submodules for autoreload
- [x] Consolidate type checking utilities into one submodule (avoid circular imports)
- [x] Consolidate custom exception into one submodule (avoid circular imports)
- [x] Consolidate code used to determine which diagnostic to use from user input
- [x] Consolidate code used to determine which goal to use from user input
- [x] Update `validate_w_lowercase_args` to use `functools.wraps` to preserve signature info in ipython
- [x] Finally un-transpose the image in the 1D xopt alignment