### PR TITLE
ENH: Undulator pointing absolute moves and xopt alignment

### DIFF
--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -8,14 +8,19 @@ from bluesky import RunEngine
 from xopt import Xopt
 from .errors import FeasibilityError
 from .plots import UpdatingDeviceCentroidPathPlot, UpdatingXoptVisualizeModelPlot, refresh_mpl_plots
-from .type_checking import validate_w_lowercase_args, Diagnostics, Methods, Devices, Turbo
-from .user_select import select_diagnostic, select_goal
+from .type_checking import validate_w_lowercase_args, Diagnostics, Methods, Devices, Turbo, Movers
+from .user_select import select_diagnostic, select_goal, select_var_range, MP_KEY, UNDP_KEY_X, UNDP_KEY_Y
 
 
 class Beam:
     @validate_call
-    def __init__(self, mirror_pitch: list[float] = [-546.0, -542.0]):
+    def __init__(
+        self,
+        mirror_pitch: list[float] = [-546.0, -542.0],
+        und_search_delta: float = 50.0,
+    ):
         self.mirror_pitch: list[float] = mirror_pitch
+        self.und_search_delta: float = und_search_delta
 
     @validate_w_lowercase_args
     def align(
@@ -24,6 +29,7 @@ class Beam:
             on_diagnostic: Diagnostics = "dg1",
             with_method: Methods = "xopt",
             using_device: Devices = "yag",
+            mover: Movers = "mirr",
             xopt_turbo_option: Turbo = "safety",
             xopt_rand_evaluate: int = 3,
             xopt_steps: int = 10,
@@ -48,6 +54,8 @@ class Beam:
             Method to use for alignment. Options: "blop, xopt". Default is "xopt".
         using_device : str, optional
             Device to use for alignment. Options: "yag, wave8". Default is "yag".
+        mover : str, optional
+            Motion device to steer the beam. Options: "mirr, und". Default is "mirr".
         xopt_turbo_option : str, optional
             Xopt turbo controller option. Options: "safety, optimize". Default is "safety".
         xopt_rand_evaluate : int, optional
@@ -75,7 +83,7 @@ class Beam:
 
         path_plot = None
         if with_method == "xopt":
-            from .xopt_scans import get_xopt_obj, init_devices
+            from .xopt_scans import get_xopt_obj, init_devices, evaluator_move
             # Allow the loading of an already instantiated xopt object, e.g. to take more steps
             if xopt_obj:
                 print("Using existing Xopt object.")
@@ -92,16 +100,31 @@ class Beam:
                     )
             else:
                 print("Loading Xopt object.")
-                xopt = get_xopt_obj(
-                    device_type=using_device,
-                    location=on_diagnostic,
-                    goal=with_goal,
-                    xopt_generator_turbo_controller=xopt_turbo_option,
-                    use_2d_markers=use_2d_markers,
-                    goal_2d=with_goal_2d,
-                    max_iter=xopt_max_iter
-                )
-                customized_boundaries = {"mirror_pitch": self.mirror_pitch}
+                xopt_kw = {
+                    "device_type": using_device,
+                    "location": on_diagnostic,
+                    "mover": mover,
+                    "goal": with_goal,
+                    "xopt_generator_turbo_controller": xopt_turbo_option,
+                    "use_2d_markers": use_2d_markers,
+                    "goal_2d": with_goal_2d,
+                    "max_iter": xopt_max_iter,
+                }
+                if mover == "mirr":
+                    xopt_kw["search_range"] = tuple(self.mirror_pitch)
+                    customized_boundaries = select_var_range(
+                        mover=mover,
+                        search_range=tuple(self.mirror_pitch),
+                    )
+                elif mover == "und":
+                    xopt_kw["search_delta"] = self.und_search_delta
+                    customized_boundaries = select_var_range(
+                        mover=mover,
+                        search_delta=self.und_search_delta,
+                    )
+                else:
+                    raise NotImplementedError(f"Mover {mover} not implemented for xopt in beam.align.")
+                xopt = get_xopt_obj(**xopt_kw)
                 if using_device == "yag":
                     print("Generating path plot")
                     path_plot = UpdatingDeviceCentroidPathPlot(
@@ -170,9 +193,10 @@ class Beam:
 
             print(f"Best objective value {val}")
             print(f"Best point {params}")
-            mirror_pitch = init_devices()["mr1l4_homs"].pitch
-            mirror_pitch.set(params["mirror_pitch"]).wait(timeout=20)
-            print(f"pitch is at {mirror_pitch.position}")
+            evaluator_move(
+                mover=mover,
+                input=params,
+            )
             if save_run:
                 now = datetime.datetime.now()
                 formatted_string = now.strftime("%y-%m-%d-%H:%M:%S")
@@ -183,7 +207,7 @@ class Beam:
                 xopt.dump(str(logs_folder / filename))
             ax = xopt.data.plot(y=xopt.vocs.objective_names)
             ax.set_xlabel("steps")
-            ax.set_ylabel("mirror pitch")
+            ax.set_ylabel("objective (to minimize)")
             xopt_eval_plot.refresh()
             if path_plot is not None:
                 path_plot.refresh()

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -200,7 +200,7 @@ class Beam:
             if save_run:
                 now = datetime.datetime.now()
                 formatted_string = now.strftime("%y-%m-%d-%H:%M:%S")
-                filename  = f"xopt_run_{on_diagnostic}_{using_device}_{formatted_string}.yaml"
+                filename  = f"xopt_run_{on_diagnostic}_{using_device}_{mover}_{formatted_string}.yaml"
                 # The logs folder at the root of the repo should exist and be writeable
                 logs_folder = Path(__file__).parent.parent.parent / "logs" / "xopt"
                 logs_folder.mkdir(parents=True, exist_ok=True)

--- a/mfx/optimize/beamline_hw.py
+++ b/mfx/optimize/beamline_hw.py
@@ -132,8 +132,8 @@ def sim_devices() -> dict[str, Device]:
         cam.sim_set_image(
             size=(512, 512),
             centroid=(
-                mdpitch * 60 - undp_dx * 0.6 + DG1_YAG_XPOS + dg1_yag_offset + random.uniform(-6, 6),
-                256 + undp_dy * 0.6 + random.uniform(-3, 3)
+                mdpitch * 60 - undp_dx * 3 + DG1_YAG_XPOS + dg1_yag_offset + random.uniform(-6, 6),
+                256 + undp_dy * 3 + random.uniform(-3, 3)
             ),
             fwhm=100,
             peak=255,
@@ -144,8 +144,8 @@ def sim_devices() -> dict[str, Device]:
         cam.sim_set_image(
             size=(512, 512),
             centroid=(
-                mdpitch * 80 - undp_dx * 0.8 + DG2_YAG_XPOS + dg2_yag_offset + random.uniform(-8, 8),
-                256 + undp_dy * 0.8 + random.uniform(-5, 5)
+                mdpitch * 80 - undp_dx * 4 + DG2_YAG_XPOS + dg2_yag_offset + random.uniform(-8, 8),
+                256 + undp_dy * 4 + random.uniform(-5, 5)
             ),
             fwhm=150,
             peak=255,
@@ -156,8 +156,8 @@ def sim_devices() -> dict[str, Device]:
         cam.sim_set_image(
             size=(728, 544),
             centroid=(
-                mdpitch * 40 - undp_dx * 0.4 + XCS_YAG_XPOS + ip_yag_offset + random.uniform(-4, 4),
-                274 + undp_dy * 0.4 + random.uniform(-7, 7)
+                mdpitch * 40 - undp_dx * 2 + XCS_YAG_XPOS + ip_yag_offset + random.uniform(-4, 4),
+                274 + undp_dy * 2 + random.uniform(-7, 7)
             ),
             fwhm=200,
             peak=255,
@@ -168,8 +168,8 @@ def sim_devices() -> dict[str, Device]:
         cam.sim_set_image(
             size=(688, 538),
             centroid=(
-                mdpitch * 70 - undp_dx * 0.7 + IP_YAG_XPOS + ip_yag_offset + random.uniform(-7, 7),
-                269 + undp_dy * 0.7 + random.uniform(-7, 7)
+                mdpitch * 70 - undp_dx * 3.5 + IP_YAG_XPOS + ip_yag_offset + random.uniform(-7, 7),
+                269 + undp_dy * 3.5 + random.uniform(-7, 7)
             ),
             fwhm=80,
             peak=255,
@@ -180,11 +180,16 @@ def sim_devices() -> dict[str, Device]:
     devices["xcs_yag1"].image1.sim_install_updater(update_fake_xcs_yag1)
     devices["mfx_ip_yag"].image1.sim_install_updater(update_fake_ip1_yag)
 
-    for name in ("mfx_dg1_yag", "mfx_dg2_yag", "xcs_yag1", "mfx_ip_yag"):
+    # MFX yags use opposite slit corners as the goal
+    for name in ("mfx_dg1_yag", "mfx_dg2_yag", "mfx_ip_yag"):
         devices[name].coords.marker1.xpos.put(150)
         devices[name].coords.marker1.ypos.put(150)
         devices[name].coords.marker2.xpos.put(350)
         devices[name].coords.marker2.ypos.put(350)
+
+    # XCS yag uses the location of marker 2 as the goal
+    devices["xcs_yag1"].coords.marker2.xpos.put(360)
+    devices["xcs_yag1"].coords.marker2.xpos.put(274)
 
     devices["mfx_dg1_wave8"].kind = "hinted"
     devices["mfx_dg2_wave8"].kind = "hinted"

--- a/mfx/optimize/beamline_hw.py
+++ b/mfx/optimize/beamline_hw.py
@@ -10,7 +10,7 @@ from ophyd.sim import SynAxis, SynSignal
 from pcdsdevices.ipm import Wave8
 
 from .devices import FakeLCLSImagePlugin, FakeYagCamera, YagCamera
-
+from .undpoint import UndPointAbs2DMFX, UndPointAbs2DSim
 
 HAPPI_NAMES = (
     "mr1l4_homs",
@@ -67,6 +67,8 @@ def init_devices(force: bool = False) -> dict[str, Device]:
     devices["mfx_ip_yag"] = YagCamera("MFX:GIGE:LBL:01:", name="mfx_ip1_yag")
     devices["mfx_ip_yag"].kind = "hinted"
 
+    devices["undp"] = UndPointAbs2DMFX()
+
     return devices
 
 
@@ -84,19 +86,29 @@ def sim_devices() -> dict[str, Device]:
     devices["mr1l4_homs"] = SimpleNamespace(pitch=SynAxis(name="mr1l4_homs_pitch", value=MIRROR_NOMINAL))
     devices["mfx_dg1_ipm"] = SimpleNamespace(inserted=True)
     devices["mfx_dg2_ipm"] = SimpleNamespace(inserted=False)
+    devices["undp"] = UndPointAbs2DSim()
     dg1_wave8_offset = random.uniform(-1, 1)
     dg2_wave8_offset = random.uniform(-1, 1)
     dg1_yag_offset = random.uniform(-30, 30)
     dg2_yag_offset = random.uniform(-50, 50)
     ip_yag_offset = random.uniform(-70, 70)
+    undp_x0 = devices["undp"].position[0]
+    undp_y0 = devices["undp"].position[1]
+
+    def get_offsets() -> tuple[float, float, float]:
+        return (
+            devices["mr1l4_homs"].pitch.position - MIRROR_NOMINAL,
+            devices["undp"].position[0] - undp_x0,
+            devices["undp"].position[1] - undp_y0
+        )
 
     def get_fake_dg1_wave8() -> float:
-        pitch = devices["mr1l4_homs"].pitch.position
-        return pitch - MIRROR_NOMINAL + DG1_WAVE8_XPOS + dg1_wave8_offset + random.uniform(-0.1, 0.1)
+        mdpitch, undp_dx, _ = get_offsets()
+        return mdpitch - undp_dx/200 + DG1_WAVE8_XPOS + dg1_wave8_offset + random.uniform(-0.1, 0.1)
 
     def get_fake_dg2_wave8() -> float:
-        pitch = devices["mr1l4_homs"].pitch.position
-        return pitch - MIRROR_NOMINAL + DG2_WAVE8_XPOS + dg2_wave8_offset + random.uniform(-0.1, 0.1)
+        mdpitch, undp_dx, _ = get_offsets()
+        return mdpitch - undp_dx/200 + DG2_WAVE8_XPOS + dg2_wave8_offset + random.uniform(-0.1, 0.1)
 
     devices["mfx_dg1_wave8"] = SimpleNamespace(
         xpos=SynSignal(
@@ -116,38 +128,50 @@ def sim_devices() -> dict[str, Device]:
     devices["mfx_ip_yag"] = FakeYagCamera("", name="mfx_ip_yag")
 
     def update_fake_dg1_yag(cam: FakeLCLSImagePlugin):
-        pitch = devices["mr1l4_homs"].pitch.position
+        mdpitch, undp_dx, undp_dy = get_offsets()
         cam.sim_set_image(
-            size=(1388, 1038),
-            centroid=((pitch - MIRROR_NOMINAL) * 60 + DG1_YAG_XPOS + dg1_yag_offset + random.uniform(-6, 6), 519 + random.uniform(-3, 3)),
+            size=(512, 512),
+            centroid=(
+                mdpitch * 60 - undp_dx * 0.6 + DG1_YAG_XPOS + dg1_yag_offset + random.uniform(-6, 6),
+                256 + undp_dy * 0.6 + random.uniform(-3, 3)
+            ),
             fwhm=100,
             peak=255,
         )
 
     def update_fake_dg2_yag(cam: FakeLCLSImagePlugin):
-        pitch = devices["mr1l4_homs"].pitch.position
+        mdpitch, undp_dx, undp_dy = get_offsets()
         cam.sim_set_image(
-            size=(1388, 1038),
-            centroid=((pitch - MIRROR_NOMINAL) * 80 + DG2_YAG_XPOS + dg2_yag_offset + random.uniform(-8, 8), 519 + random.uniform(-5, 5)),
+            size=(512, 512),
+            centroid=(
+                mdpitch * 80 - undp_dx * 0.8 + DG2_YAG_XPOS + dg2_yag_offset + random.uniform(-8, 8),
+                256 + undp_dy * 0.8 + random.uniform(-5, 5)
+            ),
             fwhm=150,
             peak=255,
         )
 
     def update_fake_xcs_yag1(cam: FakeLCLSImagePlugin):
-        pitch = devices["mr1l4_homs"].pitch.position
+        mdpitch, undp_dx, undp_dy = get_offsets()
         cam.sim_set_image(
             size=(728, 544),
-            centroid=((pitch - MIRROR_NOMINAL) * 70 + XCS_YAG_XPOS + ip_yag_offset + random.uniform(-7, 7), 274 + random.uniform(-7, 7)),
+            centroid=(
+                mdpitch * 40 - undp_dx * 0.4 + XCS_YAG_XPOS + ip_yag_offset + random.uniform(-4, 4),
+                274 + undp_dy * 0.4 + random.uniform(-7, 7)
+            ),
             fwhm=200,
             peak=255,
         )
 
     def update_fake_ip1_yag(cam: FakeLCLSImagePlugin):
-        pitch = devices["mr1l4_homs"].pitch.position
+        mdpitch, undp_dx, undp_dy = get_offsets()
         cam.sim_set_image(
             size=(688, 538),
-            centroid=((pitch - MIRROR_NOMINAL) * 70 + IP_YAG_XPOS + ip_yag_offset + random.uniform(-7, 7), 269 + random.uniform(-7, 7)),
-            fwhm=200,
+            centroid=(
+                mdpitch * 70 - undp_dx * 0.7 + IP_YAG_XPOS + ip_yag_offset + random.uniform(-7, 7),
+                269 + undp_dy * 0.7 + random.uniform(-7, 7)
+            ),
+            fwhm=80,
             peak=255,
         )
 
@@ -156,12 +180,11 @@ def sim_devices() -> dict[str, Device]:
     devices["xcs_yag1"].image1.sim_install_updater(update_fake_xcs_yag1)
     devices["mfx_ip_yag"].image1.sim_install_updater(update_fake_ip1_yag)
 
-    # Aim vaguely toward 300, 300 for the 2d camviewer marker test
     for name in ("mfx_dg1_yag", "mfx_dg2_yag", "xcs_yag1", "mfx_ip_yag"):
-        devices[name].coords.marker1.xpos.put(200)
-        devices[name].coords.marker1.ypos.put(425)
-        devices[name].coords.marker2.xpos.put(400)
-        devices[name].coords.marker2.ypos.put(625)
+        devices[name].coords.marker1.xpos.put(150)
+        devices[name].coords.marker1.ypos.put(150)
+        devices[name].coords.marker2.xpos.put(350)
+        devices[name].coords.marker2.ypos.put(350)
 
     devices["mfx_dg1_wave8"].kind = "hinted"
     devices["mfx_dg2_wave8"].kind = "hinted"
@@ -172,15 +195,5 @@ def sim_devices() -> dict[str, Device]:
 
     print("Generated fake dg1 and dg2 signals and images")
     print("Expected: 1:1 linear relationship between x and pitch")
-    print(f"Expected: dg1 wave8 reads {DG1_WAVE8_XPOS + dg1_wave8_offset} + noise when pitch is {MIRROR_NOMINAL}")
-    print(f"Expected: dg2 wave8 reads {DG2_WAVE8_XPOS + dg2_wave8_offset} + noise when pitch is {MIRROR_NOMINAL}")
-    print(f"Expected: dg1 yag reads {DG1_YAG_XPOS + dg1_yag_offset} + noise when pitch is {MIRROR_NOMINAL}")
-    print(f"Expected: dg2 yag reads {DG2_YAG_XPOS + dg2_yag_offset} + noise when pitch is {MIRROR_NOMINAL}")
-    print(f"Expected: dg2 yag reads {IP_YAG_XPOS + ip_yag_offset} + noise when pitch is {MIRROR_NOMINAL}")
-    print(f"default alignment on dg1 wave8 should pick {MIRROR_NOMINAL - dg1_wave8_offset}")
-    print(f"default alignment on dg2 wave8 should pick {MIRROR_NOMINAL - dg2_wave8_offset}")
-    print(f"default alignment on dg1 yag should pick {MIRROR_NOMINAL - dg1_yag_offset}")
-    print(f"default alignment on dg2 yag should pick {MIRROR_NOMINAL - dg2_yag_offset}")
-    print(f"default alignment on ip yag should pick {MIRROR_NOMINAL - ip_yag_offset}")
 
     return devices

--- a/mfx/optimize/beamline_hw.py
+++ b/mfx/optimize/beamline_hw.py
@@ -189,7 +189,7 @@ def sim_devices() -> dict[str, Device]:
 
     # XCS yag uses the location of marker 2 as the goal
     devices["xcs_yag1"].coords.marker2.xpos.put(360)
-    devices["xcs_yag1"].coords.marker2.xpos.put(274)
+    devices["xcs_yag1"].coords.marker2.ypos.put(274)
 
     devices["mfx_dg1_wave8"].kind = "hinted"
     devices["mfx_dg2_wave8"].kind = "hinted"

--- a/mfx/optimize/plots.py
+++ b/mfx/optimize/plots.py
@@ -4,8 +4,8 @@ Matplotlib plotting utilities for tracking the optimizer's decisions.
 
 from typing import Optional, Union
 
-import matplotlib.axes
-import matplotlib.figure
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -32,8 +32,8 @@ def centroid_path_plot(
     goal: Union[float, tuple[float, float]],
     markers: list[tuple[float, float]],
     centroids: list[tuple[float, float]],
-    figure: Optional[matplotlib.figure.Figure] = None,
-) -> matplotlib.figure.Figure:
+    figure: Optional[Figure] = None,
+) -> Figure:
     """
     Plot the path of a centroid alignment.
 
@@ -157,25 +157,21 @@ class UpdatingXoptVisualizeModelPlot:
 
     def __init__(self, xopt: Xopt):
         self.xopt = xopt
-        self.fig: Optional[matplotlib.figure.Figure] = None
-        self.axes: Optional[list[matplotlib.axes.Axes]] = None
+        self.fig: Optional[Figure] = None
+        self.axs: Optional[Union[Axes, np.ndarray]] = None
 
     def refresh(self):
         """
-        Re-render the new plot in place.
+        Close the old plot and render the new plot.
+
+        Re-rendering this in place without aberrations has been surprisingly difficult.
         """
-        if self.axes is not None:
-            try:
-                self.axes.clear()
-            except Exception:
-                for ax in self.axes:
-                    try:
-                        ax.clear()
-                    except Exception:
-                        ...
-        self.fig, self.axes = self.xopt.generator.visualize_model(
+        newfig, newaxs = self.xopt.generator.visualize_model(
             show_acquisition=False,
-            axes=self.axes
         )
         plt.figure(self.fig)
+        plt.close()
+        plt.figure(newfig)
         refresh_mpl_plots()
+        self.fig = newfig
+        self.axs = newaxs

--- a/mfx/optimize/plots.py
+++ b/mfx/optimize/plots.py
@@ -164,12 +164,18 @@ class UpdatingXoptVisualizeModelPlot:
         """
         Re-render the new plot in place.
         """
-        #if self.axes is not None:
-        #    for ax in self.axes:
-        #        ax.clear()
+        if self.axes is not None:
+            try:
+                self.axes.clear()
+            except Exception:
+                for ax in self.axes:
+                    try:
+                        ax.clear()
+                    except Exception:
+                        ...
         self.fig, self.axes = self.xopt.generator.visualize_model(
             show_acquisition=False,
-            #axes=self.axes
+            axes=self.axes
         )
         plt.figure(self.fig)
         refresh_mpl_plots()

--- a/mfx/optimize/type_checking.py
+++ b/mfx/optimize/type_checking.py
@@ -12,7 +12,9 @@ from pydantic import ConfigDict, validate_call
 Diagnostics = Literal["xcs1", "dg1", "dg2", "ip"]
 Methods = Literal["xopt", "blop"]
 Devices = Literal["yag", "wave8"]
+Movers = Literal["mirr", "und"]
 Turbo = Literal["safety", "optimize"]
+
 
 
 def validate_w_lowercase_args(func):

--- a/mfx/optimize/undpoint.py
+++ b/mfx/optimize/undpoint.py
@@ -101,6 +101,7 @@ class UndPointAbs2D(MvInterface, Device, PositionerBase):
         derived_units="um",
         original_units="mm",
         kind="hinted",
+        add_prefix=(),
     )
     ypos = Cpt(
         UnitConversionDerivedSignal,
@@ -108,6 +109,7 @@ class UndPointAbs2D(MvInterface, Device, PositionerBase):
         derived_units="um",
         original_units="mm",
         kind="hinted",
+        add_prefix=(),
     )
 
     x_raw_rbv = FCpt(EpicsSignalRO, "{x_abs_pvname}", kind="omitted")

--- a/mfx/optimize/undpoint.py
+++ b/mfx/optimize/undpoint.py
@@ -26,14 +26,21 @@ The alignment is something like:
 - request the move
 - recalibrate? (maybe?)
 """
-from lcls_tools.common.image.fit import ImageProjectionFit
-from ophyd.device import Component as Cpt, FormattedComponent as FCpt, Device
-from ophyd.signal import EpicsSignal, EpicsSignalRO
-from ophyd.pv_positioner import PVPositioner
-from pcdsdevices.signal import MultiDerivedSignal
-from pcdsdevices.type_hints import SignalToValue
 
-from .devices import YagCamera
+from typing import Callable, Optional
+
+from ophyd.device import Component as Cpt
+from ophyd.device import Device
+from ophyd.device import FormattedComponent as FCpt
+from ophyd.positioner import PositionerBase
+from ophyd.pv_positioner import PVPositioner
+from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal
+from pcdsdevices.interface import MvInterface
+from pcdsdevices.signal import MultiDerivedSignal, UnitConversionDerivedSignal
+from pcdsdevices.type_hints import SignalToValue
+from pydantic import validate_call
+
+DEFAULT_DONE_MOVE_PV = "SIOC:SYS0:ML07:AO216"
 
 
 def _get_2d_delta(mds: MultiDerivedSignal, items: SignalToValue) -> tuple[float, float]:
@@ -44,8 +51,14 @@ def _put_2d_delta(mds: MultiDerivedSignal, value: tuple[float, float]) -> Signal
     return {mds.signals[0]: value[0], mds.signals[1]: value[1]}
 
 
-class UndPoint2D(PVPositioner):
-    """Undulator pointing variant: move by (x, y)"""
+class UndPointDelta2D(PVPositioner):
+    """
+    Undulator pointing variant: delta move by (x, y).
+
+    This is the raw interface provided by ACR.
+    All other variants re-use these definitions.
+    """
+
     setpoint = Cpt(
         MultiDerivedSignal,
         attrs=["delta_x", "delta_y"],
@@ -60,7 +73,14 @@ class UndPoint2D(PVPositioner):
     actuate_value = 1
     done_value = 0
 
-    def __init__(self, prefix: str, done_pvname: str, *, name: str, **kwargs):
+    def __init__(
+        self,
+        prefix: str,
+        *,
+        done_pvname: str = DEFAULT_DONE_MOVE_PV,
+        name: str,
+        **kwargs,
+    ):
         self.done_pvname = done_pvname
         super().__init__(prefix, name=name, **kwargs)
 
@@ -70,93 +90,156 @@ class UndPoint2D(PVPositioner):
         super()._setup_move(position)
 
 
-class UndPoint1DX(UndPoint2D):
-    """Undulator pointing variant: move in x only."""
-    def _setup_move(self, position: float):
-        super()._setup_move((position, 0))
-
-
-class UndPoint1DY(UndPoint2D):
-    """Undulator pointing variant: move in y only."""
-    def _setup_move(self, position: float):
-        super()._setup_move((0, position))
-
-
-class UndulatorPointingRequest(Device):
+class UndPointAbs2D(MvInterface, Device, PositionerBase):
     """
-    Device for interfacing with the undulator repointing PVs.
-
-    You'd use this like:
-
-    undp = UndulatorPointingRequest("MFX:USER:MCC:UND", done_pvname="SIOC:SYS0:ML07:AO216", name="undp")
-    undp.dxy.move((50, 30), wait=True)
-    undp.dy.move(-100, wait=False)
+    Undulator pointing variant: absolute move by (x, y)
     """
-    dxy = FCpt(UndPoint2D, "{prefix}", done_pvname="{done_pvname}", add_prefix=("suffix", "done_pvname"))
-    dx = FCpt(UndPoint1DX, "{prefix}", done_pvname="{done_pvname}", add_prefix=("suffix", "done_pvname"))
-    dy = FCpt(UndPoint1DY, "{prefix}", done_pvname="{done_pvname}", add_prefix=("suffix", "done_pvname"))
 
-    def __init__(self, prefix: str, done_pvname: str, *, name: str, **kwargs):
+    xpos = Cpt(
+        UnitConversionDerivedSignal,
+        "x_raw_rbv",
+        derived_units="um",
+        original_units="mm",
+        kind="hinted",
+    )
+    ypos = Cpt(
+        UnitConversionDerivedSignal,
+        "y_raw_rbv",
+        derived_units="um",
+        original_units="mm",
+        kind="hinted",
+    )
+
+    x_raw_rbv = FCpt(EpicsSignalRO, "{x_abs_pvname}", kind="omitted")
+    y_raw_rbv = FCpt(EpicsSignalRO, "{y_abs_pvname}", kind="omitted")
+    delta_xy = FCpt(
+        UndPointDelta2D,
+        "{prefix}",
+        done_pvname="{done_pvname}",
+        add_prefix=("suffix", "done_pvname"),
+    )
+
+    def __init__(
+        self,
+        prefix: str,
+        *,
+        name: str,
+        done_pvname: str = DEFAULT_DONE_MOVE_PV,
+        x_abs_pvname: str = "BPMS:UNDH:4690:XOFF.D",
+        y_abs_pvname: str = "BPMS:UNDH:4690:YOFF.D",
+        **kwargs,
+    ):
         self.done_pvname = done_pvname
+        self.x_abs_pvname = x_abs_pvname
+        self.y_abs_pvname = y_abs_pvname
+        self._xpos_cache = None
+        self._ypos_cache = None
         super().__init__(prefix, name=name, **kwargs)
 
+    @validate_call
+    def move(
+        self,
+        position: tuple[float, float],
+        wait: bool = True,
+        moved_cb: Optional[Callable] = None,
+        timeout: Optional[float] = None,
+    ):
+        # Convert to the raw delta move
+        delta_move = (position[0] - self.position[0], position[1] - self.position[1])
+        return self.delta_xy.move(
+            delta_move, wait=wait, moved_cb=moved_cb, timeout=timeout
+        )
 
-class UndulatorPointingMFX(UndulatorPointingRequest):
+    @xpos.sub_value
+    def _new_xpos(self, value: float, **kwargs):
+        self._xpos_cache = value
+        self._update_pos(**kwargs)
+
+    @ypos.sub_value
+    def _new_ypos(self, value: float, **kwargs):
+        self._ypos_cache = value
+        self._update_pos(**kwargs)
+
+    def _update_pos(self, **kwargs):
+        if None not in self.position:
+            kwargs.pop("sub_type")
+            self._run_subs(
+                sub_type=self.SUB_READBACK,
+                timestamp=kwargs.pop("timestamp"),
+                value=self.position,
+                **kwargs,
+            )
+
+    @property
+    def position(self) -> tuple[float, float]:
+        return (self._xpos_cache, self._ypos_cache)
+
+
+class UndPointAbs2DMFX(UndPointAbs2D):
     """
     Undulator pointing with MFX PV defaults.
-    
+
     You can do:
-    undp = UndulatorPointingMFX()
+    undp = UndPointAbs2DMFX()
     """
+
     def __init__(
         self,
         prefix: str = "MFX:USER:MCC:UND",
-        done_pvname: str = "SIOC:SYS0:ML07:AO216",
         *,
         name: str = "mfx_undp",
         **kwargs,
     ):
-        super().__init__(prefix, name=name, done_pvname=done_pvname, **kwargs)
+        super().__init__(prefix, name=name, **kwargs)
 
 
-class UndulatorPointingMFXTest(UndulatorPointingRequest):
+class UndPointDelta2DSim(UndPointDelta2D):
     """
-    Use the test busy PV instead of the ACR busy PV.
-
-    You'll need to manually flip the busy PV from 1 to 0 to signal
-    that the move is done.
+    Test version of the raw delta und pointing logic using no PVs.
     """
-    def __init__(
-        self,
-        prefix: str = "MFX:USER:MCC:UND",
-        done_pvname: str = "MFX:USER:MCC:UND:TEST_BUSY",
-        *,
-        name: str = "test_mfx_undp",
-        **kwargs,
-    ):
-        super().__init__(prefix, name=name, done_pvname=done_pvname, **kwargs)
+
+    delta_x = Cpt(Signal)
+    delta_y = Cpt(Signal)
+    actuate = Cpt(Signal)
+    done = FCpt(Signal)
+
+    # Extra signals: keep track of how much we've moved
+    _raw_x = Cpt(Signal)
+    _raw_y = Cpt(Signal)
+
+    @actuate.sub_value
+    def _sim_new_move(self, value: int, **_):
+        """
+        Simulate what ACR does when we ask for a move
+        """
+        if value != self.actuate_value:
+            return
+        self.done.put(1 - self.done_value)
+        self._raw_x.put(self._raw_x.get() + (self.delta_x.get() / 1000))
+        self._raw_y.put(self._raw_y.get() + (self.delta_y.get() / 1000))
+        self.actuate.put(1 - self.actuate_value)
+        self.done.put(self.done_value)
 
 
-def get_pixel_diff(imager: YagCamera, marker: int = 1) -> tuple[int, int]:
+class UndPointAbs2DSim(UndPointAbs2D):
     """
-    Return the difference in pixels between the yag's centroid and the chosen marker.
-
-    Parameters
-    ----------
-    imager : YagCamera
-        The imager object to use.
-    marker : int
-        The index of the marker to compare against.
-
-    Returns
-    -------
-    pixel_diff : tuple[int, int]
-        The difference in pixels between the centroid and the marker.
+    Test version of the abs und pointing logic using no PVs.
     """
-    fit = ImageProjectionFit()
-    fit_result = fit.fit_image(imager.image1.image)
-    marker_pos = imager.coords.specific_marker_target(marker)
-    return (
-        marker_pos[0] - fit_result.centroid[0],
-        marker_pos[1] - fit_result.centroid[1], 
-    )
+
+    x_raw_rbv = Cpt(Signal)
+    y_raw_rbv = Cpt(Signal)
+    delta_xy = Cpt(UndPointDelta2DSim, "")
+
+    def __init__(self, prefix="", *, name="sim_2d_abs", **kwargs):
+        super().__init__(prefix, name=name, **kwargs)
+        self.delta_xy._raw_x.subscribe(self._new_raw_x)
+        self.delta_xy._raw_y.subscribe(self._new_raw_y)
+        # Using the real positions at the moment in time I made this class
+        self.delta_xy._raw_x.put(0.123402)
+        self.delta_xy._raw_y.put(-0.393441)
+
+    def _new_raw_x(self, value: float, **_):
+        self.x_raw_rbv.put(value)
+
+    def _new_raw_y(self, value: float, **_):
+        self.y_raw_rbv.put(value)

--- a/mfx/optimize/user_select.py
+++ b/mfx/optimize/user_select.py
@@ -9,7 +9,12 @@ from pcdsdevices.ipm import Wave8
 
 from .beamline_hw import init_devices
 from .devices import YagCamera
-from .type_checking import Devices, Diagnostics, validate_w_lowercase_args
+from .type_checking import Devices, Diagnostics, Movers, validate_w_lowercase_args
+
+
+MP_KEY = "mirror_pitch"
+UNDP_KEY_X = "undp_x"
+UNDP_KEY_Y = "undp_y"
 
 
 @validate_w_lowercase_args
@@ -108,6 +113,10 @@ def select_goal(
     if use_2d_markers:
         if device_type == "yag":
             yag_camera = select_diagnostic(device_type=device_type, location=location)
+            if location == "xcs1":
+                # Shared YAG: uses marker2 at the goal
+                return yag_camera.coords.specific_marker_target(2)
+            # MFX YAG: uses marker1, marker2 at opposite slit corners
             return yag_camera.coords.standard_two_corners_target()
         else:
             raise ValueError(
@@ -116,3 +125,75 @@ def select_goal(
             )
     
     raise RuntimeError("Invalid codepath in select_goal, how did you get here?")
+
+
+@validate_w_lowercase_args
+def select_var_range(
+    mover: Movers,
+    search_range: Optional[Union[list[tuple[float, float]], tuple[float, float]]] = None,
+    search_delta: Optional[Union[float, tuple[float, float]]] = None,
+    search_center: Optional[Union[float, tuple[float, float]]] = None,
+) -> dict[str, tuple[float, float]]:
+    """
+    Select valid move ranges for the mover.
+
+    Parameters
+    ----------
+    mover : str
+        One of "mirr" or "und", the kind of movement we'll be doing.
+    search_range : tuple of floats or list of tuple of floats, optional
+        Explicit search ranges per dimension, in units of your motion device.
+        Either search_range or search_delta must be provided.
+    search_delta : float, optional
+        The +- around the center to search for, in units of your motion device.
+        Either search_range or search_delta must be provided.
+    search_center : float or tuple of floats, optional
+        If using search_delta, this is the reference point for
+        the delta range, in units of your motion device.
+        If not provided this will be the mover's current position.
+
+    Returns
+    -------
+    var_range : dict of str to tuple
+        Min, max tuples per dimension of the mover.
+        The keys are the ones we use for the optimizer to reference the data.
+    """
+    if search_range is None and search_delta is None:
+        raise ValueError("Must provide either search_range or search_delta!")
+    if search_range is not None and search_delta is not None:
+        raise ValueError("Must provide only one of search_range and search_delta!")
+
+    if mover == "mirr":
+        # 1D mirror
+        if search_range is not None:
+            if isinstance(search_range, tuple):
+                return {MP_KEY: search_range}
+            return {MP_KEY: search_range[0]}
+        elif search_delta is not None:
+            if search_center is None:
+                devices = init_devices()
+                search_center = devices["mr1l4_homs"].position
+            return {MP_KEY: (search_center - search_delta, search_center + search_delta)}
+    elif mover == "und":
+        # 2D undulator
+        if search_range is not None:
+            if isinstance(search_range, tuple):
+                search_range = [search_range, search_range]
+            return {
+                UNDP_KEY_X: search_range[0],
+                UNDP_KEY_Y: search_range[1],
+            }
+        elif search_delta is not None:
+            if isinstance(search_delta, (float, int)):
+                search_delta = (search_delta, search_delta)
+            if search_center is None:
+                devices = init_devices()
+                search_center = devices["undp"].position
+            elif isinstance(search_center, (float, int)):
+                search_center = (search_center, search_center)
+            return {
+                UNDP_KEY_X: (search_center[0] - search_delta[0], search_center[0] + search_delta[0]),
+                UNDP_KEY_Y: (search_center[1] - search_delta[1], search_center[1] + search_delta[1]),
+            }
+    else:
+        raise NotImplementedError(f"Mover type {mover} not implemented in select_range.")

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -4,9 +4,8 @@ To test with sim, ipython -i mfx/optimize/xopt_scans.py for an interactive test
 Or python -m mfx.optimize.xopt_scans for a default sim run-through
 """
 from __future__ import annotations
-from typing import Optional
 
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -24,7 +23,6 @@ from .beamline_hw import (
     DG2_WAVE8_XPOS,
     DG2_YAG_XPOS,
     IP_YAG_XPOS,
-    MIRROR_NOMINAL,
     init_devices,
     sim_devices,
     YAG_CENTROID_X_MIN_MAX,
@@ -34,13 +32,16 @@ from .beamline_hw import (
 )
 from .errors import FeasibilityError
 from .plots import UpdatingDeviceCentroidPathPlot
-from .type_checking import validate_w_lowercase_args, Devices, Diagnostics, Turbo
-from .user_select import select_diagnostic, select_goal
+from .type_checking import validate_w_lowercase_args, Devices, Diagnostics, Turbo, Movers
+from .user_select import select_diagnostic, select_goal, select_var_range, MP_KEY, UNDP_KEY_X, UNDP_KEY_Y
 
 
+@validate_w_lowercase_args
 def get_vocs(
-    mirror_nominal: float = MIRROR_NOMINAL,
-    search_delta: float = 5,
+    mover: Movers,
+    search_range: Optional[Union[list[tuple[float, float]], tuple[float, float]]] = None,
+    search_delta: Optional[Union[float, tuple[float, float]]] = None,
+    search_center: Optional[Union[float, tuple[float, float]]] = None,
     wave8_max_value: Optional[float] = None,
     yag_size_min: Optional[float] = None,
     yag_size_max: Optional[float] = None,
@@ -52,7 +53,6 @@ def get_vocs(
     centroid_y_max: float = None,
 ) -> VOCS:
     constrants = {}
-
     if wave8_max_value is not None:
         constrants["abs_centroid_x"] = ["LESS_THAN", wave8_max_value]
     if yag_size_min is not None:
@@ -74,9 +74,12 @@ def get_vocs(
     if centroid_y_max is not None:
         constrants["centroid_y"] = ["LESS_THAN", centroid_y_max]
     return VOCS(
-        variables={
-            "mirror_pitch": [mirror_nominal - search_delta, mirror_nominal + search_delta]
-        },
+        variables=select_var_range(
+            mover=mover,
+            search_center=search_center,
+            search_delta=search_delta,
+            search_range=search_range,
+        ),
         objectives={
             "objective": "MINIMIZE",
         },
@@ -84,9 +87,31 @@ def get_vocs(
     )
 
 
+@validate_w_lowercase_args
+def evaluator_move(mover: Movers, input: dict):
+    """
+    Re-usable XOpt move primitive.
+
+    Takes XOpt's input and moves the applicable device.
+    """
+    if mover == "mirr":
+        print(f"Trying {input[MP_KEY]}")
+    elif mover == "und":
+        print(f"Trying ({input[UNDP_KEY_X]}, {input[UNDP_KEY_Y]})")
+    else:
+        raise NotImplementedError(f"Mover type {mover} not implemented in evaluator_move.")
+    devices = init_devices()
+    if mover == "mirr":
+        devices["mr1l4_homs"].pitch.set(input["mirror_pitch"]).wait(timeout=20)
+    elif mover == "und":
+        devices["undp"].move((input[UNDP_KEY_X], input[UNDP_KEY_Y]), wait=True, timeout=20)
+
+
+@validate_w_lowercase_args
 def get_evaluator_wave8(
     wave8: str = "dg1",
     wave8_xpos: Optional[float] = None,
+    mover: Movers = "mirr",
 ) -> Evaluator:
     if wave8_xpos is None:
         if wave8 == "dg1":
@@ -97,9 +122,7 @@ def get_evaluator_wave8(
             raise ValueError(f"Invalid wave8 {wave8}, expected dg1 or dg2")
 
     def evaluate(input: dict[str, float]) -> dict[str, float]:
-        print(f"Trying {input['mirror_pitch']}")
-        devices = init_devices()
-        devices["mr1l4_homs"].pitch.set(input["mirror_pitch"]).wait(timeout=20)
+        evaluator_move(mover=mover, input=input)
         xpos_device = select_diagnostic("wave8", wave8).xpos
         xpos_device.trigger().wait(timeout=10)
         xpos = xpos_device.get()
@@ -113,9 +136,11 @@ def get_evaluator_wave8(
     return Evaluator(function=evaluate)
 
 
+@validate_w_lowercase_args
 def get_evaluator_yag(
     yag: str = "dg1",
     goal: Optional[float] = None,
+    mover: Movers = "mirr",
 ) -> Evaluator:
     yag = yag.lower()
     if yag not in ("xcs1", "dg1", "dg2", "ip"):
@@ -132,9 +157,7 @@ def get_evaluator_yag(
     fit = ImageProjectionFit()
 
     def evaluate(input: dict[str, float]) -> dict[str, float]:
-        print(f"Trying {input['mirror_pitch']}")
-        devices = init_devices()
-        devices["mr1l4_homs"].pitch.set(input["mirror_pitch"]).wait(timeout=20)
+        evaluator_move(mover=mover, input=input)
         image_device = select_diagnostic("yag", yag).image1.shaped_image
         image_device.trigger().wait(timeout=10)
         image = image_device.get()
@@ -158,20 +181,18 @@ def get_evaluator_yag(
 def get_evaluator_yag_2d(
     yag: Diagnostics,
     goal: tuple[float, float],
+    mover: Movers,
 ) -> Evaluator:
     """
     Alternate evaluator in 2d space.
     """
-    devices = init_devices()
     imager = select_diagnostic("yag", yag)
     image_device = imager.image1.shaped_image
-    mirror = devices["mr1l4_homs"]
 
     fit = ImageProjectionFit()
 
     def evaluate(input: dict[str, float]) -> dict[str, float]:
-        print(f"Trying {input['mirror_pitch']}")
-        mirror.pitch.set(input["mirror_pitch"]).wait(timeout=20)
+        evaluator_move(mover=mover, input=input)
         image_device.trigger().wait(timeout=10)
         image = image_device.get()
         print(f"image shape: {image.shape}")
@@ -194,8 +215,10 @@ def get_evaluator_yag_2d(
 def get_xopt_obj(
     device_type: Devices,
     location: Diagnostics,
-    mirror_nominal: float = MIRROR_NOMINAL,
-    search_delta: float = 2,
+    mover: Movers,
+    search_range: Optional[Union[list[tuple[float, float]], tuple[float, float]]] = None,
+    search_delta: Optional[Union[float, tuple[float, float]]] = None,
+    search_center: Optional[Union[float, tuple[float, float]]] = None,
     goal: Optional[float] = None,
     wave8_max_value: Optional[float] = None,
     yag_size_min: Optional[float]  = None,
@@ -228,10 +251,18 @@ def get_xopt_obj(
         One of "yag" or "wave8"
     location : Diagnostics
         One of "xcs1", "dg1", "dg2", "ip"
-    mirror_nominal : float
-        The starting mirror pitch position and midpoint of the optimization search.
-    search_delta : float
-        How far +/- we check away from the mirror nominal pitch position
+    mover : str
+        One of "mirr" or "und", the kind of movement we'll be doing.
+    search_range : tuple of floats or list of tuple of floats, optional
+        Explicit search ranges per dimension, in units of your motion device.
+        Either search_range or search_delta must be provided.
+    search_delta : float, optional
+        The +- around the center to search for, in units of your motion device.
+        Either search_range or search_delta must be provided.
+    search_center : float or tuple of floats, optional
+        If using search_delta, this is the reference point for
+        the delta range, in units of your motion device.
+        If not provided this will be the mover's current position.
     goal : float, optional
         Either the wave8 xpos to aim for, or the x coordinate to aim for on a yag.
     wave8_max_value : float, optional
@@ -297,8 +328,10 @@ def get_xopt_obj(
         centroid_y_max = centroid_y_max or WAVE8_CENTROID_Y_MIN_MAX[1]
 
     vocs = get_vocs(
-        mirror_nominal=mirror_nominal,
+        mover=mover,
+        search_center=search_center,
         search_delta=search_delta,
+        search_range=search_range,
         wave8_max_value=wave8_max_value,
         yag_size_min=yag_size_min,
         yag_size_max=yag_size_max,
@@ -315,16 +348,19 @@ def get_xopt_obj(
             evaluator = get_evaluator_yag_2d(
                 yag=location,
                 goal=goal_value,
+                mover=mover,
             )
         else:
             evaluator = get_evaluator_yag(
                 yag=location,
                 goal=goal_value,
+                mover=mover,
             )
     else:
         evaluator = get_evaluator_wave8(
             wave8=location,
             wave8_xpos=goal_value,
+            mover=mover,
         )
     generator = ExpectedImprovementGenerator(vocs=vocs, turbo_controller=xopt_generator_turbo_controller)
     generator.gp_constructor.use_low_noise_prior = False


### PR DESCRIPTION
Enable undulator alignment on the yags.

- [x] Create an absolute move version of the undulator pointing
- [x] Create simulated devices for testing undulator pointing logic
- [x] Add undulator pointing as an option in xopt alignment (careful: use a narrow search range around the start position)
- [x] Offline testing to validate internal logic

This required substantial API changes to make sense of the differing options.

I'm testing this using this command (with simulated hardware):
```
xopt = beam.align(use_2d_markers=True, mover="und", on_diagnostic="xcs1")
```
It results in plots like this:
![image](https://github.com/user-attachments/assets/de9940c9-2bcb-4edf-9b9a-b4d4707a9d5d)

The old commands still work too:
```
xopt = beam.align(use_2d_markers=True, mover="mirr", on_diagnostic="dg1")
```
You can even run these in the same sim session back to back and it gives reasonable results (the sim is coded for both the fake und and the fake mirror to move the apparent yag position.
![image](https://github.com/user-attachments/assets/88e14134-b839-44a2-a1bd-f22c27fe407d)

Now that I've made some progress, I'm reading back the diff and noting my notable changes in diff order:
- Add `und_search_delta` setting in `Beam` class, which is how far from the starting pointing the undulator pointing will try to move. This seemed like the correct way to do undulator scans, as boxes around the start position instead of requiring you to input an absolute undulator x,y position range.
- Add a `mover` argument to `Beam.align`, which can either be `"mirr"` for the offset mirror or `"und"` for the undulator pointing.
- Add a code branch for using undulator alignment in `Beam.align`
- Set up real devices and sim devices for undulator pointing in `beamline_hw`
- Lots of small tweaks to the sim settings to make it more like (but not quite the same as) how the real beamline is.
- Move sim `xcs_yag1`'s markers to be more similar to how they work in real life (different from the mfx yag markers)
- Much ado about plotting: I tried really hard to get in-place refresh to work consistently with the xopt model plots but it always had bad side effects. I decided to stop dumping time here and instead I made the old plots disappear as we create new ones, so at least we don't get 11 windows to close per scan.
- Add a `Movers` type to pick between the mirror and the undulators
- Completely rework the `undpoint` submodule for undulator motors that move in absolute space (and simulated versions for testing)
- Add a user selector for vocs ranges to reconcile our differences in range setting
- Update `get_vocs` in `xopt_scans` to be able to expect the undulator
- Break out `evaluator_move` in `xopt_scans` to update for undulator pointing and make re-usable
- Update `get_xopt_obj` to handle different movers