### PR TITLE
ENH/FIX: updates and fixes for undulator pointing

### DIFF
--- a/mfx/beamline.py
+++ b/mfx/beamline.py
@@ -126,7 +126,8 @@ with safe_load('Compact_Spectrometer'):
 
 with safe_load('Undulator_Pointing'):
     from mfx.optimize.undpoint import UndulatorPointingMFX
-    undp=UndulatorPointingMFX()
+    und_abs=UndulatorPointingMFX()
+    und_del=und_abs.dxy
 
 with safe_load('RE_Scans'):
     from mfx.scan import *

--- a/mfx/optimize/beamline_hw.py
+++ b/mfx/optimize/beamline_hw.py
@@ -128,7 +128,7 @@ def sim_devices() -> dict[str, Device]:
         cam.sim_set_image(
             size=(512, 512),
             centroid=(
-                xpos + mdpitch * 60 - undp_dx * 3 + dg1_yag_offset + random.uniform(-6, 6),
+                xpos + mdpitch * 60 + undp_dx * 3 + dg1_yag_offset + random.uniform(-6, 6),
                 ypos + undp_dy * 3 + random.uniform(-3, 3)
             ),
             fwhm=100,
@@ -141,7 +141,7 @@ def sim_devices() -> dict[str, Device]:
         cam.sim_set_image(
             size=(512, 512),
             centroid=(
-                xpos + mdpitch * 80 - undp_dx * 4 + dg2_yag_offset + random.uniform(-8, 8),
+                xpos + mdpitch * 80 + undp_dx * 4 + dg2_yag_offset + random.uniform(-8, 8),
                 ypos + undp_dy * 4 + random.uniform(-5, 5)
             ),
             fwhm=150,
@@ -154,7 +154,7 @@ def sim_devices() -> dict[str, Device]:
         cam.sim_set_image(
             size=(728, 544),
             centroid=(
-                xpos + mdpitch * 40 - undp_dx * 2 + xcs_yag_offset + random.uniform(-4, 4),
+                xpos + mdpitch * 40 + undp_dx * 2 + xcs_yag_offset + random.uniform(-4, 4),
                 ypos + undp_dy * 2 + random.uniform(-7, 7)
             ),
             fwhm=200,
@@ -166,7 +166,7 @@ def sim_devices() -> dict[str, Device]:
         cam.sim_set_image(
             size=(688, 538),
             centroid=(
-                mdpitch * 70 - undp_dx * 3.5 + IP_YAG_XPOS + ip_yag_offset + random.uniform(-7, 7),
+                mdpitch * 70 + undp_dx * 3.5 + IP_YAG_XPOS + ip_yag_offset + random.uniform(-7, 7),
                 269 + undp_dy * 3.5 + random.uniform(-7, 7)
             ),
             fwhm=80,

--- a/mfx/optimize/beamline_hw.py
+++ b/mfx/optimize/beamline_hw.py
@@ -82,21 +82,23 @@ def sim_devices() -> dict[str, Device]:
     devices["mr1l4_homs"] = SimpleNamespace(pitch=SynAxis(name="mr1l4_homs_pitch", value=MIRROR_NOMINAL))
     devices["mfx_dg1_ipm"] = SimpleNamespace(inserted=True)
     devices["mfx_dg2_ipm"] = SimpleNamespace(inserted=False)
-    devices["undp"] = UndPointAbs2DSim()
+    und_abs = UndPointAbs2DSim()
+    devices["und_abs"] = und_abs
+    devices["und_del"] = und_abs.delta_xy
     dg1_wave8_offset = random.uniform(-1, 1)
     dg2_wave8_offset = random.uniform(-1, 1)
     xcs_yag_offset = random.uniform(-5, 5)
     dg1_yag_offset = random.uniform(-10, 10)
     dg2_yag_offset = random.uniform(-20, 20)
     ip_yag_offset = random.uniform(-30, 30)
-    undp_x0 = devices["undp"].position[0]
-    undp_y0 = devices["undp"].position[1]
+    undp_x0 = devices["und_abs"].position[0]
+    undp_y0 = devices["und_abs"].position[1]
 
     def get_offsets() -> tuple[float, float, float]:
         return (
             devices["mr1l4_homs"].pitch.position - MIRROR_NOMINAL,
-            devices["undp"].position[0] - undp_x0,
-            devices["undp"].position[1] - undp_y0
+            devices["und_abs"].position[0] - undp_x0,
+            devices["und_abs"].position[1] - undp_y0
         )
 
     def get_fake_dg1_wave8() -> float:

--- a/mfx/optimize/beamline_hw.py
+++ b/mfx/optimize/beamline_hw.py
@@ -61,7 +61,9 @@ def init_devices(force: bool = False) -> dict[str, Device]:
     devices["mfx_ip_yag"] = YagCamera("MFX:GIGE:LBL:01:", name="mfx_ip1_yag")
     devices["mfx_ip_yag"].kind = "hinted"
 
-    devices["undp"] = UndPointAbs2DMFX()
+    und_abs = UndPointAbs2DMFX()
+    devices["und_abs"] = und_abs
+    devices["und_del"] = und_abs.delta_xy
 
     return devices
 

--- a/mfx/optimize/undpoint.py
+++ b/mfx/optimize/undpoint.py
@@ -27,7 +27,7 @@ The alignment is something like:
 - recalibrate? (maybe?)
 """
 
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
@@ -35,6 +35,7 @@ from ophyd.device import FormattedComponent as FCpt
 from ophyd.positioner import PositionerBase
 from ophyd.pv_positioner import PVPositioner
 from ophyd.signal import EpicsSignal, EpicsSignalRO, Signal
+from ophyd.status import MoveStatus
 from pcdsdevices.interface import MvInterface
 from pcdsdevices.signal import MultiDerivedSignal, UnitConversionDerivedSignal
 from pcdsdevices.type_hints import SignalToValue
@@ -53,6 +54,20 @@ def _put_2d_delta(mds: MultiDerivedSignal, value: tuple[float, float]) -> Signal
     # Setting 50 to the delta PV causes the real value to move by -50
     # So, when you ask for 50 we'll put -50 to the delta PV instead, to move the real value by 50
     return {mds.signals[0]: -value[0], mds.signals[1]: -value[1]}
+
+
+@validate_call
+def coerce_input_to_tuple(position: Union[tuple[float, float], float], ypos: Optional[float]) -> tuple[float, float]:
+    """
+    Utility to coerce user input like move(3, 4) to move((3, 4))
+    """
+    if isinstance(position, tuple):
+        if len(position) == 2:
+            return position
+        raise ValueError(f"Expected tuple of length 2, got {position}")
+    elif ypos is None:
+        raise TypeError(f"Expected position to be a tuple, got {position}")
+    return (position, ypos)
 
 
 class UndPointDelta2D(PVPositioner):
@@ -87,6 +102,37 @@ class UndPointDelta2D(PVPositioner):
     ):
         self.done_pvname = done_pvname
         super().__init__(prefix, name=name, **kwargs)
+
+    @validate_call
+    def move(
+        self,
+        position: Union[tuple[float, float], float],
+        y_delta: Optional[float] = None,
+        wait: bool = True,
+        timeout: Optional[float] = None,
+        moved_cb: Optional[Callable] = None,
+    ) -> MoveStatus:
+        """
+        Do a relative move of the undulator.
+
+        Parameters
+        ----------
+        position : tuple[float, float] or float
+            If a tuple, this is the x, y delta to move by.
+            If a float, this is the x delta to move by, and y_delta should be given as the second argument.
+        y_delta : float, optional
+            If position is given as as float x value, this is the accompanying y value.
+        wait : bool, optional
+            Whether to wait for the move to complete, or not. Defaults to True.
+        timeout : float, optional
+            Maximum time to wait for the motion. If None, the default timeout
+            for this positioner is used.
+        moved_cb : callable
+            Call this callback when movement has finished. This callback must
+            accept one keyword argument: 'obj' which will be set to this
+            positioner instance.
+        """
+        return super().move(coerce_input_to_tuple(position, y_delta), wait=wait, timeout=timeout, moved_cb=moved_cb)
 
     def _setup_move(self, position: tuple[float, float]):
         # Also reset the actuate PV before we actuate
@@ -147,16 +193,37 @@ class UndPointAbs2D(MvInterface, Device, PositionerBase):
     @validate_call
     def move(
         self,
-        position: tuple[float, float],
+        position: Union[tuple[float, float], float],
+        y_abs: Optional[float] = None,
         wait: bool = True,
-        moved_cb: Optional[Callable] = None,
         timeout: Optional[float] = None,
+        moved_cb: Optional[Callable] = None,
     ):
+        """
+        Do an absolute move of the undulator.
+
+        Parameters
+        ----------
+        position : tuple[float, float] or float
+            If a tuple, this is the x, y position to move to.
+            If a float, this is the x position to move to, and y_abs should be given as the second argument.
+        y_abs : float, optional
+            If position is given as as float x value, this is the accompanying y value.
+        wait : bool, optional
+            Whether to wait for the move to complete, or not. Defaults to True.
+        timeout : float, optional
+            Maximum time to wait for the motion. If None, the default timeout
+            for this positioner is used.
+        moved_cb : callable
+            Call this callback when movement has finished. This callback must
+            accept one keyword argument: 'obj' which will be set to this
+            positioner instance.
+        """
         return self.delta_xy.move(
-            self.get_delta_from_abs(position),
+            self.get_delta_from_abs(coerce_input_to_tuple(position, y_abs)),
             wait=wait,
-            moved_cb=moved_cb,
             timeout=timeout,
+            moved_cb=moved_cb,
         )
 
     def get_delta_from_abs(self, position: tuple[float, float]) -> tuple[float, float]:

--- a/mfx/optimize/undpoint.py
+++ b/mfx/optimize/undpoint.py
@@ -137,6 +137,8 @@ class UndPointAbs2D(MvInterface, Device, PositionerBase):
         self._xpos_cache = None
         self._ypos_cache = None
         super().__init__(prefix, name=name, **kwargs)
+        # Alias
+        self.dxy = self.delta_xy
 
     @validate_call
     def move(
@@ -146,11 +148,21 @@ class UndPointAbs2D(MvInterface, Device, PositionerBase):
         moved_cb: Optional[Callable] = None,
         timeout: Optional[float] = None,
     ):
-        # Convert to the raw delta move
-        delta_move = (position[0] - self.position[0], position[1] - self.position[1])
         return self.delta_xy.move(
-            delta_move, wait=wait, moved_cb=moved_cb, timeout=timeout
+            self.get_delta_from_abs(position),
+            wait=wait,
+            moved_cb=moved_cb,
+            timeout=timeout,
         )
+
+    def get_delta_from_abs(self, position: tuple[float, float]) -> tuple[float, float]:
+        """
+        Convert the absolute position request to a delta move.
+
+        This is needed because our raw moves are deltas and we
+        need absolute positions for the optimizer.
+        """
+        return (position[0] - self.position[0], position[1] - self.position[1])
 
     @xpos.sub_value
     def _new_xpos(self, value: float, **kwargs):

--- a/mfx/optimize/undpoint.py
+++ b/mfx/optimize/undpoint.py
@@ -44,11 +44,15 @@ DEFAULT_DONE_MOVE_PV = "SIOC:SYS0:ML07:AO216"
 
 
 def _get_2d_delta(mds: MultiDerivedSignal, items: SignalToValue) -> tuple[float, float]:
-    return tuple(items.values())
+    # See polarity note below
+    return tuple(-val for val in items.values())
 
 
 def _put_2d_delta(mds: MultiDerivedSignal, value: tuple[float, float]) -> SignalToValue:
-    return {mds.signals[0]: value[0], mds.signals[1]: value[1]}
+    # Note on the polarity:
+    # Setting 50 to the delta PV causes the real value to move by -50
+    # So, when you ask for 50 we'll put -50 to the delta PV instead, to move the real value by 50
+    return {mds.signals[0]: -value[0], mds.signals[1]: -value[1]}
 
 
 class UndPointDelta2D(PVPositioner):
@@ -229,8 +233,8 @@ class UndPointDelta2DSim(UndPointDelta2D):
         if value != self.actuate_value:
             return
         self.done.put(1 - self.done_value)
-        self._raw_x.put(self._raw_x.get() + (self.delta_x.get() / 1000))
-        self._raw_y.put(self._raw_y.get() + (self.delta_y.get() / 1000))
+        self._raw_x.put(self._raw_x.get() + (-self.delta_x.get() / 1000))
+        self._raw_y.put(self._raw_y.get() + (-self.delta_y.get() / 1000))
         self.actuate.put(1 - self.actuate_value)
         self.done.put(self.done_value)
 

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -49,7 +49,7 @@ def get_variables(mover: Movers, narrow: bool = False):
             delta = constraint_data.mirr.range_delta
         variables[MP_KEY] = [center - delta, center + delta]
     elif mover == "und":
-        undp = init_devices()["undp"]
+        undp = init_devices()["und_abs"]
         pos = undp.position
         if narrow and constraint_data.und.max_travel_distance is not None:
             delta = constraint_data.und.max_travel_distance
@@ -105,7 +105,7 @@ def evaluator_move(mover: Movers, input: dict):
     if mover == "mirr":
         devices["mr1l4_homs"].pitch.set(input["mirror_pitch"]).wait(timeout=20)
     elif mover == "und":
-        devices["undp"].move((input[UNDP_KEY_X], input[UNDP_KEY_Y]), wait=True, timeout=20)
+        devices["und_abs"].move((input[UNDP_KEY_X], input[UNDP_KEY_Y]), wait=True, timeout=20)
 
 
 @validate_w_lowercase_args


### PR DESCRIPTION
The most important thing here is that I inverted the direction of the delta moves to match reality. A move of +50 in the delta pointing PV resulted in a change of -50 in the absolute position.

The change is under the hood and transparent to the user.

Full changelog:

- Rename `undp` to `und_abs` and split off `und_del` to make it very apparent whether the mover is an absolute mover or a delta mover. Apply this in both the full and mini optimize mfx3 variants.
- Invert the polarity of the delta move PVs and the related sims
- Allow us to move as e.g. `und_abs(0, 0)` in addition to `und_abs((0, 0))`
- Add `und_abs.dxy` as an alias of `und_abs.delta_xy`
- Bring out `get_delta_from_abs` into its own function, so we can call this function to understand what the code intends to do as an audit.