### PR TITLE
ENH: allow higher travel distances for undulator

### DIFF
--- a/mfx/optimize/constraints.py
+++ b/mfx/optimize/constraints.py
@@ -94,7 +94,7 @@ class UndulatorConstraints:
 
 hxr_und_constraints = UndulatorConstraints(
     xy_delta=100,
-    max_travel_distance=5,
+    max_travel_distance=25,
 )
 
 @dataclass


### PR DESCRIPTION
As discussed in the call, 5 -> 25

This is a constraint on how far we're allowed to move from the previous location.

Contributes to #206