### PR TITLE
213 implement geomrun function

### DIFF
--- a/mfx/autorun.py
+++ b/mfx/autorun.py
@@ -396,6 +396,8 @@ def autorun(**kwargs):
     _autorun(**kwargs)
 
 def geomrun(**kwargs):
+    kwargs['tag'] = "geom"
+    kwargs['sample'] = "geometry-calibration"
     kwargs['run_type'] = "GEOM"
     _autorun(**kwargs)
 

--- a/mfx/autorun.py
+++ b/mfx/autorun.py
@@ -187,7 +187,7 @@ def ioc_cam_recorder(cam='camera name', run_length=10, tag='?'):
             shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
 
-def _autorun(sample='?', tag=None, run_length=300, record=True,
+def _autorun(sample='?', tag=None, run_type="DATA", run_length=300, record=True,
             runs=5, inspire=False, daq_delay=5, picker=None, cam=None, close=True, daq_num=2):
     """
     Automate runs.... With optional quotes
@@ -244,11 +244,8 @@ def _autorun(sample='?', tag=None, run_length=300, record=True,
     if picker=='flip':
         pp.flipflop()
 
-    run_type="SAMPLE"
     if tag is None:
         tag = sample
-    else:
-        run_type = tag
 
     if daq_num == 1:
         for i in range(runs):

--- a/mfx/autorun.py
+++ b/mfx/autorun.py
@@ -396,7 +396,7 @@ def autorun(**kwargs):
     _autorun(**kwargs)
 
 def geomrun(**kwargs):
-    kwargs['tag'] = "GEOM"
+    kwargs['run_type'] = "GEOM"
     _autorun(**kwargs)
 
 post_template = """\

--- a/mfx/autorun.py
+++ b/mfx/autorun.py
@@ -187,7 +187,7 @@ def ioc_cam_recorder(cam='camera name', run_length=10, tag='?'):
             shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
 
-def autorun(sample='?', tag=None, run_length=300, record=True,
+def _autorun(sample='?', tag=None, run_length=300, record=True,
             runs=5, inspire=False, daq_delay=5, picker=None, cam=None, close=True, daq_num=2):
     """
     Automate runs.... With optional quotes
@@ -244,8 +244,11 @@ def autorun(sample='?', tag=None, run_length=300, record=True,
     if picker=='flip':
         pp.flipflop()
 
+    run_type="SAMPLE"
     if tag is None:
         tag = sample
+    else:
+        run_type = tag
 
     if daq_num == 1:
         for i in range(runs):
@@ -326,8 +329,7 @@ def autorun(sample='?', tag=None, run_length=300, record=True,
                     daq.control.setRecord(True)
                 else:
                     daq.control.setRecord(False)
-
-                daq.control.setState("running")
+                daq.control.setState("running", {"run_type": run_type})
                 while daq.control.getState() != "running":
                     ...
                 start_time = time()
@@ -393,6 +395,12 @@ def autorun(sample='?', tag=None, run_length=300, record=True,
     else:
         logger.error('Please enter daq 1 or 2.')
 
+def autorun(**kwargs):
+    _autorun(**kwargs)
+
+def geomrun(**kwargs):
+    kwargs['tag'] = "GEOM"
+    _autorun(**kwargs)
 
 post_template = """\
 Run Number {}: {}

--- a/mfx/beamline.py
+++ b/mfx/beamline.py
@@ -149,8 +149,12 @@ with safe_load('Find_PV'):
     from mfx.find import *
     find = Find()
 
-with safe_load('Find_PV'):
+with safe_load('Get_Info'):
     from scripts.get_info import *
+
+with safe_load('Wire_Scan'):
+    from mfx.wire import *
+    wire = Wire()
 
 # with safe_load("laser wp power"):
 #     # Hack the LXE class to make it work with Newports

--- a/mfx/mfx_timing.py
+++ b/mfx/mfx_timing.py
@@ -83,6 +83,13 @@ class MFX_Timing:
         return steps
 
 
+    def _seq_60hz_yano(self):
+        steps = [['ray1', 1],
+                 ['ray2', 1],
+                 ['daq_readout', 0]]
+        return steps
+
+
     def _seq_30hz(self):
         steps = [['ray_readout', 1],
                  ['pp_trig', 0],
@@ -205,6 +212,15 @@ class MFX_Timing:
             elif rep == 10:
                 self._seq_init(sync_mark=120)
                 self._seq_put(self._seq_10hz())
+            elif rep == '120_truncated':
+                self._seq_init(sync_mark=120)
+                self._seq_put(self._seq_120hz_trucated())
+            elif rep == '60_truncated':
+                self._seq_init(sync_mark=60)
+                self._seq_put(self._seq_60hz_trucated())
+            elif rep == '60_yano':
+                self._seq_init(sync_mark=60)
+                self._seq_put(self._seq_60hz_yano())
 
         self.seq.start()
         return self.sequence

--- a/mfx/mfx_timing.py
+++ b/mfx/mfx_timing.py
@@ -8,14 +8,19 @@ class MFX_Timing:
             'wait':0,
             'pp_trig':197,
             'daq_readout':198,
+            'sample1':201,
+            'sample2':202,
             'laser_on':203,
-            'laser_off1':204,
-            'laser_off2':205,
-            'ray_readout':210,
+            'laser_off':204,
+            'sample5':205,
+            'sample6':206,
+            'sample7':207,
+            'sample8':208,
+            'sample9':209,
+            'ray0':210,
             'ray1':211,
             'ray2':212,
             'ray3':213,
-            'blank':209
         }
         self.sync_markers = {0.5:0, 1:1, 5:2, 10:3, 30:4, 60:5, 120:6, 360:7}
         self.sequence = []
@@ -46,7 +51,7 @@ class MFX_Timing:
 
 
     def _seq_120hz(self):
-        steps = [['ray_readout', 1],
+        steps = [['ray0', 1],
                  ['daq_readout',0],
                  ['ray1',1],
                  ['daq_readout',0],
@@ -58,7 +63,7 @@ class MFX_Timing:
 
 
     def _seq_120hz_trucated(self):
-        steps = [['ray_readout', 1],
+        steps = [['ray0', 1],
                  ['daq_readout',0]]
         return steps
 
@@ -69,8 +74,20 @@ class MFX_Timing:
         return steps
 
 
+    def _seq_90hz_yano(self):
+        steps = [['ray1', 1],
+                 ['pp_trig',0],
+                 ['sample1',1],
+                 ['daq_readout',0],
+                 ['ray1',1],
+                 ['daq_readout',0],
+                 ['wait',1],
+                 ['daq_readout', 0]]
+        return steps
+
+
     def _seq_60hz(self):
-        steps = [['ray_readout', 1],
+        steps = [['ray0', 1],
                  ['pp_trig', 0],
                  ['ray1', 1],
                  ['daq_readout', 0],
@@ -82,7 +99,7 @@ class MFX_Timing:
 
 
     def _seq_60hz_trucated(self):
-        steps = [['ray_readout', 1],
+        steps = [['ray0', 1],
                  ['ray1', 0],
                  ['ray2', 1],
                  ['daq_readout', 0]]
@@ -97,7 +114,7 @@ class MFX_Timing:
 
 
     def _seq_30hz(self):
-        steps = [['ray_readout', 1],
+        steps = [['ray0', 1],
                  ['pp_trig', 0],
                  ['ray1', 1],
                  ['ray2', 1],
@@ -107,31 +124,31 @@ class MFX_Timing:
 
 
     def _seq_20hz(self):
-        steps = [['ray_readout', 1],
+        steps = [['ray0', 1],
                  ['pp_trig', 0],
                  ['ray1', 1],
                  ['ray2', 1],
                  ['daq_readout', 0],
-                 ['blank', 1],
-                 ['blank', 1],
+                 ['wait', 1],
+                 ['wait', 1],
                  ['ray3', 1]]
         return steps
 
 
     def _seq_10hz(self):
-        steps = [['ray_readout', 1],
+        steps = [['ray0', 1],
                  ['pp_trig', 0],
                  ['ray1', 1],
                  ['ray2', 1],
                  ['daq_readout', 0],
-                 ['blank', 1],
-                 ['blank', 1],
-                 ['blank', 1],
-                 ['blank', 1],
-                 ['blank', 1],
-                 ['blank', 1],
-                 ['blank', 1],
-                 ['blank', 1],
+                 ['wait', 1],
+                 ['wait', 1],
+                 ['wait', 1],
+                 ['wait', 1],
+                 ['wait', 1],
+                 ['wait', 1],
+                 ['wait', 1],
+                 ['wait', 1],
                  ['ray3', 1]]
         return steps
 
@@ -224,11 +241,14 @@ class MFX_Timing:
             elif rep == '120_yano':
                 self._seq_init(sync_mark=120)
                 self._seq_put(self._seq_120hz_yano())
+            elif rep == '90_yano':
+                self._seq_init(sync_mark=60)
+                self._seq_put(self._seq_90hz_yano())
             elif rep == '60_truncated':
                 self._seq_init(sync_mark=60)
                 self._seq_put(self._seq_60hz_trucated())
             elif rep == '60_yano':
-                self._seq_init(sync_mark=60)
+                self._seq_init(sync_mark=120)
                 self._seq_put(self._seq_60hz_yano())
 
         self.seq.start()

--- a/mfx/mfx_timing.py
+++ b/mfx/mfx_timing.py
@@ -63,6 +63,12 @@ class MFX_Timing:
         return steps
 
 
+    def _seq_120hz_yano(self):
+        steps = [['ray1', 1],
+                 ['daq_readout',0]]
+        return steps
+
+
     def _seq_60hz(self):
         steps = [['ray_readout', 1],
                  ['pp_trig', 0],
@@ -215,6 +221,9 @@ class MFX_Timing:
             elif rep == '120_truncated':
                 self._seq_init(sync_mark=120)
                 self._seq_put(self._seq_120hz_trucated())
+            elif rep == '120_yano':
+                self._seq_init(sync_mark=120)
+                self._seq_put(self._seq_120hz_yano())
             elif rep == '60_truncated':
                 self._seq_init(sync_mark=60)
                 self._seq_put(self._seq_60hz_trucated())

--- a/mfx/notch_scan.py
+++ b/mfx/notch_scan.py
@@ -179,10 +179,9 @@ class NotchScan():
         if answer.lower() == "y":
             facility = input("Enter facility (s3df or nersc) to continue: ")
             user = input("Enter username to continue: ")
-            self.output.series(
+            self.output(
                 user=user, 
                 facility=facility, 
-                run_type='series', 
                 exp=exp, 
                 run=run_number, 
                 energy=energy_scan_start_eV, 
@@ -191,76 +190,71 @@ class NotchScan():
                 daq_num=daq_num)
 
 
-    class output:
-        def __init__(self):
-            pass
+    def output(
+            self,
+            user: str,
+            facility: str = "NERSC",
+            exp: str = None,
+            run: str = None,
+            energy: float = None,
+            step: float = None,
+            num: int = None,
+            daq_num: int = 2):
+        """Perform Vernier scan results analysis.
 
+        Parameters:
+            user (str):
+                Requires username and password for S3DF.
+            facility (str):
+                Default: "S3DF". Options: "S3DF", "NERSC"
+            exp (str): 
+                experiment number. Current experiment by default
+            run (str): 
+                The first run you'd like to process
+            energy (float):
+                specify the starting energy in eV
+            step (float):
+                specify the energy step size in eV
+            num (int):
+                specify the total number of runs
+            daq_num: int, optional
+                Switch between daq 1 and 2. Default 2
 
-        def series(
-                user: str,
-                facility: str = "S3DF",
-                run_type: str = 'series',
-                exp: str = None,
-                run: str = None,
-                energy: float = None,
-                step: float = None,
-                num: int = None,
-                daq_num: int = 2):
-            """Perform Vernier scan results analysis.
+        """
+        import logging
+        import os
+        from mfx.db import daq
+        from mfx.macros import get_exp, get_run
+        import mfx.cctbx
+        logger = logging.getLogger(__name__)
 
-            Parameters:
-                facility (str):
-                    Default: "S3DF". Options: "S3DF, NERSC
-                type (str):
-                    specify whether it is a vernier 'scan' or 'series'
-                exp (str): 
-                    experiment number. Current experiment by default
-                run (str): 
-                    The run you'd like to process
-                energy (float):
-                    specify the starting energy in eV (only for 'series')
-                step (float):
-                    specify the energy step size in eV (only for 'series')
-                num (int):
-                    specify the total number of runs (only for 'series')
-                daq_num: int, optional
-                    Switch between daq 1 and 2. Default 2
+        if daq_num == 2:
+            station=0
+        elif daq_num == 1:
+            station=1
+        else:
+            logging.error('Please enter daq 1 or 2.')
 
-            """
-            import logging
-            import os
-            from mfx.db import daq
-            from mfx.macros import get_exp, get_run
-            import mfx.cctbx
-            logger = logging.getLogger(__name__)
+        logging.info("Plotting XRT-Spec Output")
+        if exp is None:
+            exp = str(get_exp(station=station))
 
-            if daq_num == 2:
-                station=0
-            elif daq_num == 1:
-                station=1
-            else:
-                logging.error('Please enter daq 1 or 2.')
+        if run is None:
+            run = int(get_run(station=station))
 
-            logging.info("Plotting XRT-Spec Output")
-            if exp is None:
-                exp = str(get_exp(station=station))
+        facility = facility.upper()
+        if facility == 'NERSC':
+            logging.warning(f"Have you renewed your token with sshproxy today?")
+            token = input("(y/n)? ")
 
-            if run is None:
-                run = int(get_run(station=station))
+            if token.lower() == "n":
+                cctbx.sshproxy(user)
 
-            facility = facility.upper()
-            if facility == 'NERSC':
-                logging.warning(f"Have you renewed your token with sshproxy today?")
-                token = input("(y/n)? ")
+        proc = [
+            f"ssh -Yt {user}@s3dflogin "
+            f"python /sdf/group/lcls/ds/tools/mfx/scripts/cctbx/energy_calib_output.py "
+            f"-f {facility} -t series -e {exp} -r {run} -z {energy} -s {step} -n {num}"
+            ]
 
-                if token.lower() == "n":
-                    cctbx.sshproxy(user)
-
-            proc = [
-                f"ssh -Yt {user}@s3dflogin "
-                f"python /sdf/group/lcls/ds/tools/mfx/scripts/cctbx/energy_calib_output.py "
-                f"-f {facility} -t {run_type} -e {exp} -r {run} -z {energy} -s {step} -n {num}"
-                ]
-
-            logging.info(proc)
-            os.system(proc[0])
+        logging.info(proc)
+        os.system(proc[0])

--- a/mfx/vernier.py
+++ b/mfx/vernier.py
@@ -434,6 +434,12 @@ class Vernier:
             energy = int(os.popen("caget MFX:USER:MCC:EPHOT:SET1 | awk '{print $2}'").read().strip())
             return energy
 
+        def set2():
+            import os
+            os.system(f'caget MFX:USER:MCC:EPHOT:SET2')
+            energy = int(os.popen("caget MFX:USER:MCC:EPHOT:SET2 | awk '{print $2}'").read().strip())
+            return energy
+
     class put:
         def __init__(self):
             pass
@@ -445,3 +451,7 @@ class Vernier:
         def set1(energy):
             import os
             os.system(f'caput MFX:USER:MCC:EPHOT:SET1 {energy}')
+
+        def set2(energy):
+            import os
+            os.system(f'caput MFX:USER:MCC:EPHOT:SET2 {energy}')

--- a/mfx/vernier.py
+++ b/mfx/vernier.py
@@ -443,7 +443,7 @@ class Vernier:
 
         def ref2():
             import os
-            os.system(f'caget MFX:USER:MCC:EPHOT:REF1')
+            os.system(f'caget MFX:USER:MCC:EPHOT:REF2')
             energy = int(os.popen("caget MFX:USER:MCC:EPHOT:REF2 | awk '{print $2}'").read().strip())
             return energy
 

--- a/mfx/vernier.py
+++ b/mfx/vernier.py
@@ -15,7 +15,7 @@ class Vernier:
             inspire: bool = False,
             record: bool = False,
             daq_num: int = 2,
-            mcc_pv: str = 'MFX:USER:MCC:EPHOT:SET1'):
+            mcc: str = None):
         """Perform Vernier scan.
 
         Parameters:
@@ -49,12 +49,13 @@ class Vernier:
             daq_num: int, optional
                 Switch between daq 1 and 2. Default 2
 
-            mcc_pv (str): 
-                Vernier PV. Optional. Default: 'MFX:USER:MCC:EPHOT:SET1'.
+            mcc (str): 
+                PV type either 'vernier' or 'k'
         
 
         """
         from ophyd import EpicsSignal
+        from pcdsdevices.pv_positioner import OnePVMotor
         import logging
         logger = logging.getLogger(__name__)
         try:
@@ -66,6 +67,14 @@ class Vernier:
             from bluesky import RunEngine
             RE = RunEngine({})
         from nabs.plans import daq_scan
+
+        if mcc.lower() == 'vernier':
+            mcc_pv = 'MFX:USER:MCC:EPHOT:SET1'
+        elif mcc.lower() == 'k':
+            mcc_pv = 'MFX:USER:MCC:EPHOT:SET2'
+        else:
+            logger.error('Please enter spread type of vernier or k only')
+            sys.exit()
 
         if picker=='open':
             pp.open()
@@ -86,10 +95,11 @@ class Vernier:
         logger.info(f"Run Number {run_number} Running {sample}......{quote()['quote']}")
 
         if daq_num == 1:
+            mcc_pv_motor = EpicsSignal(mcc_pv, name='mcc')
             RE(
                 daq_scan(
                     [],
-                    EpicsSignal(mcc_pv, name='mcc'),
+                    mcc_pv_motor,
                     energy_scan_start_eV,
                     energy_scan_end_eV,
                     energy_scan_steps,
@@ -97,15 +107,16 @@ class Vernier:
                     record=record))
 
         elif daq_num == 2:
+            mcc_pv_motor = OnePVMotor(mcc_pv, name="mcc")
             daq.configure(
-                EpicsSignal(mcc_pv, name='mcc'),
+                motors=[mcc_pv_motor],
                 group_mask=0x1,
-                events=events_per_step,
+                events=120,
                 record=record)
 
             RE(bp.scan(
                 [daq],
-                EpicsSignal(mcc_pv, name='mcc'),
+                mcc_pv_motor,
                 energy_scan_start_eV,
                 energy_scan_end_eV,
                 energy_scan_steps))
@@ -422,10 +433,16 @@ class Vernier:
         def __init__(self):
             pass
 
-        def ref():
+        def ref1():
             import os
             os.system(f'caget MFX:USER:MCC:EPHOT:REF1')
             energy = int(os.popen("caget MFX:USER:MCC:EPHOT:REF1 | awk '{print $2}'").read().strip())
+            return energy
+
+        def ref2():
+            import os
+            os.system(f'caget MFX:USER:MCC:EPHOT:REF1')
+            energy = int(os.popen("caget MFX:USER:MCC:EPHOT:REF2 | awk '{print $2}'").read().strip())
             return energy
 
         def set1():
@@ -444,9 +461,13 @@ class Vernier:
         def __init__(self):
             pass
 
-        def ref(energy):
+        def ref1(energy):
             import os
             os.system(f'caput MFX:USER:MCC:EPHOT:REF1 {energy}')
+
+        def ref2(energy):
+            import os
+            os.system(f'caput MFX:USER:MCC:EPHOT:REF2 {energy}')
     
         def set1(energy):
             import os

--- a/mfx/vernier.py
+++ b/mfx/vernier.py
@@ -60,7 +60,8 @@ class Vernier:
         try:
             from mfx.db import RE, pp, daq
             from mfx.autorun import quote, post
-            from mfx.macros import get_exp
+            from mfx.macros import get_exp, get_run
+            import bluesky.plans as bp
         except ImportError:
             from bluesky import RunEngine
             RE = RunEngine({})
@@ -84,15 +85,34 @@ class Vernier:
         run_number = get_run(station=station) + 1
         logger.info(f"Run Number {run_number} Running {sample}......{quote()['quote']}")
 
-        RE(
-            daq_scan(
-                [],
+        if daq_num == 1:
+            RE(
+                daq_scan(
+                    [],
+                    EpicsSignal(mcc_pv, name='mcc'),
+                    energy_scan_start_eV,
+                    energy_scan_end_eV,
+                    energy_scan_steps,
+                    events=events_per_step,
+                    record=record))
+
+        elif daq_num == 2:
+            daq.configure(
+                EpicsSignal(mcc_pv, name='mcc'),
+                group_mask=0x1,
+                events=events_per_step,
+                record=record)
+
+            RE(bp.scan(
+                [daq],
                 EpicsSignal(mcc_pv, name='mcc'),
                 energy_scan_start_eV,
                 energy_scan_end_eV,
-                energy_scan_steps,
-                events=events_per_step,
-                record=record))
+                energy_scan_steps))
+
+        else:
+            logger.error('Please enter daq 1 or 2.')
+
         pp.close()
         daq.disconnect()
         post(

--- a/mfx/vernier.py
+++ b/mfx/vernier.py
@@ -105,13 +105,15 @@ class Vernier:
                     energy_scan_steps,
                     events=events_per_step,
                     record=record))
+            daq.disconnect()
 
         elif daq_num == 2:
             mcc_pv_motor = OnePVMotor(mcc_pv, name="mcc")
+            mcc_pv_motor.setpoint.kind = "hinted"
             daq.configure(
                 motors=[mcc_pv_motor],
                 group_mask=0x1,
-                events=120,
+                events=events_per_step,
                 record=record)
 
             RE(bp.scan(
@@ -125,14 +127,14 @@ class Vernier:
             logger.error('Please enter daq 1 or 2.')
 
         pp.close()
-        daq.disconnect()
         post(
             sample=sample, 
             tag=tag, 
             run_number=run_number, 
             post=record, 
             inspire=inspire,
-            daq_num=daq_num)
+            daq_num=daq_num,
+            add_note=f'Energy range:{energy_scan_start_eV}-{energy_scan_end_eV}eV, steps:{energy_scan_steps}eV @ {events_per_step} events per step')
         logger.warning('Finished with all runs thank you for choosing the MFX beamline!\n')
 
         logging.warning(f"Scan completed. Would you like to analyze the output?")

--- a/mfx/wire.py
+++ b/mfx/wire.py
@@ -1,0 +1,241 @@
+class Wire:
+    def __init__(self):
+        self.x_pv = 'MFX:USR:MMN:41'
+        self.y_pv = 'MFX:USR:MMN:42'
+        pass
+
+
+    def scan(
+            self,
+            start: float,
+            end: float,
+            num_steps: int,
+            num_events: int = 120,
+            sample: str = 'wire',
+            tag: str = 'wire',
+            picker: str = None,
+            inspire: bool = False,
+            record: bool = False,
+            daq_num: int = 2,
+            mcc: str = None):
+        """Perform wire scan.
+
+        Parameters:
+            start (float): 
+                Position to start the scan at.
+
+            end (float): 
+                Position to end the scan at.
+
+            num_steps (int): 
+                Number of steps in scan.
+
+            num_events (int): 
+                Number of events per step. Optional. Default: 120.
+
+            sample: str, optional
+                Sample Name
+
+            tag: str, optional
+                Run group tag
+
+            picker: str, optional
+                If 'open' it opens pp before run starts. If 'flip' it flipflops before run starts
+
+            inspire: bool, optional
+                Set false by default because it makes Sandra sad. Set True to inspire
+
+            record (bool): 
+                whether to record the scan or not. Optional. Default: False.
+
+            daq_num: int, optional
+                Switch between daq 1 and 2. Default 2
+
+            mcc (str): 
+                PV type either 'vernier' or 'k'
+        
+
+        """
+        import sys
+        from ophyd import EpicsSignal
+        from pcdsdevices.pv_positioner import OnePVMotor
+        import logging
+        logger = logging.getLogger(__name__)
+        try:
+            from mfx.db import RE, pp, daq
+            from mfx.autorun import quote, post
+            from mfx.macros import get_exp, get_run
+            import bluesky.plans as bp
+        except ImportError:
+            from bluesky import RunEngine
+            RE = RunEngine({})
+        from nabs.plans import daq_scan
+
+        if mcc.lower() == 'x':
+            mcc_pv = self.x_pv
+        elif mcc.lower() == 'y':
+            mcc_pv = self.y_pv
+        else:
+            logger.error('Please enter either x or y to scan')
+            sys.exit()
+
+        if picker=='open':
+            pp.open()
+        if picker=='flip':
+            pp.flipflop()
+
+        if tag is None:
+            tag = sample
+
+        if daq_num == 1:
+            station = 1
+        elif daq_num == 2:
+            station = 0
+        else:
+            logger.error('Please enter daq 1 or 2.')
+
+        run_number = get_run(station=station) + 1
+        logger.info(f"Run Number {run_number} Running {sample}......{quote()['quote']}")
+
+        if daq_num == 1:
+            mcc_pv_motor = EpicsSignal(mcc_pv, name='mcc')
+            RE(
+                daq_scan(
+                    [],
+                    mcc_pv_motor,
+                    start,
+                    end,
+                    num_steps,
+                    events=num_events,
+                    record=record))
+            daq.disconnect()
+
+        elif daq_num == 2:
+            mcc_pv_motor = OnePVMotor(mcc_pv, name="mcc")
+            mcc_pv_motor.setpoint.kind = "hinted"
+            daq.configure(
+                motors=[mcc_pv_motor],
+                group_mask=0x1,
+                events=num_events,
+                record=record)
+
+            RE(bp.scan(
+                [daq],
+                mcc_pv_motor,
+                start,
+                end,
+                num_steps))
+
+        else:
+            logger.error('Please enter daq 1 or 2.')
+
+        pp.close()
+        post(
+            sample=sample, 
+            tag=tag, 
+            run_number=run_number, 
+            post=record, 
+            inspire=inspire,
+            daq_num=daq_num,
+            add_note=f'Motor range:{start}-{end}eV, steps:{num_steps} @ {num_events} events per step for motor:{mcc_pv}')
+        logger.warning('Finished with all runs thank you for choosing the MFX beamline!\n')
+
+        logging.warning(f"Scan completed. Would you like to analyze the output?")
+        answer = input("(y/n)? ")
+
+        if answer.lower() == "y":
+            facility = input("Enter facility (s3df or nersc) to continue: ")
+            user = input("Enter username to continue: ")
+            exp = str(get_exp())
+            self.output.scan(
+                user=user, 
+                facility=facility, 
+                run_type='scan', 
+                exp=exp, 
+                run=run_number)
+
+
+    class output:
+        def __init__(self):
+            pass
+
+
+        def scan(
+                user: str,
+                facility: str = "S3DF",
+                run_type: str = 'scan',
+                exp: str = None,
+                run: str = None):
+            """Perform Vernier scan results analysis.
+
+            Parameters:
+                facility (str):
+                    Default: "S3DF". Options: "S3DF, NERSC
+                type (str):
+                    specify whether it is a vernier 'scan' or 'series'
+                exp (str): 
+                    experiment number. Current experiment by default
+                run (str): 
+                    The run you'd like to process
+            """
+            import logging
+            import os
+            from mfx.db import daq
+            from mfx.macros import get_exp
+            import mfx.cctbx
+            logger = logging.getLogger(__name__)
+
+            logging.info("Plotting XRT-Spec Output")
+            if exp is None:
+                exp = str(get_exp())
+
+            if run is None:
+                run = [daq.run_number()]
+
+            facility = facility.upper()
+            if facility == 'NERSC':
+                logging.warning(f"Have you renewed your token with sshproxy today?")
+                token = input("(y/n)? ")
+
+                if token.lower() == "n":
+                    cctbx.sshproxy(user)
+
+            proc = [
+                f"ssh -Yt {user}@s3dflogin "
+                f"python /sdf/group/lcls/ds/tools/mfx/scripts/cctbx/energy_calib_output.py "
+                f"-f {facility} -t {run_type} -e {exp} -r {run}"
+                ]
+
+            logging.info(proc)
+            os.system(proc[0])
+
+
+    class get:
+        def __init__(self):
+            pass
+
+
+        def x():
+            import os
+            os.system(f'caget MFX:USR:MMN:41')
+            value = os.popen("caget MFX:USR:MMN:41 | awk '{print $2}'").read().strip()
+            return value
+
+        def y():
+            import os
+            os.system(f'caget MFX:USR:MMN:42')
+            value = os.popen("caget MFX:USR:MMN:42 | awk '{print $2}'").read().strip()
+            return value
+
+
+    class put:
+        def __init__(self):
+            pass
+
+        def x(value):
+            import os
+            os.system(f'caput MFX:USR:MMN:41 {value}')
+
+        def y(value):
+            import os
+            os.system(f'caput MFX:USR:MMN:42 {value}')

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -121,7 +121,7 @@ class yano:
         return adjusted_delay 
 
 
-    def set_delay(self, delay):
+    def set_delay(self, delay, rep=30):
         """
         Set the delay
 
@@ -129,32 +129,57 @@ class yano:
         ----------
         delay: float
             Requested laser delay in nanoseconds.
+
+        rep: int, optional
+            Set repitition rate only 60 and 30 Hz are currently available.
+            30 Hz is default
         """
         import logging
         import sys
+        from mfx.mfx_timing import set_seq
+        
         logger = logging.getLogger(__name__)
+
         # Determine event code of inhibit pulse
         logger.info("Setting delay %s ns (%s us)", delay, delay/1000.)
         self.delay = delay
         opo_delay = self.opo_time_zero - delay
         opo_ec = self.opo_ec_short
-        if delay > self.opo_time_zero + 3e9/120:
-            logger.error('Laser delay requested is too long. GO TO A SYNCHROTRON')
-            sys.exit()
-        elif delay > self.opo_time_zero + 2e9/120:
-            opo_delay += 3e9/120
-            opo_ec = self.opo_ec_longest
-            logger.info('Laser is 3 buckets before the beam')
-        elif delay > self.opo_time_zero + 1e9/120:
-            opo_delay += 2e9/120
-            opo_ec = self.opo_ec_longer
-            logger.info('Laser is 2 buckets before the beam')
-        elif delay > self.opo_time_zero:
-            opo_delay += 1e9/120
-            opo_ec = self.opo_ec_long
-            logger.info('Laser is 1 bucket before the beam')
+
+        if rep == 30:
+            set_seq(rep=30)
+            if delay > self.opo_time_zero + 3e9/120:
+                logger.error('Laser delay requested is too long. GO TO A SYNCHROTRON')
+                sys.exit()
+            elif delay > self.opo_time_zero + 2e9/120:
+                opo_delay += 3e9/120
+                opo_ec = self.opo_ec_longest
+                logger.info('Laser is 3 buckets before the beam')
+            elif delay > self.opo_time_zero + 1e9/120:
+                opo_delay += 2e9/120
+                opo_ec = self.opo_ec_longer
+                logger.info('Laser is 2 buckets before the beam')
+            elif delay > self.opo_time_zero:
+                opo_delay += 1e9/120
+                opo_ec = self.opo_ec_long
+                logger.info('Laser is 1 bucket before the beam')
+            else:
+                logger.info('Laser is in the same bucket as the beam')    
+
+        elif rep == 60:
+            set_seq(rep='60_yano')
+            if delay > self.opo_time_zero + 1e9/120:
+                logger.error('Laser delay requested is too long at 60 Hz. Switch to 30 Hz')
+                sys.exit()
+            elif delay > self.opo_time_zero:
+                opo_delay += 1e9/120
+                opo_ec = self.opo_ec_long
+                logger.info('Laser is 1 bucket before the beam')
+            else:
+                logger.info('Laser is in the same bucket as the beam')
+
         else:
-            logger.info('Laser is in the same bucket as the beam')      
+            logger.error('Please enter either 30 or 60 Hz.')
 
 
         self.opo.ns_delay.put(opo_delay)
@@ -227,8 +252,8 @@ class yano:
         OPO Shutter ->  {}
         """
         if daq_num==1:
-        from elog import HutchELog
-        elog=HutchELog.from_conf(instrument='MFX',station=1)
+            from elog import HutchELog
+            elog=HutchELog.from_conf(instrument='MFX',station=1)
 
         if add_note!='':
             add_note = '\n' + add_note

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -15,7 +15,7 @@ class yano:
         self.evo = Trigger('MFX:LAS:EVR:01:TRIG5', name='evo_trigger')
 
         # Laser parameter
-        self.opo_time_zero = 671630
+        self.opo_time_zero = 671740
 
         # Event code switch logic for longer delay
         self.opo_ec_short = 212

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -166,6 +166,7 @@ class yano:
                 opo_ec = self.opo_ec_long
                 logger.info('Laser is 1 bucket before the beam')
             else:
+                opo_ec = self.DAQ
                 logger.info('Laser is in the same bucket as the beam')    
 
         elif rep == 60:
@@ -178,15 +179,25 @@ class yano:
                 opo_ec = self.opo_ec_long
                 logger.info('Laser is 1 bucket before the beam')
             else:
+                opo_ec = self.DAQ
                 logger.info('Laser is in the same bucket as the beam')
+
+        elif rep == 90:
+            mfx_timing.set_seq(rep='90_yano')
+            if delay > self.opo_time_zero:
+                logger.error('Laser delay requested is too long at 60 Hz. Switch to 30 Hz')
+                sys.exit()
+            else:
+                opo_ec = self.DAQ
+                logger.info('Laser and drolet in the same bucket as the beam')
 
         elif rep == 120:
             mfx_timing.set_seq(rep='120_yano')
-            if delay > self.opo_time_zero + 1e9/120:
+            if delay > self.opo_time_zero:
                 logger.error('Laser delay requested is too long at 120 Hz. Switch to 30 Hz')
                 sys.exit()
             else:
-                opo_ec = self.opo_ec_long
+                opo_ec = self.DAQ
                 logger.info('Laser and drolet in the same bucket as the beam')
 
         else:
@@ -521,7 +532,8 @@ class yano:
             Requested laser delay in nanoseconds.
 
         rep: int, optional
-            Set repitition rate only 60 and 30 Hz are currently available.
+            Set repitition rate only 120, 60, 30 Hz are currently available.
+            90 Hz is available using 2 ADE
             30 Hz is default
 
         daq_num: int, optional

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -399,7 +399,14 @@ class yano:
                 return status
 
 
-    def generate_energy_seq(self, energy_scan_start_eV, energy_scan_end_eV, energy_scan_steps, run_length, step_time):
+    def generate_energy_seq(
+        self,
+        energy_scan_start_eV,
+        energy_scan_end_eV,
+        energy_scan_steps,
+        run_length,
+        step_time,
+        brewster=None):
         """Perform Vernier scan.
 
         Parameters:
@@ -414,9 +421,15 @@ class yano:
 
             run_length: int, optional
                 number of seconds for run 300 is default
+
+            brewster: int, optional
+                weights the bottom division of sequence twice.
+                ie 2 weights the bottom half.
         """
         if energy_scan_steps <= 0:
             raise ValueError("Step size must be positive")
+
+        run_total = round(run_length / step_time)
 
         up = list(range(
             energy_scan_start_eV, energy_scan_end_eV, energy_scan_steps))
@@ -427,16 +440,24 @@ class yano:
             -energy_scan_steps))
 
         up_down = len(up) + len(down)
-        run_total = round(run_length / step_time)
+
+        part_up = []
+        part_down = []
+        if brewster > 0:
+            part_up = up[:len(up) // brewster]
+
+            part_down = down[len(down) // brewster:]
+
+            up_down = len(part_up) + len(part_down) + up_down
+
         number_iterations = run_total // up_down
-        # remainder = run_total % up_down
 
         energy_seq = []
         for seq in range(number_iterations):
+            energy_seq.extend(part_up)
+            energy_seq.extend(part_down)
             energy_seq.extend(up)
             energy_seq.extend(down)
-
-        # energy_seq.extend(up[0:remainder-1])
 
         return energy_seq
 
@@ -458,7 +479,8 @@ class yano:
         daq_num=2,
         spread=[],
         spread_type=None,
-        step_time=None):
+        step_time=None,
+        brewster=None):
         """
         Perform a single run of the experiment
 
@@ -513,6 +535,10 @@ class yano:
 
         step_time: int, optional
             step time for each energy of 'vernier' or 'k'
+
+        brewster: int, optional
+            weights the bottom division of SPREAD sequence twice.
+            ie 2 weights the bottom half.
 
         Note
         ----
@@ -669,7 +695,7 @@ class yano:
                             logger.error('Please enter spread type of vernier or k only')
                             sys.exit()
                         spread_comment = f'SPREAD Conditions: type:{spread_type}, range:{spread[0]}-{spread[1]}eV, step:{spread[2]}eV @ {step_time}s'
-                        energy_seq = self.generate_energy_seq(spread[0], spread[1], spread[2], run_length, step_time)
+                        energy_seq = self.generate_energy_seq(spread[0], spread[1], spread[2], run_length, step_time, brewster)
 
                         energy = int(os.popen(spead_ref).read().strip())
                         try:

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -206,11 +206,15 @@ class yano:
         inspire: bool, optional
             Set false by default because it makes Sandra sad. Set True to inspire
 
+        daq_num: int, optional
+            Switch between daq 1 and 2. Default 2
         add_note: string, optional
             adds additional note to elog message 
         """
-        from mfx.db import daq, elog
+        from mfx.db import elog
         from mfx.autorun import quote
+        from mfx.macros import get_exp
+
         post_template = """\
         Run Number {}: {}
 
@@ -222,6 +226,10 @@ class yano:
         EVO fiber 3 ->  {}
         OPO Shutter ->  {}
         """
+        if daq_num==1:
+        from elog import HutchELog
+        elog=HutchELog.from_conf(instrument='MFX',station=1)
+
         if add_note!='':
             add_note = '\n' + add_note
         if tag is None:
@@ -232,7 +240,7 @@ class yano:
             comment = f"Running {sample}{add_note}"
         delay = self.get_delay()
         if run_number is None:
-            run_number = daq.run_number()
+            run_number = get_run(station=0)
         info = [run_number, comment, self._delaystr(delay)]
         info.extend(self.shutter_status)
         post_msg = post_template.format(*info)
@@ -289,13 +297,16 @@ class yano:
             If ``True``, we'll end the run after the daq has stopped.
         """
         import logging
-        logger = logging.getLogger(__name__)
+        
         from time import sleep
         from mfx.db import daq
+        from ophyd.utils import StatusTimeoutError, WaitTimeoutError
+
+        logger = logging.getLogger(__name__)
 
         logger.debug(('Daq.begin(events=%s, duration=%s, record=%s, '
-                      'use_l3t=%s, controls=%s, wait=%s)'),
-                     events, duration, record, use_l3t, controls, wait)
+                        'use_l3t=%s, controls=%s, wait=%s)'),
+                        events, duration, record, use_l3t, controls, wait)
         status = True
         try:
             if record is not None and record != daq.record:
@@ -365,6 +376,10 @@ class yano:
         
         laser_delay: float
             Requested laser delay in nanoseconds.
+
+        daq_num: int, optional
+            Switch between daq 1 and 2. Default 2
+
         Note
         ----
         0: (fiber1=False, fiber2=False, fiber3=False)
@@ -379,6 +394,7 @@ class yano:
         from time import sleep
         from mfx.db import daq, pp
         from mfx.autorun import quote
+        from mfx.macros import get_run, get_exp
 
         # Configure the shutters
         if fiber == 0:

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -446,7 +446,7 @@ class yano:
         if brewster > 0:
             part_up = up[:len(up) // brewster]
 
-            part_down = down[len(down) // brewster:]
+            part_down = down[-len(down) // brewster:]
 
             up_down = len(part_up) + len(part_down) + up_down
 
@@ -694,15 +694,16 @@ class yano:
                         else:
                             logger.error('Please enter spread type of vernier or k only')
                             sys.exit()
-                        spread_comment = f'SPREAD Conditions: type:{spread_type}, range:{spread[0]}-{spread[1]}eV, step:{spread[2]}eV @ {step_time}s'
+                        spread_comment = f'SPREAD Conditions: type:{spread_type}, range:{spread[0]}-{spread[1]}eV, step:{spread[2]}eV @ {step_time}s, Brewster: {brewster}'
                         energy_seq = self.generate_energy_seq(spread[0], spread[1], spread[2], run_length, step_time, brewster)
 
-                        energy = int(os.popen(spead_ref).read().strip())
-                        try:
-                            ind = energy_seq.index(energy)
-                            energy_seq = energy_seq[ind:]
-                        except ValueError:
-                            logger.error(f"{energy} not found in the sequence. Starting with first energy")
+                        if brewster is None:
+                            energy = int(os.popen(spead_ref).read().strip())
+                            try:
+                                ind = energy_seq.index(energy)
+                                energy_seq = energy_seq[ind:]
+                            except ValueError:
+                                logger.error(f"{energy} not found in the sequence. Starting with first energy")
 
                         for eng in energy_seq:
                             os.system(f'caput {spread_pv} {eng}')

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -136,7 +136,7 @@ class yano:
         """
         import logging
         import sys
-        from mfx.mfx_timing import set_seq
+        from mfx.mfx_timing import MFX_Timing
         
         logger = logging.getLogger(__name__)
 
@@ -147,7 +147,7 @@ class yano:
         opo_ec = self.opo_ec_short
 
         if rep == 30:
-            set_seq(rep=30)
+            MFX_Timing.set_seq(rep=30)
             if delay > self.opo_time_zero + 3e9/120:
                 logger.error('Laser delay requested is too long. GO TO A SYNCHROTRON')
                 sys.exit()
@@ -167,7 +167,7 @@ class yano:
                 logger.info('Laser is in the same bucket as the beam')    
 
         elif rep == 60:
-            set_seq(rep='60_yano')
+            MFX_Timing.set_seq(rep='60_yano')
             if delay > self.opo_time_zero + 1e9/120:
                 logger.error('Laser delay requested is too long at 60 Hz. Switch to 30 Hz')
                 sys.exit()

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -221,7 +221,7 @@ class yano:
         return delay
 
 
-    def post(self, sample='?', tag=None, run_number=None, post=False, inspire=False, daq_num=2, add_note=''):
+    def post(self, sample='?', tag=None, run_number=None, post=False, inspire=False, daq_num=2, spread=None, add_note=''):
         """
         Posts a message to the elog
 
@@ -244,8 +244,12 @@ class yano:
 
         daq_num: int, optional
             Switch between daq 1 and 2. Default 2
+        
         add_note: string, optional
             adds additional note to elog message 
+
+        spread: str, optional
+            Special note for running SPREAD
         """
         from mfx.db import elog
         from mfx.autorun import quote
@@ -261,6 +265,7 @@ class yano:
         EVO fiber 2 ->  {}
         EVO fiber 3 ->  {}
         OPO Shutter ->  {}
+        {}
         """
         if daq_num==1:
             from elog import HutchELog
@@ -279,6 +284,8 @@ class yano:
             run_number = get_run(station=0)
         info = [run_number, comment, self._delaystr(delay)]
         info.extend(self.shutter_status)
+        if spread is not None:
+            info.extend([spread])
         post_msg = post_template.format(*info)
         print('\n' + post_msg + '\n')
         if post:
@@ -373,6 +380,48 @@ class yano:
                 return status
 
 
+    def generate_energy_seq(self, energy_scan_start_eV, energy_scan_end_eV, energy_scan_steps, run_length, step_time):
+        """Perform Vernier scan.
+
+        Parameters:
+            energy_scan_start_eV (float): 
+                Photon energy (in eV) to start the scan at.
+
+            energy_scan_end_eV (float): 
+                Photon energy (in eV) to end the scan at.
+
+            energy_scan_steps (int): 
+                Step Size (in eV).
+
+            run_length: int, optional
+                number of seconds for run 300 is default
+        """
+        if energy_scan_steps <= 0:
+            raise ValueError("Step size must be positive")
+
+        up = list(range(
+            energy_scan_start_eV, energy_scan_end_eV, energy_scan_steps))
+
+        down = list(range(
+            energy_scan_end_eV - energy_scan_steps,
+            energy_scan_start_eV - energy_scan_steps,
+            -energy_scan_steps))
+
+        up_down = len(up) + len(down)
+        run_total = round(run_length / step_time)
+        number_iterations = run_total // up_down
+        remainder = run_total % up_down
+
+        energy_seq = []
+        for seq in range(number_iterations):
+            energy_seq.extend(up)
+            energy_seq.extend(down)
+
+        energy_seq.extend(up[0:remainder-1])
+
+        return energy_seq
+
+
     def run(
         self, 
         sample='?', 
@@ -387,7 +436,10 @@ class yano:
         free_space=None, 
         laser_delay=None, 
         rep=30,
-        daq_num=2):
+        daq_num=2,
+        spread=[],
+        spread_type=None,
+        step_time=None):
         """
         Perform a single run of the experiment
 
@@ -427,12 +479,21 @@ class yano:
         laser_delay: float
             Requested laser delay in nanoseconds.
 
-        daq_num: int, optional
-            Switch between daq 1 and 2. Default 2
-        
         rep: int, optional
             Set repitition rate only 60 and 30 Hz are currently available.
             30 Hz is default
+
+        daq_num: int, optional
+            Switch between daq 1 and 2. Default 2
+
+        spread: list, optional
+            List SPREAD energies to dither over as [start, end, step]
+
+        spread_type: str, optional
+            SPREAD type either 'vernier' or 'k'
+
+        step_time: int, optional
+            step time for each energy of 'vernier' or 'k'
 
         Note
         ----
@@ -443,6 +504,8 @@ class yano:
 
         For alternative laser configurations either use ``configure_shutters`` to set parameters
         """
+        import os
+        import sys
         import logging
 
         from time import sleep, time
@@ -572,20 +635,42 @@ class yano:
                     start_time = time()
                     end_time = start_time + run_length
                     
-                    while time() < end_time:
-                        elapsed_time = time() - start_time
-                        progress = min(elapsed_time / run_length, 1)  # Ensure progress doesn't exceed 1
+                    if len(spread) == 3 and spread_type is not None:
+                        if spread_type.lower() == 'vernier':
+                            spread_pv = 'MFX:USER:MCC:EPHOT:SET1'
+                            spead_ref = 'MFX:USER:MCC:EPHOT:REF1'
+                            if step_time is None:
+                                step_time=1
+                        elif spread_type.lower() == 'k':
+                            spread_pv = 'MFX:USER:MCC:EPHOT:SET2'
+                            spead_ref = 'MFX:USER:MCC:EPHOT:REF2'
+                            if step_time is None:
+                                step_time=10
+                        else:
+                            logger.error('Please enter spread type of vernier or k only')
+                            sys.exit()
+                        spread_comment = f'SPREAD Conditions: type:{spread_type}, range:{spread[0]}-{spread[1]}eV, step:{spread[2]}eV @ {step_time}s'
+                        energy_seq = self.generate_energy_seq(spread[0], spread[1], spread[2], run_length, step_time)
+                        for energy in energy_seq:
+                            os.system(f'caput {spread_pv} {energy}')
+                            sleep(step_time)
+
+                    else:
+                        spread_comment = None
+                        while time() < end_time:
+                            elapsed_time = time() - start_time
+                            progress = min(elapsed_time / run_length, 1)  # Ensure progress doesn't exceed 1
+                            
+                            filled_length = int(60 * progress)
+                            bar = '=' * filled_length + '-' * (60 - filled_length)
+                            
+                            percentage = f"{progress:.0%}"
+                            
+                            print(f"\rProgress: [{bar}] {percentage}", end="")
+                            
+                            sleep(1)  # Update frequency
                         
-                        filled_length = int(60 * progress)
-                        bar = '=' * filled_length + '-' * (60 - filled_length)
-                        
-                        percentage = f"{progress:.0%}"
-                        
-                        print(f"\rProgress: [{bar}] {percentage}", end="")
-                        
-                        sleep(1)  # Update frequency
-                    
-                    print("\rProgress: [" + "="*60 + "] 100%") # Final, complete bar
+                        print("\rProgress: [" + "="*60 + "] 100%") # Final, complete bar
 
                     daq.control.setState("configured")
                     while daq.control.getState() != "configured":
@@ -598,7 +683,8 @@ class yano:
                             run_number=run_number, 
                             post=record, 
                             inspire=inspire,
-                            daq_num=daq_num)
+                            daq_num=daq_num,
+                            spread=spread_comment)
 
                     sleep(daq_delay)
 
@@ -632,3 +718,5 @@ class yano:
             logger.warning('Finished with all runs thank you for choosing the MFX beamline!\n')
         else:
             logger.error('Please enter daq 1 or 2.')
+
+    

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -221,7 +221,7 @@ class yano:
         return delay
 
 
-    def post(self, sample='?', tag=None, run_number=None, post=False, inspire=False, add_note=''):
+    def post(self, sample='?', tag=None, run_number=None, post=False, inspire=False, daq_num=2, add_note=''):
         """
         Posts a message to the elog
 
@@ -592,7 +592,7 @@ class yano:
                         ...
 
                     if record:
-                        post(
+                        self.post(
                             sample=sample, 
                             tag=tag, 
                             run_number=run_number, 
@@ -610,7 +610,7 @@ class yano:
                 daq.control.setState("running")
                 pp.close()
                 if record:
-                    post(
+                    self.post(
                         sample=sample, 
                         tag=tag, 
                         run_number=run_number, 

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -131,7 +131,7 @@ class yano:
             Requested laser delay in nanoseconds.
 
         rep: int, optional
-            Set repitition rate only 60 and 30 Hz are currently available.
+            Set repetition rate only 60 and 30 Hz are currently available.
             30 Hz is default
         """
         import logging

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -137,17 +137,19 @@ class yano:
         import logging
         import sys
         from mfx.mfx_timing import MFX_Timing
+        mfx_timing = MFX_Timing()
         
         logger = logging.getLogger(__name__)
 
         # Determine event code of inhibit pulse
         logger.info("Setting delay %s ns (%s us)", delay, delay/1000.)
+        logger.info(f"Setting reprate: {rep}")
         self.delay = delay
         opo_delay = self.opo_time_zero - delay
         opo_ec = self.opo_ec_short
 
         if rep == 30:
-            MFX_Timing.set_seq(rep=30)
+            mfx_timing.set_seq(rep=30)
             if delay > self.opo_time_zero + 3e9/120:
                 logger.error('Laser delay requested is too long. GO TO A SYNCHROTRON')
                 sys.exit()
@@ -167,7 +169,7 @@ class yano:
                 logger.info('Laser is in the same bucket as the beam')    
 
         elif rep == 60:
-            MFX_Timing.set_seq(rep='60_yano')
+            mfx_timing.set_seq(rep='60_yano')
             if delay > self.opo_time_zero + 1e9/120:
                 logger.error('Laser delay requested is too long at 60 Hz. Switch to 30 Hz')
                 sys.exit()
@@ -175,6 +177,14 @@ class yano:
                 opo_delay += 1e9/120
                 opo_ec = self.opo_ec_long
                 logger.info('Laser is 1 bucket before the beam')
+            else:
+                logger.info('Laser is in the same bucket as the beam')
+
+        elif rep == 120:
+            mfx_timing.set_seq(rep='120_yano')
+            if delay > self.opo_time_zero + 1e9/120:
+                logger.error('Laser delay requested is too long at 120 Hz. Switch to 30 Hz')
+                sys.exit()
             else:
                 logger.info('Laser is in the same bucket as the beam')
 
@@ -362,7 +372,20 @@ class yano:
                 return status
 
 
-    def run(self, sample='?', tag=None, run_length=300, record=True, runs=5, inspire=False, daq_delay=5, picker=None, fiber=-1, free_space=None, laser_delay=None):
+    def run(
+        self, 
+        sample='?', 
+        tag=None, 
+        run_length=300, 
+        record=True, 
+        runs=5, 
+        inspire=False, 
+        daq_delay=5, 
+        picker=None, 
+        fiber=-1, 
+        free_space=None, 
+        laser_delay=None, 
+        rep=30):
         """
         Perform a single run of the experiment
 
@@ -404,6 +427,10 @@ class yano:
 
         daq_num: int, optional
             Switch between daq 1 and 2. Default 2
+        
+        rep: int, optional
+            Set repitition rate only 60 and 30 Hz are currently available.
+            30 Hz is default
 
         Note
         ----
@@ -445,7 +472,7 @@ class yano:
                 self.opo_shutter('IN')
 
         if laser_delay is not None:
-            self.set_delay(laser_delay)
+            self.set_delay(laser_delay, rep=rep)
         delay = self.get_delay()
         logger.info(self._delaystr(delay))
 

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -186,7 +186,8 @@ class yano:
                 logger.error('Laser delay requested is too long at 120 Hz. Switch to 30 Hz')
                 sys.exit()
             else:
-                logger.info('Laser is in the same bucket as the beam')
+                opo_ec = self.opo_ec_long
+                logger.info('Laser and drolet in the same bucket as the beam')
 
         else:
             logger.error('Please enter either 30 or 60 Hz.')
@@ -385,7 +386,8 @@ class yano:
         fiber=-1, 
         free_space=None, 
         laser_delay=None, 
-        rep=30):
+        rep=30,
+        daq_num=2):
         """
         Perform a single run of the experiment
 
@@ -443,7 +445,7 @@ class yano:
         """
         import logging
 
-        from time import sleep
+        from time import sleep, time
         from mfx.db import daq, pp
         from mfx.autorun import quote
         from mfx.macros import get_run, get_exp
@@ -555,8 +557,6 @@ class yano:
                         break
 
                     logger.info(f"Run Number {run_number} Running {sample}......{quote()['quote']}")
-                    if cam is not None:
-                        ioc_cam_recorder(cam, run_length, tag)
 
                     daq.control.setState("configured")
                     while daq.control.getState() != "configured":

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -267,6 +267,23 @@ class yano:
         OPO Shutter ->  {}
         {}
         """
+        post_template2 = """
+            <table border="1">
+            <thead><tr><th colspan="2"><center>Run Number {1}: {2}</center></th></tr></thead>
+            <tbody><tr>
+            <td><b><center>Fiber/Shutter</center></b></td>
+            <td><b><center>Spread</center></b></td></tr>
+            <tr><td><center>EVO fiber 1 -> {3}</center></td>
+            <td><center>Spread: {7}</center></td></tr>
+            <tr><td><center>EVO fiber 2 -> {4}</center></td>
+            <td><center></center></td></tr>
+            <tr><td><center>EVO fiber 3 -> {5}</center></td>
+            <td><center></center></td></tr>
+            <tr><td><center>OPO Shutter -> {6}</center></td>
+            <td><center></center></td></tr>
+            </tbody>
+            </table>
+        """
         if daq_num==1:
             from elog import HutchELog
             elog=HutchELog.from_conf(instrument='MFX',station=1)
@@ -286,6 +303,8 @@ class yano:
         info.extend(self.shutter_status)
         if spread is not None:
             info.extend([spread])
+        else:
+            info.extend(["Spread      -> NO"])
         post_msg = post_template.format(*info)
         print('\n' + post_msg + '\n')
         if post:
@@ -410,14 +429,14 @@ class yano:
         up_down = len(up) + len(down)
         run_total = round(run_length / step_time)
         number_iterations = run_total // up_down
-        remainder = run_total % up_down
+        # remainder = run_total % up_down
 
         energy_seq = []
         for seq in range(number_iterations):
             energy_seq.extend(up)
             energy_seq.extend(down)
 
-        energy_seq.extend(up[0:remainder-1])
+        # energy_seq.extend(up[0:remainder-1])
 
         return energy_seq
 
@@ -638,12 +657,12 @@ class yano:
                     if len(spread) == 3 and spread_type is not None:
                         if spread_type.lower() == 'vernier':
                             spread_pv = 'MFX:USER:MCC:EPHOT:SET1'
-                            spead_ref = 'MFX:USER:MCC:EPHOT:REF1'
+                            spead_ref = "caget MFX:USER:MCC:EPHOT:SET1 | awk '{print $2}'"
                             if step_time is None:
                                 step_time=1
                         elif spread_type.lower() == 'k':
                             spread_pv = 'MFX:USER:MCC:EPHOT:SET2'
-                            spead_ref = 'MFX:USER:MCC:EPHOT:REF2'
+                            spead_ref = "caget MFX:USER:MCC:EPHOT:SET2 | awk '{print $2}'"
                             if step_time is None:
                                 step_time=10
                         else:
@@ -651,8 +670,16 @@ class yano:
                             sys.exit()
                         spread_comment = f'SPREAD Conditions: type:{spread_type}, range:{spread[0]}-{spread[1]}eV, step:{spread[2]}eV @ {step_time}s'
                         energy_seq = self.generate_energy_seq(spread[0], spread[1], spread[2], run_length, step_time)
-                        for energy in energy_seq:
-                            os.system(f'caput {spread_pv} {energy}')
+
+                        energy = int(os.popen(spead_ref).read().strip())
+                        try:
+                            ind = energy_seq.index(energy)
+                            energy_seq = energy_seq[ind:]
+                        except ValueError:
+                            logger.error(f"{energy} not found in the sequence. Starting with first energy")
+
+                        for eng in energy_seq:
+                            os.system(f'caput {spread_pv} {eng}')
                             sleep(step_time)
 
                     else:
@@ -702,7 +729,8 @@ class yano:
                         run_number=run_number, 
                         post=record, 
                         inspire=inspire,
-                        daq_num=daq_num, 
+                        daq_num=daq_num,
+                        spread=spread_comment, 
                         add_note='Run ended prematurely. Probably sample delivery problem')
                 logger.warning("[*] Stopping Run and exiting???...")
                 self.configure_shutters(fiber1=False, fiber2=False, fiber3=False, free_space=False)

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -390,12 +390,14 @@ class yano:
         For alternative laser configurations either use ``configure_shutters`` to set parameters
         """
         import logging
-        logger = logging.getLogger(__name__)
+
         from time import sleep
         from mfx.db import daq, pp
         from mfx.autorun import quote
         from mfx.macros import get_run, get_exp
 
+        logger = logging.getLogger(__name__)
+        
         # Configure the shutters
         if fiber == 0:
             self.fiber_0()
@@ -432,48 +434,149 @@ class yano:
         if tag is None:
             tag = sample
 
-        for i in range(runs):
-            logger.info(f"Run Number {get_run(station=1) + 1} Running {sample}......{quote()['quote']}")
-            run_number = get_run(station=1) + 1
-            status = self.begin(duration = run_length, record = record, wait = True, end_run = True)
-            if status is False:
-                pp.close()
+        if daq_num == 1:
+            for i in range(runs):
+                run_number = get_run(station=1) + 1
+                logger.info(f"Run Number {get_run(station=1) + 1} Running {sample}......{quote()['quote']}")
+                status = self.begin(duration = run_length, record = record, wait = True, end_run = True)
+                if status is False:
+                    pp.close()
+                    self.post(
+                        sample=sample, 
+                        tag=tag, 
+                        run_number=run_number, 
+                        post=record, 
+                        inspire=inspire,
+                        daq_num=daq_num,
+                        add_note='Run ended prematurely. Probably sample delivery problem')
+                    self.configure_shutters(fiber1=False, fiber2=False, fiber3=False, free_space=False)
+                    logger.warning("[*] Stopping Run and exiting???...")
+                    sleep(5)
+                    daq.stop()
+                    daq.disconnect()
+                    logger.warning('Run ended prematurely. Probably sample delivery problem')
+                    break
+
                 self.post(
                     sample=sample, 
                     tag=tag, 
                     run_number=run_number, 
                     post=record, 
-                    inspire=inspire, 
-                    add_note='Run ended prematurely. Probably sample delivery problem')
-                self.configure_shutters(fiber1=False, fiber2=False, fiber3=False, free_space=False)
-                logger.warning("[*] Stopping Run and exiting???...")
-                sleep(5)
-                daq.stop()
-                daq.disconnect()
-                logger.warning('Run ended prematurely. Probably sample delivery problem')
-                break
-
-            self.post(
-                sample=sample, 
-                tag=tag, 
-                run_number=run_number, 
-                post=record, 
-                inspire=inspire)
-            try:
-                sleep(daq_delay)
-            except KeyboardInterrupt:
+                    inspire=inspire,
+                    daq_num=daq_num)
+                try:
+                    sleep(daq_delay)
+                except KeyboardInterrupt:
+                    pp.close()
+                    self.configure_shutters(fiber1=False, fiber2=False, fiber3=False, free_space=False)
+                    logger.warning("[*] Stopping Run and exiting???...")
+                    sleep(5)
+                    daq.disconnect()
+                    status = False
+                    if status is False:
+                        logger.warning('Run ended prematurely. Probably sample delivery problem')
+                        break
+            if status:
                 pp.close()
                 self.configure_shutters(fiber1=False, fiber2=False, fiber3=False, free_space=False)
-                logger.warning("[*] Stopping Run and exiting???...")
-                sleep(5)
+                daq.end_run()
                 daq.disconnect()
-                status = False
-                if status is False:
-                    logger.warning('Run ended prematurely. Probably sample delivery problem')
-                    break
-        if status:
+                logger.warning('Finished with all runs thank you for choosing the MFX beamline!\n')
+
+        elif daq_num == 2:
+            try:
+                for i in range(runs):
+                    run_number = get_run(station=0) + 1
+                    from psdaq.control.DaqControl import DaqControl  # NOQA
+                    daq.control = DaqControl(
+                        host=daq.control.host,
+                        platform=daq.control.platform,
+                        timeout=10000,
+                    )
+                    instr = daq.control.getInstrument()
+                    if instr is None:
+                        logger.error('Failed to connect to LCLS-II DAQ')
+                        break
+                    start_state = daq.control.getState()
+                    if start_state == 'error':
+                        logger.error('DAQ is in an error state.')
+                        break
+
+                    logger.info(f"Run Number {run_number} Running {sample}......{quote()['quote']}")
+                    if cam is not None:
+                        ioc_cam_recorder(cam, run_length, tag)
+
+                    daq.control.setState("configured")
+                    while daq.control.getState() != "configured":
+                        ...
+                    if record:
+                        daq.control.setRecord(True)
+                    else:
+                        daq.control.setRecord(False)
+
+                    daq.control.setState("running")
+                    while daq.control.getState() != "running":
+                        ...
+                    start_time = time()
+                    end_time = start_time + run_length
+                    
+                    while time() < end_time:
+                        elapsed_time = time() - start_time
+                        progress = min(elapsed_time / run_length, 1)  # Ensure progress doesn't exceed 1
+                        
+                        filled_length = int(60 * progress)
+                        bar = '=' * filled_length + '-' * (60 - filled_length)
+                        
+                        percentage = f"{progress:.0%}"
+                        
+                        print(f"\rProgress: [{bar}] {percentage}", end="")
+                        
+                        sleep(1)  # Update frequency
+                    
+                    print("\rProgress: [" + "="*60 + "] 100%") # Final, complete bar
+
+                    daq.control.setState("configured")
+                    while daq.control.getState() != "configured":
+                        ...
+
+                    if record:
+                        post(
+                            sample=sample, 
+                            tag=tag, 
+                            run_number=run_number, 
+                            post=record, 
+                            inspire=inspire,
+                            daq_num=daq_num)
+
+                    sleep(daq_delay)
+
+            except KeyboardInterrupt:
+                daq.control.setState("configured")
+                while daq.control.getState() != "configured":
+                    ...
+                daq.control.setRecord(False)
+                daq.control.setState("running")
+                pp.close()
+                if record:
+                    post(
+                        sample=sample, 
+                        tag=tag, 
+                        run_number=run_number, 
+                        post=record, 
+                        inspire=inspire,
+                        daq_num=daq_num, 
+                        add_note='Run ended prematurely. Probably sample delivery problem')
+                logger.warning("[*] Stopping Run and exiting???...")
+                self.configure_shutters(fiber1=False, fiber2=False, fiber3=False, free_space=False)
+                logger.warning('Run ended prematurely. Probably sample delivery problem')
+
             pp.close()
             self.configure_shutters(fiber1=False, fiber2=False, fiber3=False, free_space=False)
-            daq.end_run()
-            daq.disconnect()
+            daq.control.setState("configured")
+            while daq.control.getState() != "configured":
+                ...
+            daq.control.setRecord(False)
+            daq.control.setState("running")
             logger.warning('Finished with all runs thank you for choosing the MFX beamline!\n')
+        else:
+            logger.error('Please enter daq 1 or 2.')

--- a/mfx/yano.py
+++ b/mfx/yano.py
@@ -417,7 +417,7 @@ class yano:
         energy_scan_steps,
         run_length,
         step_time,
-        brewster=None):
+        brewster=0):
         """Perform Vernier scan.
 
         Parameters:
@@ -483,7 +483,7 @@ class yano:
         inspire=False, 
         daq_delay=5, 
         picker=None, 
-        fiber=-1, 
+        fiber=0, 
         free_space=None, 
         laser_delay=None, 
         rep=30,
@@ -491,7 +491,7 @@ class yano:
         spread=[],
         spread_type=None,
         step_time=None,
-        brewster=None):
+        brewster=0):
         """
         Perform a single run of the experiment
 
@@ -523,7 +523,7 @@ class yano:
 
         fiber: int, optional
             Number of laser fibers. Default is -1. See ``configure_shutters`` for more
-            information
+            information. Default 0
 
         free_space: bool, optional
             Sets the free_space laser shutter to Closed (False) or Open (True). Default is None.
@@ -709,7 +709,7 @@ class yano:
                         spread_comment = f'SPREAD Conditions: type:{spread_type}, range:{spread[0]}-{spread[1]}eV, step:{spread[2]}eV @ {step_time}s, Brewster: {brewster}'
                         energy_seq = self.generate_energy_seq(spread[0], spread[1], spread[2], run_length, step_time, brewster)
 
-                        if brewster is None:
+                        if brewster > 0:
                             energy = int(os.popen(spead_ref).read().strip())
                             try:
                                 ind = energy_seq.index(energy)

--- a/scripts/cctbx/cctbx_start.py
+++ b/scripts/cctbx/cctbx_start.py
@@ -90,8 +90,20 @@ db {{
         setting_lines = cctbx_settings.readlines()
         change = False
         if setting_lines[3] != f'    experiment = "{exp}"\n':
-            logging.warning(f"Changing experiment to current: {exp}")
+            logging.warning(
+                f"Phil file is for a different experiment. Would you like to change it?")
+            answer = input("(y/n)? ")
+
+        if answer.lower() == "y":
+            logging.info(f"Changing experiment to current: {exp}")
             change = True
+        elif answer.lower() == "n":
+            logging.info("Not changing phil")
+            change = False
+        else:
+            logging.info("Not valid response. so no change")
+            change = False
+        
     else:
         logging.warning(f"settings.phil file doesn't exist. Writing new one for {exp}")
         change = True

--- a/scripts/cctbx/energy_calib_output.sh
+++ b/scripts/cctbx/energy_calib_output.sh
@@ -13,7 +13,8 @@ case $facility in
   S3DF)
     mfx_dir="/sdf/group/lcls/ds/tools/mfx"
     mfx3="/sdf/group/lcls/ds/tools/mfx"
-    source /sdf/group/lcls/ds/tools/cctbx/setup.sh
+    # source /sdf/group/lcls/ds/tools/cctbx/setup.sh #psana1
+    source /sdf/group/lcls/ds/tools/cctbx-psana2/build/conda_setpaths.sh
     ;;
 
   NERSC)

--- a/scripts/cctbx/energy_calib_output.sh
+++ b/scripts/cctbx/energy_calib_output.sh
@@ -19,7 +19,8 @@ case $facility in
   NERSC)
     mfx_dir="/global/common/software/lcls/mfx"
     mfx3="/global/common/software/lcls/mfx"
-    source /global/common/software/cctbx/alcc-recipes/cctbx/activate.sh
+    # source /global/common/software/cctbx/alcc-recipes/cctbx/activate.sh #psana1
+    source /pscratch/sd/c/cctbx/psana2/alcc-recipes/cctbx/activate.sh
     ;;
 esac
 

--- a/scripts/cctbx/fee_calib.py
+++ b/scripts/cctbx/fee_calib.py
@@ -56,7 +56,7 @@ def process_run(exp, run_num, detector_name, max_events):
         ds = psana.DataSource(f'exp={exp}:run={run_num}:smd')
     except:
         # psana2
-        ds = psana.DataSource(f"exp={exp},run={run_num},detectors=['{detector_name}'],max_events={max_events}")
+        ds = psana.DataSource(exp={exp},run={run_num},detectors=[f'{detector_name}'],max_events={max_events})
     try:
         detector = psana.Detector(detector_name)
 

--- a/scripts/cctbx/fee_calib.py
+++ b/scripts/cctbx/fee_calib.py
@@ -71,6 +71,8 @@ def process_run(exp, run_num, detector_name, max_events):
         try:
             # psana2
             detector = run.Detector(detector_name)
+        except:
+            pass
         for nevt, evt in enumerate(run.events()):
             total_attempts += 1
             try:

--- a/scripts/cctbx/fee_calib.py
+++ b/scripts/cctbx/fee_calib.py
@@ -56,7 +56,7 @@ def process_run(exp, run_num, detector_name, max_events):
         ds = psana.DataSource(f'exp={exp}:run={run_num}:smd')
     except:
         # psana2
-        ds = psana.DataSource(f'exp={exp},run={run_num},detectors=['{detector_name}']',
+        ds = psana.DataSource(f'exp={exp},run={run_num},detectors=['{detector_name}'],
             max_events=max_events)
     try:
         detector = psana.Detector(detector_name)

--- a/scripts/cctbx/fee_calib.py
+++ b/scripts/cctbx/fee_calib.py
@@ -56,8 +56,7 @@ def process_run(exp, run_num, detector_name, max_events):
         ds = psana.DataSource(f'exp={exp}:run={run_num}:smd')
     except:
         # psana2
-        ds = psana.DataSource(f'exp={exp},run={run_num},detectors=['{detector_name}'],
-            max_events=max_events)
+        ds = psana.DataSource(f"exp={exp},run={run_num},detectors=['{detector_name}'],max_events={max_events}")
     try:
         detector = psana.Detector(detector_name)
 

--- a/scripts/cctbx/fee_calib.py
+++ b/scripts/cctbx/fee_calib.py
@@ -60,6 +60,7 @@ def process_run(exp, run_num, detector_name, max_events):
     try:
         detector = psana.Detector(detector_name)
     except:
+        # psana2
         detector = None
 
     data = None

--- a/scripts/cctbx/fee_calib.py
+++ b/scripts/cctbx/fee_calib.py
@@ -52,29 +52,46 @@ calibration {
 
 def process_run(exp, run_num, detector_name, max_events):
     """Process a single run and return accumulated spectrum"""
-    ds = psana.DataSource(f'exp={exp}:run={run_num}:smd')
-    detector = psana.Detector(detector_name)
+    try:
+        ds = psana.DataSource(f'exp={exp}:run={run_num}:smd')
+    except:
+        # psana2
+        ds = psana.DataSource(f'exp={exp},run={run_num},detectors=['{detector_name}']',
+            max_events=max_events)
+    try:
+        detector = psana.Detector(detector_name)
 
     data = None
     total_events = 0
     total_attempts = 0
 
     for run in ds.runs():
+        try:
+            # psana2
+            detector = run.Detector(detector_name)
         for nevt, evt in enumerate(run.events()):
             total_attempts += 1
-            spectrum = detector.get(evt)
+            try:
+                is_psana1=True
+                spectrum = detector.get(evt)
+                dta = spectrum.hproj().astype(float)
+            except:
+                # psana2
+                is_psana1 = False
+                spectrum = detector.raw.hproj(evt)
+                dta = spectrum.astype(float)
             if not spectrum:
                 continue
 
-            dta = spectrum.hproj().astype(float)
             if data is None:
                 data = dta
             else:
                 data += dta
             total_events += 1
 
-            if total_events >= max_events:
-                break
+            if is_psana1:
+                if total_events >= max_events:
+                    break
 
     print(f"  Processed {total_attempts} total events to get {total_events} good events")
     return data, total_events

--- a/scripts/cctbx/fee_calib.py
+++ b/scripts/cctbx/fee_calib.py
@@ -59,6 +59,8 @@ def process_run(exp, run_num, detector_name, max_events):
         ds = psana.DataSource(exp={exp},run={run_num},detectors=[f'{detector_name}'],max_events={max_events})
     try:
         detector = psana.Detector(detector_name)
+    except:
+        detector = None
 
     data = None
     total_events = 0

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -187,7 +187,7 @@ class MFXTransfocator(TransfocatorBase):
         self.tfs_10.remove()
 
 
-    def find_best_combo(self, target=None, energy_eV=None, n=4, z_obj=150.0, show=True, **kwargs):
+    def find_best_combo(self, target=None, energy_eV=None, n=4, z_obj=0, show=True, **kwargs):
 
         """
         Calculate the best lens array to hit the nominal sample point

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -187,7 +187,7 @@ class MFXTransfocator(TransfocatorBase):
         self.tfs_10.remove()
 
 
-    def find_best_combo(self, target=None, energy=None, n=4, z_obj=150.0, show=True, **kwargs):
+    def find_best_combo(self, target=None, energy_eV=None, n=4, z_obj=150.0, show=True, **kwargs):
 
         """
         Calculate the best lens array to hit the nominal sample point
@@ -216,11 +216,14 @@ class MFXTransfocator(TransfocatorBase):
         kwargs:
             Passed to :meth:`.Calculator.find_solution`
         """
+        if 'energy' in kwargs:
+            raise ValueError('energy is no longer the correct input variable. Please use energy_eV. Thank Fred.')
+
         energy = energy_eV or self.beam_energy.get()
         try:
             assert energy > 1000
         except AssertionError:
-            print(f"please double-check that {energy} is in eV, not keV.")
+            logging.warning(f"please double-check that {energy} is in eV, not keV.")
         target = target or self.nominal_sample
         calc = TFS_Calculator(tfs_lenses=self.tfs_lenses, prefocus_lenses=self.xrt_lenses)
         combo, diff = calc.find_solution(target, energy, n, z_obj, **kwargs)


### PR DESCRIPTION
Gabriel made the "run_type" attribute available from the DAQ control object, thus allowing us to set it to particular values, like "GEOM", that are assigned at the beginning of the run and can be used through the ARP and LUTE for decision making on what analysis workflow to run, e.g. geometry calibration. We could not use the "tag" attribute for this effect, because it is set at the end of the run and would introduce a racing problem.
Not tested in production yet.