### PR TITLE
TFS tracking focus

### DIFF
--- a/conf-tmp.yml
+++ b/conf-tmp.yml
@@ -1,0 +1,21 @@
+hutch: mfx
+
+# Locate happi database
+db: /reg/g/pcds/pyps/apps/hutch-python/device_config/db.json
+
+# Hutch-specific imports
+load: mfx.beamline_tmp
+
+#daq_platform:
+#    default: 0
+
+# DAQ interface configuration
+daq_type: lcls2
+
+daq_host: drp-srcf-cmp014
+
+daq_platform:
+  default: 0
+
+
+#experiment: lu5017

--- a/mfx/beamline_tmp.py
+++ b/mfx/beamline_tmp.py
@@ -1,0 +1,278 @@
+import logging
+from hutch_python.utils import safe_load
+
+logger = logging.getLogger(__name__)
+
+# with safe_load('quiet errors'):
+#     from IPython import get_ipython
+#     ip = get_ipython()
+#     ip.InteractiveTB.set_mode(mode="Minimal")
+#
+# with safe_load('sequencer'):
+#     from pcdsdevices.sequencer import EventSequencer
+#     sequencer = EventSequencer('ECS:SYS0:7', name='mfx_sequencer')
+#     mfx_sequencer = sequencer
+#     sequencer2 = EventSequencer('ECS:SYS0:12', name='mfx_sequencer_spare')
+#     mfx_sequencer_spare = sequencer2
+#
+# with safe_load('rayonix utils'):
+#     from mfx.rayonix import Rayonix
+#     rayonix = Rayonix(mfx_sequencer)
+#     mfx_rayonix = rayonix
+
+with safe_load('mfx_transfocator'):
+    from tfs.transfocator import Transfocator
+    tfs = Transfocator("MFX:LENS", name='MFX Transfocator')
+    from tfs import utils as tfs_utils
+    from tfs.transfocator_scan import *
+
+# with safe_load('mfx_prefocus'):
+#     from .devices import XFLS
+#     mfx_prefocus = XFLS('MFX:DIA:XFLS', name='mfx_prefocus')
+#
+# with safe_load('Scan PVs'):
+#     from mfx.db import scan_pvs
+#     scan_pvs.enable()
+#
+# with safe_load('beam_suspender'):
+#     from mfx.suspenders import BeamEnergySuspendFloor
+#     beam_suspender = BeamEnergySuspendFloor(0.6)
+#
+# with safe_load('macros'):
+#     from mfx.macros import *
+#
+# with safe_load('MFX_Timing'):
+#     from mfx.mfx_timing import *
+#     mfx_timing = MFX_Timing(sequencer)
+#
+# with safe_load('delay_scan'):
+#     from mfx.delay_scan import *
+#
+# with safe_load('autorun'):
+#     from mfx.autorun import *
+#
+# with safe_load('attenuator_scan'):
+#     from mfx.attenuator_scan import *
+#
+# with safe_load('focus_scan'):
+#     from mfx.focus_scan import *
+#
+# with safe_load('plans'):
+#     from mfx.plans import *
+#
+# with safe_load('Mesh Voltage Control'):
+#     from pcdsdevices.analog_signals import Mesh
+#     mesh = Mesh('MFX:USR', 0, 1)
+#
+# with safe_load('detector_image'):
+#     from mfx.detector_image import *
+#
+# with safe_load("drift_correct"):
+#     from mfx.timetool import *
+#
+# with safe_load('bash_utilities'):
+#     from mfx.bash_utilities import *
+#     bs = bs()
+#
+# with safe_load('cctbx'):
+#     from mfx.cctbx import *
+#     cctbx = cctbx()
+#
+# with safe_load('OM'):
+#     from mfx.om import *
+#     om = OM()
+#
+# with safe_load('xas'):
+#     import mfx.xas as xas
+#
+# with safe_load('beam'):
+#     from mfx.optimize.errors import *
+#     from mfx.optimize.plots import *
+#     from mfx.optimize.type_checking import *
+#     from mfx.optimize.user_select import *
+#     from mfx.optimize.constraints import *
+#     from mfx.optimize.beam import *
+#     beam = Beam()
+#
+# with safe_load('vernier'):
+#     from mfx.vernier import *
+#     vernier = Vernier()
+#
+# with safe_load('yano-kern_code'):
+#     from mfx.yano import *
+#     yano = yano()
+#
+# with safe_load('Droplet_on_Demand_Colliding_Droplets'):
+#     from dod.codi import *
+#     codi = CoDI()
+#
+# with safe_load('Droplet_on_Demand'):
+#     from dod.dod import *
+#     dod = DoD(modules = 'codi')
+#
+# with safe_load('Debugging Scripts'):
+#     from mfx.debug import *
+#     debug = Debug()
+#
+# with safe_load('XLJ'):
+#     from pcdsdevices.jet import BeckhoffJet
+#     xlj = BeckhoffJet('MFX:LJH', name='xlj')
+#
+# with safe_load('XLJ_Fast'):
+#     from mfx.xlj_fast import *
+#     xlj_fast_rx = BypassPositionCheck("MFX:HRA:MMS:02", name="xlj_fast_rx")
+#     xlj_fast_ry = BypassPositionCheck("MFX:HRA:MMS:04", name="xlj_fast_ry")
+#     xlj_fast_rz = BypassPositionCheck("MFX:HRA:MMS:03", name="xlj_fast_rz")
+#
+# with safe_load('XLJ_Fast_Rot'):
+#     from mfx.xlj_fast_rot import *
+#     from pcdsdevices.epics_motor import IMS
+#     xlj_fast_rx = IMS("MFX:HRA:MMS:02", name="xlj_fast_rx")
+#     xlj_fast_ry = IMS("MFX:HRA:MMS:04", name="xlj_fast_ry")
+#     xlj_fast_rz = IMS("MFX:HRA:MMS:03", name="xlj_fast_rz")
+#
+# with safe_load('DCCM'):
+#     from mfx.dccm import DCCM
+#     dccm = DCCM(name='DCCM')
+#
+# with safe_load('Notch_Scan'):
+#     from mfx.notch_scan import *
+#     notch = NotchScan()
+#
+# with safe_load('Compact_Spectrometer'):
+#     from mfx.vonhamos import DeterministicVonHamos6Crystal
+#     spec = DeterministicVonHamos6Crystal("MFX:SPEC", name="dvh")
+#
+# with safe_load('Undulator_Pointing'):
+#     from mfx.optimize.undpoint import UndPointAbs2DMFX
+#     und_abs=UndPointAbs2DMFX()
+#     und_del=und_abs.dxy
+#
+# with safe_load('RE_Scans'):
+#     from mfx.scan import *
+#     scan = Scan()
+#
+# with safe_load('Find_PV'):
+#     from mfx.find import *
+#     find = Find()
+#
+# with safe_load('Get_Info'):
+#     from scripts.get_info import *
+#
+# with safe_load('Wire_Scan'):
+#     from mfx.wire import *
+#     wire = Wire()
+#
+# with safe_load('EXAFS'):
+#     from mfx.exafs import *
+#     exafs = Exafs()
+#
+# with safe_load('EXAFS_Builder'):
+#     from mfx.exafs_energy_range_builder import *
+#     exafs_energy_range_builder = EXAFSEnergyRangeBuilder()
+
+# with safe_load("laser wp power"):
+#     # Hack the LXE class to make it work with Newports
+#     class LXE(LaserEnergyPositioner):
+#         from pcdsdevices.lxe import LaserEnergyPositioner
+#         from hutch_python.utils import get_current_experiment
+#         from pcdsdevices.device import Component as Cpt
+#         from pcdsdevices.epics_motor import Newport
+#         motor = Cpt(Newport, "")
+#         lxe_calib_file = (
+#             f"/reg/neh/operator/mfxopr/experiments/{get_current_experiment('mfx')}/wpcalib"
+#         )
+#         try:
+#             lxe = LXE("MFX:LAS:MMN:08", calibration_file=lxe_calib_file, name="lxe")
+#         except OSError:
+#             print(f"Could not load file: {lxe_calib_file}")
+#             raise FileNotFoundError
+
+# with safe_load('FS45 lxt & lxt_ttc'):
+#     import logging
+#     logging.getLogger('pint').setLevel(logging.ERROR)
+#
+#     from pcdsdevices.device import ObjectComponent as OCpt
+#     from pcdsdevices.lxe import LaserTiming
+#     from pcdsdevices.pseudopos import SyncAxis
+#     from pcdsdevices.device_types import DelayNewport
+#     from mfx.db import mfx_txt
+#
+#     lxt = LaserTiming('LAS:FS45', name='lxt')
+#     txt = mfx_txt
+#     # <we are missibng the compensation 'motor'>
+#
+#     class LXTTTC(SyncAxis):
+#         lxt = OCpt(lxt)
+#         txt = OCpt(txt)
+#
+#         tab_component_names = True
+#         scales = {'txt': -1}
+#         warn_deadband = 5e-14
+#         fix_sync_keep_still = 'lxt'
+#         sync_limits = (-10e-6, 10e-6)
+#
+#     lxt_ttc = LXTTTC('', name='lxt_ttc')
+
+# with safe_load('add laser motor groups'):
+#     from pcdsdevices.device_types import Newport
+#     from pcdsdevices.device_types import DelayNewport
+#     from pcdsdevices.usb_encoder import UsDigitalUsbEncoder
+#     from mfx.db import mfx_lxt_fast1
+#     lxt_fast=mfx_lxt_fast1
+#
+#     #opa_comp = Newport('MFX:LAS:MMN:01', name='opa_comp') # linear motor for OPA compressor
+#     # this is the timetool compensationn stage. You might want this one
+#     class las():
+#         #opa_comp = opa_comp # waveplate for the main compressor
+#         # Time tool motors
+#         # initialize motors here for tab completion if wanted
+#         with safe_load('add more laser motors'):
+#             lasmot2 = Newport('MFX:LAS:MMN:02', name='lasmot2') # give descriptions later
+#             lasmot3 = Newport('MFX:LAS:MMN:03', name='lasmot3')
+#             lasmot4 = Newport('MFX:LAS:MMN:04', name='lasmot4')
+#             lasmot5 = Newport('MFX:LAS:MMN:05', name='lasmot5')
+#             lasmot7 = Newport('MFX:LAS:MMN:07', name='lasmot7')
+#             lasmot8 = Newport('MFX:LAS:MMN:08', name='lasmot8')
+#             lens_v = Newport('MFX:LAS:MMN:05', name='lens_v')
+#             lens_f = Newport('MFX:LAS:MMN:10', name='lens_f')
+#             lens_h = Newport('MFX:LAS:MMN:04', name='lens_h')
+#             lens_g = Newport('MFX:LAS:MMN:12', name='lens_g')
+#
+#         with safe_load('Fast delay encoders'):
+#             lxt_fast1_enc = UsDigitalUsbEncoder('MFX:USDUSB4:01:CH0', name='lxt_fast_enc1', linked_axis=mfx_lxt_fast1)
+#
+#         # timing virtual motors for x-ray laser delay adjustment
+#         lxt = lxt # virtual motor that moves the laser timing system phase shifter
+#         txt = txt
+#         lxt_ttc = lxt_ttc
+#         lxt_fast1 = mfx_lxt_fast1
+
+#aliases added by Leland 071523
+with safe_load('Make Aliases'):
+    from mfx.db import mfx_attenuator as att
+    from mfx.db import mfx_dg1_slits as s1
+    from mfx.db import mfx_dg2_upstream_slits as s2
+    from mfx.db import mfx_dg2_midstream_slits as s3
+    from mfx.db import mfx_dg2_downstream_slits as s4
+    from mfx.db import mfx_dia_pim as yag0
+    from mfx.db import mfx_dg1_pim as yag1
+    from mfx.db import mfx_dg2_pim as yag2
+    from mfx.db import at1l0 as fat1
+    from mfx.db import at2l0 as fat2
+    from mfx.db import mec_yag0_mfx as mec_yag0
+    from mfx.db import mfx_dia_ipm as ipm0
+    from mfx.db import mfx_dg1_ipm as ipm1
+    from mfx.db import mfx_dg2_ipm as ipm2
+    from mfx.db import mfx_pulsepicker as pp
+    #from mfx.db import mfx_prefocus as crl1
+    crl1=mfx_prefocus
+    from mfx.db import um6_ipm as xcs_yag1
+    from mfx.db import hx2_slits as xpp_s1
+    from mfx.db import mfx_von_hamos_6crystal as vh
+    import numpy as np
+    from importlib import reload
+    from mfx.db import mfx_atm as tt
+    lens_v=las.lens_v
+    lens_h=las.lens_h
+    lens_f=las.lens_f

--- a/tfs/lens.py
+++ b/tfs/lens.py
@@ -183,19 +183,22 @@ class MFXLens(InOutPVStatePositioner, LensCalcMixin):
     y = FCpt(OnePVMotorRetry, '{y_pv}', kind='normal')
 
     def __init__(self, prefix, **kwargs):
-        if 'TFS' not in prefix:
-            self.x_pv = None
-            self.y_pv = None
-        else:
-            lens_num = _parse_lens_number(prefix)
+        # Only assign X/Y motor PVs for true TFS lenses of the form ":TFS:##"
+        # Prefocus lenses (":DIA:##") should not use the TFS X/Y motor map.
+        m = re.search(r":(TFS|DIA):(\d+)$", prefix)
+        if m and m.group(1) == 'TFS':
+            lens_num = int(m.group(2))
             try:
                 mapping = LENS_MOTOR_PVS[lens_num]
             except KeyError:
-                raise ValueError(f"Unknown lens number {lens_num} parsed from prefix {prefix}")
+                raise ValueError(f"Unknown TFS lens number {lens_num} parsed from prefix {prefix}")
             self.x_pv = mapping['x']
             self.y_pv = mapping['y']
+        else:
+            # For DIA or any non-matching suffix, do not configure X/Y PVs
+            self.x_pv = None
+            self.y_pv = None
         super().__init__(prefix, **kwargs)
-        
 
     @property
     def radius(self):

--- a/tfs/sim_transfocator.py
+++ b/tfs/sim_transfocator.py
@@ -39,7 +39,7 @@ class SimTransfocator(FakeTransfocator):
     tfs_09 = Cpt(SimLens, ":TFS:09")
     tfs_10 = Cpt(SimLens, ":TFS:10")
 
-def make_tfs_sim(tfs, prefix="SIM:TFS", name="tfs_sim"):
+def make_tfs_sim(tfs, prefix="SIM:", name="tfs_sim"):
     stage = Stage(name="stage")
     stage.set(tfs.translation.position).wait()
     stage.high_limit = tfs.translation.high_limit

--- a/tfs/sim_transfocator.py
+++ b/tfs/sim_transfocator.py
@@ -1,0 +1,70 @@
+from ophyd import Component as Cpt
+from ophyd.sim import SynAxis, FakeEpicsSignal, make_fake_device
+from tfs.transfocator import Transfocator
+from tfs.lens import MFXLens as RealLens
+
+class SimLens(RealLens):
+    _sig_z      = Cpt(FakeEpicsSignal,  ":Z",      auto_monitor=True)
+    _sig_radius = Cpt(FakeEpicsSignal,  ":RADIUS", auto_monitor=True)
+    _sig_focus  = Cpt(FakeEpicsSignal,  ":FOCUS",  auto_monitor=True)
+
+class Stage(SynAxis):
+    def attach(self, tfs_dev):
+        self._lenses = [
+            getattr(tfs_dev, nm)
+            for nm in tfs_dev.component_names
+            if isinstance(getattr(tfs_dev, nm), SimLens)
+        ]
+
+    def mv(self, value):
+        delta = value - self.position
+        st = self.set(value); st.wait()
+        for l in getattr(self, "_lenses", []):
+            l._sig_z.set(l._sig_z.get() + delta).wait()
+        return st
+
+FakeTransfocator = make_fake_device(Transfocator)
+
+class SimTransfocator(FakeTransfocator):
+    prefocus_top = Cpt(SimLens, ":DIA:03")
+    prefocus_mid = Cpt(SimLens, ":DIA:02")
+    prefocus_bot = Cpt(SimLens, ":DIA:01")
+    tfs_02 = Cpt(SimLens, ":TFS:02")
+    tfs_03 = Cpt(SimLens, ":TFS:03")
+    tfs_04 = Cpt(SimLens, ":TFS:04")
+    tfs_05 = Cpt(SimLens, ":TFS:05")
+    tfs_06 = Cpt(SimLens, ":TFS:06")
+    tfs_07 = Cpt(SimLens, ":TFS:07")
+    tfs_08 = Cpt(SimLens, ":TFS:08")
+    tfs_09 = Cpt(SimLens, ":TFS:09")
+    tfs_10 = Cpt(SimLens, ":TFS:10")
+
+def make_tfs_sim(tfs, prefix="SIM:TFS", name="tfs_sim"):
+    stage = Stage(name="stage")
+    stage.set(tfs.translation.position).wait()
+    stage.high_limit = tfs.translation.high_limit
+    stage.low_limit  = tfs.translation.low_limit
+
+    def _translation(self):
+        return stage
+    SimTransfocator.translation = property(_translation)
+
+    tfs_sim = SimTransfocator(prefix=prefix, name=name)
+    stage.attach(tfs_sim)
+
+    for i in range(2, 10):
+        real, sim = getattr(tfs, f"tfs_0{i}"), getattr(tfs_sim, f"tfs_0{i}")
+        sim._sig_z.set(float(real.z)).wait()
+        sim._sig_radius.set(float(real.radius)).wait()
+
+    real, sim = getattr(tfs, "tfs_10"), getattr(tfs_sim, "tfs_10")
+    sim._sig_z.set(float(real.z)).wait()
+    sim._sig_radius.set(float(real.radius)).wait()
+
+    for nm in ("prefocus_bot", "prefocus_mid", "prefocus_top"):
+        real, sim = getattr(tfs, nm), getattr(tfs_sim, nm)
+        sim._sig_z.set(float(real.z)).wait()
+        sim._sig_radius.set(float(real.radius)).wait()
+
+    return tfs_sim
+

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -484,45 +484,89 @@ class MFXTransfocator(TransfocatorBase):
           position and recompute the lens combo at that energy, then continue.
         """
         if not energies:
-            logger.error("No energies provided")
+            print("No energies provided.")
             return None
 
-        # Translation stage and limits
         stage = self.translation
         z_high = stage.high_limit
         z_low = stage.low_limit
 
-        # Start near the high limit
         z_top_mm = z_high - margin_mm
         stage.mv(z_top_mm)
+        print(f"Stage limits: low={z_low:.3f} mm, high={z_high:.3f} mm, margin={margin_mm:.3f} mm")
+        print(f"Stage moved to starting position: z={z_top_mm:.3f} mm")
 
-        # Initial combo and reference length
         E_start = energies[0]
         combo = self.find_best_combo(energy_eV=E_start, show=show)
-        # TODO: insert lenses
         reference_length = focal_length(radius=combo.tfs_radius, energy=E_start)
+        print(f"Initial energy: {E_start:.2f} eV, reference focal length: {reference_length:.3f} mm")
+
+        def _inserted_lenses_from_combo(c):
+            lenses = getattr(c, "lenses", c)
+            inserted = []
+            for lens in lenses:
+                try:
+                    state = lens._inserted.get()
+                    if state == 1:
+                        inserted.append(lens.prefix)
+                except Exception:
+                    pass
+            return inserted
+
+        current_z = z_top_mm
+        results = []
+        results.append({
+            "energy": E_start,
+            "inserted_lenses": _inserted_lenses_from_combo(combo),
+            "z_position": current_z,
+        })
 
         for E in energies[1:]:
-            # Compute focal length for current combo at this energy
-            tentative_length = focal_length(radius=combo.tfs_radius, energy=E)
-            tentative_target = z_top_mm - (tentative_length - reference_length)
+            f_len = focal_length(radius=combo.tfs_radius, energy=E)
+            target = z_top_mm - (f_len - reference_length)
+            print(f"Energy {E:.2f} eV: computed focal length = {f_len:.3f} mm, target z = {target:.3f} mm")
 
-            if tentative_target > (z_low + margin_mm):
-                # Safe to move stage
-                stage.mv(tentative_target)
+            if target > (z_low + margin_mm):
+                print(f"Moving stage to {target:.3f} mm (same lens combo).")
+                stage.mv(target)
+                current_z = target
+                results.append({
+                    "energy": E,
+                    "inserted_lenses": _inserted_lenses_from_combo(combo),
+                    "z_position": current_z,
+                })
             else:
-                # Out of stage travel: return to top and recompute combo
+                print("Target below low limit margin. Returning to top and recomputing lens combo.")
                 stage.mv(z_top_mm)
+                current_z = z_top_mm
                 combo = self.find_best_combo(energy_eV=E, show=show)
-                # TODO: insert lenses
-                # Compare new focal length to starting one and adjust z stage
-                new_length = focal_length(radius=combo.tfs_radius, energy=E)
-                new_target = z_top_mm - (new_length - reference_length)
+
+                new_f = focal_length(radius=combo.tfs_radius, energy=E)
+                new_target = z_top_mm - (new_f - reference_length)
+                print(f"New combo: focal length = {new_f:.3f} mm, new target z = {new_target:.3f} mm")
+
                 if new_target < (z_low + margin_mm):
-                    logger.error("Stage is out of travel, cannot compensate for energy change")
-                    # TODO: what to do here?
-                    return None
+                    print("Stage out of travel range. Cannot compensate further.")
+                    results.append({
+                        "energy": E,
+                        "inserted_lenses": _inserted_lenses_from_combo(combo),
+                        "z_position": current_z,
+                    })
+                    return results
+
+                print(f"Moving stage to {new_target:.3f} mm (new combo).")
                 stage.mv(new_target)
+                current_z = new_target
+                results.append({
+                    "energy": E,
+                    "inserted_lenses": _inserted_lenses_from_combo(combo),
+                    "z_position": current_z,
+                })
+
+        print(f"Tracking complete. Final energy: {results[-1]['energy']:.2f} eV, stage position: {results[-1]['z_position']:.3f} mm.")
+        print(f"Lenses currently inserted: {results[-1]['inserted_lenses']}")
+        return results
+
 
 class Transfocator(MFXTransfocator):
     pass

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -513,7 +513,7 @@ class MFXTransfocator(TransfocatorBase):
 
         for E in energies[1:]:
             f_len = focal_length(radius=combo.tfs_radius, energy=E)
-            target = z_top_mm - (f_len - reference_length)
+            target = z_top_mm - (f_len - reference_length)*1000
             print(f"Energy {E:.2f} eV: computed focal length = {f_len:.3f}, target z = {target:.3f}")
 
             if target > (z_low + margin_mm):
@@ -532,7 +532,7 @@ class MFXTransfocator(TransfocatorBase):
                 combo = self.find_best_combo(energy_eV=E, show=show)
 
                 new_f = focal_length(radius=combo.tfs_radius, energy=E)
-                new_target = z_top_mm - (new_f - reference_length)
+                new_target = z_top_mm - (new_f - reference_length)*1000
                 print(f"New combo: focal length = {new_f:.3f}, new target z = {new_target:.3f}")
 
                 if new_target < (z_low + margin_mm):

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -1,5 +1,7 @@
 import math
 import logging
+from pathlib import Path
+import json
 
 from pcdsdevices.device_types import IMS
 from ophyd import (Device, EpicsSignalRO, Component as Cpt,
@@ -493,13 +495,13 @@ class MFXTransfocator(TransfocatorBase):
 
         z_top_mm = z_high - margin_mm
         stage.mv(z_top_mm)
-        print(f"Stage limits: low={z_low:.3f} mm, high={z_high:.3f} mm, margin={margin_mm:.3f} mm")
-        print(f"Stage moved to starting position: z={z_top_mm:.3f} mm")
+        print(f"Stage limits: low={z_low:.3f}, high={z_high:.3f}, margin={margin_mm:.3f}")
+        print(f"Stage moved to starting position: z={z_top_mm:.3f}")
 
         E_start = energies[0]
         combo = self.find_best_combo(energy_eV=E_start, show=show)
         reference_length = focal_length(radius=combo.tfs_radius, energy=E_start)
-        print(f"Initial energy: {E_start:.2f} eV, reference focal length: {reference_length:.3f} mm")
+        print(f"Initial energy: {E_start:.2f} eV, reference focal length: {reference_length:.3f}")
 
         current_z = z_top_mm
         results = []
@@ -512,10 +514,10 @@ class MFXTransfocator(TransfocatorBase):
         for E in energies[1:]:
             f_len = focal_length(radius=combo.tfs_radius, energy=E)
             target = z_top_mm - (f_len - reference_length)
-            print(f"Energy {E:.2f} eV: computed focal length = {f_len:.3f} mm, target z = {target:.3f} mm")
+            print(f"Energy {E:.2f} eV: computed focal length = {f_len:.3f}, target z = {target:.3f}")
 
             if target > (z_low + margin_mm):
-                print(f"Moving stage to {target:.3f} mm (same lens combo).")
+                print(f"Moving stage to {target:.3f} (same lens combo).")
                 stage.mv(target)
                 current_z = target
                 results.append({
@@ -531,7 +533,7 @@ class MFXTransfocator(TransfocatorBase):
 
                 new_f = focal_length(radius=combo.tfs_radius, energy=E)
                 new_target = z_top_mm - (new_f - reference_length)
-                print(f"New combo: focal length = {new_f:.3f} mm, new target z = {new_target:.3f} mm")
+                print(f"New combo: focal length = {new_f:.3f}, new target z = {new_target:.3f}")
 
                 if new_target < (z_low + margin_mm):
                     print("Stage out of travel range. Cannot compensate further.")
@@ -542,7 +544,7 @@ class MFXTransfocator(TransfocatorBase):
                     })
                     return results
 
-                print(f"Moving stage to {new_target:.3f} mm (new combo).")
+                print(f"Moving stage to {new_target:.3f} (new combo).")
                 stage.mv(new_target)
                 current_z = new_target
                 results.append({
@@ -551,8 +553,13 @@ class MFXTransfocator(TransfocatorBase):
                     "z_position": current_z,
                 })
 
-        print(f"Tracking complete. Final energy: {results[-1]['energy']:.2f} eV, stage position: {results[-1]['z_position']:.3f} mm.")
+        print(f"Tracking complete. Final energy: {results[-1]['energy']:.2f} eV, stage position: {results[-1]['z_position']:.3f}.")
         print(f"Lenses currently inserted: {results[-1]['inserted_lenses']}")
+        
+        save_path = Path.home() / "track_focus_results.json"
+        with open(save_path, "w") as f:
+            json.dump(results, f, indent=4)
+        print(f"Tracking results saved to {save_path}")
         return results
 
 

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -542,7 +542,10 @@ class MFXTransfocator(TransfocatorBase):
                     self.mv_stage_to_pos(shrinking_max_z_stage_mm)
                     combo = self.find_best_combo(energy_eV=energy, show=show)
                     if combo:
-                        break
+                        new_target_z_stage_mm = self.get_z_stage_target(energy, combo, ref_focal_length_um, ref_z_stage_mm)
+                        if new_target_z_stage_mm > min_z_stage_mm:
+                            self.mv_stage_to_target_pos(energy, combo, new_target_z_stage_mm, track_record)
+                            break
                     else:
                         shrinking_max_z_stage_mm -= margin_mm
                 if not combo:
@@ -555,7 +558,7 @@ class MFXTransfocator(TransfocatorBase):
         with open(save_path, "w") as f:
             json.dump(track_record, f, indent=4)
         print(f"Tracking results saved to {save_path}")
-        return results
+        return track_record
 
 
 class Transfocator(MFXTransfocator):

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -470,6 +470,60 @@ class MFXTransfocator(TransfocatorBase):
 
         return schedule
 
+    def track_focus(self, energies, *, margin_mm=10.0, show=False):
+        """
+        Keep the focal length fixed over a provided list of energies by
+        compensating with the translation stage. Lenses are NOT actuated.
+
+        Workflow:
+        - Move stage to high limit minus a small margin.
+        - Compute initial lens combo and reference focal length.
+        - For each next energy, compute focal length for the current combo and
+          move the stage to compensate.
+        - If the move would exceed the stage low limit, return to the top
+          position and recompute the lens combo at that energy, then continue.
+        """
+        if not energies:
+            logger.error("No energies provided")
+            return None
+
+        # Translation stage and limits
+        stage = self.translation
+        z_high = stage.high_limit
+        z_low = stage.low_limit
+
+        # Start near the high limit
+        z_top_mm = z_high - margin_mm
+        stage.mv(z_top_mm)
+
+        # Initial combo and reference length
+        E_start = energies[0]
+        combo = self.find_best_combo(energy_eV=E_start, show=show)
+        # TODO: insert lenses
+        reference_length = focal_length(radius=combo.tfs_radius, energy=E_start)
+
+        for E in energies[1:]:
+            # Compute focal length for current combo at this energy
+            tentative_length = focal_length(radius=combo.tfs_radius, energy=E)
+            tentative_target = z_top_mm - (tentative_length - reference_length)
+
+            if tentative_target > (z_low + margin_mm):
+                # Safe to move stage
+                stage.mv(tentative_target)
+            else:
+                # Out of stage travel: return to top and recompute combo
+                stage.mv(z_top_mm)
+                combo = self.find_best_combo(energy_eV=E, show=show)
+                # TODO: insert lenses
+                # Compare new focal length to starting one and adjust z stage
+                new_length = focal_length(radius=combo.tfs_radius, energy=E)
+                new_target = z_top_mm - (new_length - reference_length)
+                if new_target < (z_low + margin_mm):
+                    logger.error("Stage is out of travel, cannot compensate for energy change")
+                    # TODO: what to do here?
+                    return None
+                stage.mv(new_target)
+
 class Transfocator(MFXTransfocator):
     pass
 

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -546,8 +546,7 @@ class MFXTransfocator(TransfocatorBase):
                         if new_target_z_stage_mm > min_z_stage_mm:
                             self.mv_stage_to_target_pos(energy, combo, new_target_z_stage_mm, track_record)
                             break
-                    else:
-                        shrinking_max_z_stage_mm -= margin_mm
+                    shrinking_max_z_stage_mm -= margin_mm
                 if not combo:
                     print("Stage out of travel. Cannot compensate further...")
 

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -501,23 +501,11 @@ class MFXTransfocator(TransfocatorBase):
         reference_length = focal_length(radius=combo.tfs_radius, energy=E_start)
         print(f"Initial energy: {E_start:.2f} eV, reference focal length: {reference_length:.3f} mm")
 
-        def _inserted_lenses_from_combo(c):
-            lenses = getattr(c, "lenses", c)
-            inserted = []
-            for lens in lenses:
-                try:
-                    state = lens._inserted.get()
-                    if state == 1:
-                        inserted.append(lens.prefix)
-                except Exception:
-                    pass
-            return inserted
-
         current_z = z_top_mm
         results = []
         results.append({
             "energy": E_start,
-            "inserted_lenses": _inserted_lenses_from_combo(combo),
+            "inserted_lenses": [lens.prefix for lens in combo.lenses],
             "z_position": current_z,
         })
 
@@ -532,7 +520,7 @@ class MFXTransfocator(TransfocatorBase):
                 current_z = target
                 results.append({
                     "energy": E,
-                    "inserted_lenses": _inserted_lenses_from_combo(combo),
+                    "inserted_lenses": [lens.prefix for lens in combo.lenses],
                     "z_position": current_z,
                 })
             else:
@@ -549,7 +537,7 @@ class MFXTransfocator(TransfocatorBase):
                     print("Stage out of travel range. Cannot compensate further.")
                     results.append({
                         "energy": E,
-                        "inserted_lenses": _inserted_lenses_from_combo(combo),
+                        "inserted_lenses": [lens.prefix for lens in combo.lenses],
                         "z_position": current_z,
                     })
                     return results
@@ -559,7 +547,7 @@ class MFXTransfocator(TransfocatorBase):
                 current_z = new_target
                 results.append({
                     "energy": E,
-                    "inserted_lenses": _inserted_lenses_from_combo(combo),
+                    "inserted_lenses": [lens.prefix for lens in combo.lenses],
                     "z_position": current_z,
                 })
 

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -472,6 +472,43 @@ class MFXTransfocator(TransfocatorBase):
 
         return schedule
 
+    def get_stage_limits(self, margin_mm):
+        stage = self.translation
+        z_high_mm = stage.high_limit
+        z_low_mm = stage.low_limit
+        z_max_mm = z_high_mm - margin_mm
+        z_min_mm = z_low_mm + margin_mm
+        print(f"Stage limits: low={z_low_mm:.3f} mm, high={z_high_mm:.3f} mm, margin={margin_mm:.3f} mm")
+        return z_min_mm, z_max_mm
+
+    def mv_stage_to_pos(self, z_mm):
+        stage = self.translation
+        print(f"Moving stage to position: z={z_mm:.3f}mm")
+        stage.mv(z_mm)
+        print(f"Stage moved to position: z={z_mm:.3f}mm")
+        return z_mm
+
+    def set_reference_combo(self, energy_eV, show=False):
+        combo = self.find_best_combo(energy_eV=energy_eV, show=show)
+        ref_focal_length_um = focal_length(combo.tfs_radius, energy=energy_eV)
+        print(f"Reference energy: {energy_eV:.2f} eV, reference focal length: {ref_focal_length_um:.3f} um")
+        return combo, ref_focal_length_um
+
+    def get_z_stage_target(self, energy_eV, combo, ref_focal_length_um, ref_z_stage_mm):
+        focal_length_um = focal_length(combo.tfs_radius, energy=energy_eV)
+        z_stage_target_mm = ref_z_stage_mm - (focal_length_um - ref_focal_length_um) * 1000
+        print(f"Energy {energy_eV:.2f} eV: computed focal length = {focal_length_um:.3f} um, target z = {z_stage_target_mm:.3f} mm.")
+        return z_stage_target_mm
+
+    def mv_stage_to_target_pos(self, energy_eV, combo, target_z_mm, track_record):
+        print(f"Moving stage to {target_z_mm:.3f} mm.")
+        stage.mv(target_z_mm)
+        track_record.append({
+            "energy": energy_eV,
+            "inserted_lenses": [lens.prefix for lens in combo.lenses],
+            "z_position": target_z_mm
+        })
+
     def track_focus(self, energies, *, margin_mm=10.0, show=False):
         """
         Keep the focal length fixed over a provided list of energies by
@@ -489,76 +526,33 @@ class MFXTransfocator(TransfocatorBase):
             print("No energies provided.")
             return None
 
-        stage = self.translation
-        z_high = stage.high_limit
-        z_low = stage.low_limit
+        min_z_stage_mm, max_z_stage_mm = self.get_stage_limits(margin_mm)
+        ref_z_stage_mm = self.mv_stage_to_pos(max_z_stage_mm)
+        combo, ref_focal_length_um = self.set_reference_combo(energies[0], show=show)
+        track_record = []
 
-        z_top_mm = z_high - margin_mm
-        stage.mv(z_top_mm)
-        print(f"Stage limits: low={z_low:.3f}, high={z_high:.3f}, margin={margin_mm:.3f}")
-        print(f"Stage moved to starting position: z={z_top_mm:.3f}")
-
-        E_start = energies[0]
-        combo = self.find_best_combo(energy_eV=E_start, show=show)
-        reference_length = focal_length(radius=combo.tfs_radius, energy=E_start)
-        print(f"Initial energy: {E_start:.2f} eV, reference focal length: {reference_length:.3f}")
-
-        current_z = z_top_mm
-        results = []
-        results.append({
-            "energy": E_start,
-            "inserted_lenses": [lens.prefix for lens in combo.lenses],
-            "z_position": current_z,
-        })
-
-        for E in energies[1:]:
-            f_len = focal_length(radius=combo.tfs_radius, energy=E)
-            target = z_top_mm - (f_len - reference_length)*1000
-            print(f"Energy {E:.2f} eV: computed focal length = {f_len:.3f}, target z = {target:.3f}")
-
-            if target > (z_low + margin_mm):
-                print(f"Moving stage to {target:.3f} (same lens combo).")
-                stage.mv(target)
-                current_z = target
-                results.append({
-                    "energy": E,
-                    "inserted_lenses": [lens.prefix for lens in combo.lenses],
-                    "z_position": current_z,
-                })
+        for energy in energies:
+            target_z_stage_mm = self.get_z_stage_target(energy, combo, ref_focal_length_um, ref_z_stage_mm)
+            if target_z_stage_mm > min_z_stage_mm:
+                self.mv_stage_to_target_pos(energy, combo, target_z_stage_mm, track_record)
             else:
-                print("Target below low limit margin. Returning to top and recomputing lens combo.")
-                stage.mv(z_top_mm)
-                current_z = z_top_mm
-                combo = self.find_best_combo(energy_eV=E, show=show)
+                shrinking_max_z_stage_mm = max_z_stage_mm
+                while shrinking_max_z_stage_mm > min_z_stage_mm:
+                    self.mv_stage_to_pos(shrinking_max_z_stage_mm)
+                    combo = self.find_best_combo(energy_eV=energy, show=show)
+                    if combo:
+                        break
+                    else:
+                        shrinking_max_z_stage_mm -= margin_mm
+                if not combo:
+                    print("Stage out of travel. Cannot compensate further...")
 
-                new_f = focal_length(radius=combo.tfs_radius, energy=E)
-                new_target = z_top_mm - (new_f - reference_length)*1000
-                print(f"New combo: focal length = {new_f:.3f}, new target z = {new_target:.3f}")
-
-                if new_target < (z_low + margin_mm):
-                    print("Stage out of travel range. Cannot compensate further.")
-                    results.append({
-                        "energy": E,
-                        "inserted_lenses": [lens.prefix for lens in combo.lenses],
-                        "z_position": current_z,
-                    })
-                    return results
-
-                print(f"Moving stage to {new_target:.3f} (new combo).")
-                stage.mv(new_target)
-                current_z = new_target
-                results.append({
-                    "energy": E,
-                    "inserted_lenses": [lens.prefix for lens in combo.lenses],
-                    "z_position": current_z,
-                })
-
-        print(f"Tracking complete. Final energy: {results[-1]['energy']:.2f} eV, stage position: {results[-1]['z_position']:.3f}.")
-        print(f"Lenses currently inserted: {results[-1]['inserted_lenses']}")
+        print(f"Tracking complete. Final energy: {track_record[-1]['energy']:.2f} eV, stage position: {track_record[-1]['z_position']:.3f} mm.")
+        print(f"Lenses currently inserted: {track_record[-1]['inserted_lenses']}")
         
         save_path = Path.home() / "track_focus_results.json"
         with open(save_path, "w") as f:
-            json.dump(results, f, indent=4)
+            json.dump(track_record, f, indent=4)
         print(f"Tracking results saved to {save_path}")
         return results
 

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -501,6 +501,7 @@ class MFXTransfocator(TransfocatorBase):
         return z_stage_target_mm
 
     def mv_stage_to_target_pos(self, energy_eV, combo, target_z_mm, track_record):
+        stage = self.translation
         print(f"Moving stage to {target_z_mm:.3f} mm.")
         stage.mv(target_z_mm)
         track_record.append({


### PR DESCRIPTION
This PR is associated to issue #229 

We added a function to keep the focal length fixed over a provided list of energies by compensating with the translation stage. Lenses are NOT actuated.

Workflow:
- Move stage to high limit minus a small margin.
- Compute initial lens combo and reference focal length.
- For each next energy, compute focal length for the current combo and
  move the stage to compensate.
- If the move would exceed the stage low limit, return to the top
  position and recompute the lens combo at that energy, then continue.


Initial test in simulation (the radii and z positions are initialised to 0 for a fake device):


```python
In [40]: from ophyd.sim import SynAxis, make_fake_device
    ...: from tfs.transfocator import Transfocator
    ...: 
    ...: 
    ...: class Stage(SynAxis):
    ...:     def mv(self, value):
    ...:         return self.set(value)
    ...: 
    ...: stage = Stage(name="stage", value=0.0)
    ...: stage.high_limit = 200.0
    ...: stage.low_limit = 0.0
    ...: 
    ...: FakeTransfocator = make_fake_device(Transfocator)
    ...: 
    ...: class TestTransfocator(FakeTransfocator):
    ...:     @property
    ...:     def translation(self):
    ...:         return stage
    ...: 
    ...: tfs = TestTransfocator(prefix="SIM:TFS", name="tfs")
    ...: 
    ...: energies = [7050, 7100, 7150]
    ...: tfs.track_focus(energies, margin_mm=5.0)
Pre-focussing lens for 7050 eV:
FakeMFXLens(SIM:TFS:DIA:01, name=tfs_prefocus_bot)
Radius: 0 um

Pre-focussing lens for 7050 eV:
FakeMFXLens(SIM:TFS:DIA:01, name=tfs_prefocus_bot)
Radius: 0 um

+----------------+--------+---+
| Prefix         | Radius | Z |
+----------------+--------+---+
| SIM:TFS:DIA:01 | 0      | 0 |
| SIM:TFS:DIA:03 | 0      | 0 |
| SIM:TFS:DIA:02 | 0      | 0 |
+----------------+--------+---+


```