### PR TITLE
EXAFS - introduces calib method for undulator pointing

### DIFF
--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -12,7 +12,7 @@ from xopt import Xopt
 from sklearn.linear_model import LinearRegression
 from .errors import FeasibilityError
 from .plots import UpdatingDeviceCentroidPathPlot, UpdatingXoptVisualizeModelPlot
-from .type_checking import validate_w_lowercase_args, Diagnostics, Methods, Devices, Turbo, Movers
+from .type_checking import validate_w_lowercase_args, Diagnostics, Packages, Methods, Devices, Turbo, Movers
 from .user_select import select_diagnostic, select_goal, MP_KEY, UNDP_KEY_X, UNDP_KEY_Y
 from .constraints import constraint_data
 from .utils import snake_order
@@ -92,7 +92,8 @@ class Beam:
             fig.tight_layout()
             plot_path = str(out_dir / f"calib_scatter_{on_diagnostic}_{ts}.png")
             fig.savefig(plot_path, dpi=120)
-            plt.close(fig)
+            plt.show(block=False)
+            plt.pause(0.001)
             print(f"[calibrate] Wrote scatter plot: {plot_path}")
         except Exception as exc:
             print(f"[calibrate] Warning: failed to save plot: {exc}")
@@ -159,10 +160,6 @@ class Beam:
         Run grid scan over undp_x/undp_y, fit linear model, save coefficients.
         Returns the calibration dict.
         """
-        # Set safe bounds for undulator
-        xopt_obj.vocs.variables[UNDP_KEY_X] = [0, 200]
-        xopt_obj.vocs.variables[UNDP_KEY_Y] = [-450, -200]
-
         # Build grid in the VOCS variable space, then evaluate via connected evaluator
         df_grid = xopt_obj.vocs.grid_inputs(n=grid_bins)
         print(f"[calibrate] Grid inputs generated: shape={df_grid.shape}")
@@ -200,7 +197,11 @@ class Beam:
         grid_csv = None
         try:
             grid_csv = str(out_dir / f"calib_grid_{on_diagnostic}_{ts}.csv")
-            res[[UNDP_KEY_X, UNDP_KEY_Y, "centroid_x", "centroid_y"]].to_csv(grid_csv, index=False)
+            cols = [UNDP_KEY_X, UNDP_KEY_Y, "centroid_x", "centroid_y"]
+            for extra_col in ("wave8_x", "wave8_y", "wave8_sum"):
+                if extra_col in res.columns:
+                    cols.append(extra_col)
+            res[cols].to_csv(grid_csv, index=False)
             print(f"[calibrate] Wrote grid preview CSV: {grid_csv}")
         except Exception as exc:
             print(f"[calibrate] Warning: failed to write grid CSV: {exc}")
@@ -240,29 +241,41 @@ class Beam:
         """Calibrate, fit linear model, solve for undulator position"""
         if mover != "und":
             raise ValueError(f"Only 'und' mover is supported for calibration.")
-        if using_device != "yag":
-            raise ValueError(f"Only 'yag' device is supported for calibration.")
+        # if using_device != "yag":
+        #     raise ValueError(f"Only 'yag' device is supported for calibration.")
         if not isinstance(goal, tuple) or len(goal) != 2:
             raise ValueError(f"Goal must be a tuple of two floats.")
 
         from .xopt_scans import evaluator_move
         
         print(f"[_calib] Checking calibration freshness...")
-        fresh = self.check_calibration(on_diagnostic=on_diagnostic, xopt_obj=xopt, threshold_sigma=2.0)
-        if fresh: 
+        fresh = self.check_calibration(
+            on_diagnostic=on_diagnostic, xopt_obj=xopt, threshold_sigma=2.0
+        )
+        if fresh:
             calib = self._load_calibration(on_diagnostic)
-            print(f"[_calib] Calibration is fresh, using calibration from {calib.get('timestamp')}")
+            print(
+                f"[_calib] Calibration is fresh, using calibration from {calib.get('timestamp')}"
+            )
         else:
-            print(f"[_calib] Calibration is stale, running calibrate() with grid_bins={grid_bins}...")
-            calib = self.calibrate(xopt_obj=xopt, on_diagnostic=on_diagnostic, grid_bins=grid_bins)
+            print(
+                f"[_calib] Calibration is stale, running calibrate() with grid_bins={grid_bins}..."
+            )
+            calib = self.calibrate(
+                xopt_obj=xopt, on_diagnostic=on_diagnostic, grid_bins=grid_bins
+            )
 
         print(f"[_calib] Solving for undulator position to achieve goal {goal}...")
         undp_xy = self._undp_solve(goal, calib)
         print(f"[_calib] Moving to undulator position {undp_xy}...")
-        evaluator_move(mover=mover, input={UNDP_KEY_X: undp_xy[0], UNDP_KEY_Y: undp_xy[1]})
+        evaluator_move(
+            mover=mover, input={UNDP_KEY_X: undp_xy[0], UNDP_KEY_Y: undp_xy[1]}
+        )
         return xopt
 
-    def _turbo(self, xopt, path_plot, xopt_rand_evaluate, xopt_steps, mover, xopt_turbo_option):
+    def _turbo(
+        self, xopt, path_plot, xopt_rand_evaluate, xopt_steps, mover, xopt_turbo_option
+    ):
         """Execute turbo optimization method."""
         from .xopt_scans import evaluator_move, get_variables
         
@@ -338,27 +351,27 @@ class Beam:
 
     @validate_w_lowercase_args
     def align(
-            self,
-            with_goal: Optional[float] = None,
-            on_diagnostic: Diagnostics = "dg1",
-            with_package: Methods = "xopt",
-            with_method: str = "turbo",
-            using_device: Devices = "yag",
-            mover: Movers = "mirr",
-            xopt_turbo_option: Turbo = "safety",
-            xopt_rand_evaluate: int = 3,
-            xopt_steps: int = 10,
-            xopt_max_iter: int = 2000,
-            blop_qr_n: int = 16,
-            blop_qei_n: int = 16,
-            blop_qei_iterations: int = 5,
-            use_2d_markers: bool = False,
-            with_goal_2d: Optional[tuple[float, float]] = None,
-            xopt_obj: Optional[Xopt] = None,
-            save_run: bool = True,
-            num_frames: int = 1,
-            grid_bins: int = 5
-            ):
+        self,
+        with_goal: Optional[float] = None,
+        on_diagnostic: Diagnostics = "dg1",
+        with_package: Packages = "xopt",
+        with_method: Methods = "turbo",
+        using_device: Devices = "yag",
+        mover: Movers = "mirr",
+        xopt_turbo_option: Turbo = "optimize",  # changed from safety to optimize to allow for wave8 optimization (which currently doesn't have constraints)
+        xopt_rand_evaluate: int = 3,
+        xopt_steps: int = 10,
+        xopt_max_iter: int = 2000,
+        blop_qr_n: int = 16,
+        blop_qei_n: int = 16,
+        blop_qei_iterations: int = 5,
+        use_2d_markers: bool = False,
+        with_goal_2d: Optional[tuple[float, float]] = None,
+        xopt_obj: Optional[Xopt] = None,
+        save_run: bool = True,
+        num_frames: int = 1,
+        grid_bins: int = 5,
+    ):
         """Perform Beam Alignment
 
         Parameters
@@ -401,9 +414,20 @@ class Beam:
         grid_bins: int, optional
             Number of grid bins for calibration. Default is 5.
         """
-        # Validate goal with not doing 2d optimization using camera markers
-        if (using_device=="wave8" or not use_2d_markers) and not with_goal:
-            raise ValueError("Must provide parameter with_goal (float) for running YAG or wave8 optimization.")
+        # Validate goals
+        if using_device == "wave8" and (with_goal is None and with_goal_2d is None):
+            raise ValueError(
+                "Wave8 requires with_goal (float) or with_goal_2d (tuple[float,float])."
+            )
+        if (
+            using_device == "yag"
+            and (not use_2d_markers)
+            and (with_goal is None)
+            and (with_goal_2d is None)
+        ):
+            raise ValueError(
+                "YAG requires with_goal (float) or with_goal_2d, or use_2d_markers=True."
+            )
 
         path_plot = None
         if with_package == "xopt":
@@ -445,18 +469,18 @@ class Beam:
                     dump_file=dump_file,
                     num_frames=num_frames,
                 )
+                goal = select_goal(
+                    device_type=using_device,
+                    location=on_diagnostic,
+                    goal=with_goal,
+                    goal_2d=with_goal_2d,
+                    use_2d_markers=use_2d_markers,
+                )
                 if using_device == "yag":
                     print("Generating path plot")
-                    goal = select_goal(
-                            device_type=using_device,
-                            location=on_diagnostic,
-                            goal=with_goal,
-                            goal_2d=with_goal_2d,
-                            use_2d_markers=use_2d_markers,
-                        )
                     path_plot = UpdatingDeviceCentroidPathPlot(
                         imager=select_diagnostic("yag", on_diagnostic),
-                        goal= goal,
+                        goal=goal,
                         constraints=constraint_data.yag.get(on_diagnostic),
                     )
                     xopt._cached_path_plot = path_plot

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -1,23 +1,348 @@
 import traceback
 import datetime
+import time
+import json
 from typing import Optional
+import numpy as np
+import pandas as pd
 from pathlib import Path
 from pydantic import validate_call
 from bluesky import RunEngine
 from xopt import Xopt
+from sklearn.linear_model import LinearRegression
 from .errors import FeasibilityError
 from .plots import UpdatingDeviceCentroidPathPlot, UpdatingXoptVisualizeModelPlot
 from .type_checking import validate_w_lowercase_args, Diagnostics, Methods, Devices, Turbo, Movers
-from .user_select import select_diagnostic, select_goal
+from .user_select import select_diagnostic, select_goal, MP_KEY, UNDP_KEY_X, UNDP_KEY_Y
 from .constraints import constraint_data
+from .utils import snake_order
 
 class Beam:
+
+    def _predict_centroid(self, undp_xy: tuple[float, float], calib: dict) -> tuple[float, float]:
+        """Predict centroid from undulator position using calibration coefficients."""
+        a0, a1, a2 = calib["coeff_x"]
+        b0, b1, b2 = calib["coeff_y"]
+        ux, uy = undp_xy
+        pred_x = a0 + a1 * ux + a2 * uy
+        pred_y = b0 + b1 * ux + b2 * uy
+        return (float(pred_x), float(pred_y))
+
+    def _undp_solve(self, goal: tuple[float, float], calib: dict) -> tuple[float, float]:
+        """
+        Solve for undp_x, undp_y that achieve target centroid given calibration.
+        """
+        a0, a1, a2 = calib["coeff_x"]
+        b0, b1, b2 = calib["coeff_y"]
+        M = np.array([[a1, a2], [b1, b2]], dtype=float)
+        rhs = np.array([goal[0] - a0, goal[1] - b0], dtype=float)
+        sol = np.linalg.solve(M, rhs)
+        return (float(sol[0]), float(sol[1]))
+
+    
+    def _save_calibration_plots(self, res, reg_x, reg_y, out_dir, on_diagnostic, ts):
+        """Save calibration plots to file."""
+        plot_path = None
+        try:
+            import matplotlib.pyplot as plt
+            fig, axs = plt.subplots(2, 2, figsize=(10, 8))
+
+            undp_x = res[UNDP_KEY_X]
+            undp_y = res[UNDP_KEY_Y]
+            cent_x = res["centroid_x"]
+            cent_y = res["centroid_y"]
+
+            undp_x_range = np.linspace(undp_x.min(), undp_x.max(), 100)
+            undp_y_range = np.linspace(undp_y.min(), undp_y.max(), 100)
+            undp_x_mean = float(undp_x.mean())
+            undp_y_mean = float(undp_y.mean())
+
+            # centroid_x vs undp_x (vary undp_x, hold undp_y at mean)
+            axs[0, 0].scatter(undp_x, cent_x, s=20)
+            X_line = np.column_stack([undp_x_range, np.full_like(undp_x_range, undp_y_mean)])
+            axs[0, 0].plot(undp_x_range, reg_x.predict(X_line), 'r--', linewidth=1)
+            axs[0, 0].set_xlabel("undp_x [um]")
+            axs[0, 0].set_ylabel("centroid_x [px]")
+            axs[0, 0].set_title("centroid_x vs undp_x")
+
+            # centroid_x vs undp_y (vary undp_y, hold undp_x at mean)
+            axs[0, 1].scatter(undp_y, cent_x, s=20, color="orange")
+            X_line = np.column_stack([np.full_like(undp_y_range, undp_x_mean), undp_y_range])
+            axs[0, 1].plot(undp_y_range, reg_x.predict(X_line), 'r--', linewidth=1)
+            axs[0, 1].set_xlabel("undp_y [um]")
+            axs[0, 1].set_ylabel("centroid_x [px]")
+            axs[0, 1].set_title("centroid_x vs undp_y")
+
+            # centroid_y vs undp_x (vary undp_x, hold undp_y at mean)
+            axs[1, 0].scatter(undp_x, cent_y, s=20, color="green")
+            Y_line = np.column_stack([undp_x_range, np.full_like(undp_x_range, undp_y_mean)])
+            axs[1, 0].plot(undp_x_range, reg_y.predict(Y_line), 'r--', linewidth=1)
+            axs[1, 0].set_xlabel("undp_x [um]")
+            axs[1, 0].set_ylabel("centroid_y [px]")
+            axs[1, 0].set_title("centroid_y vs undp_x")
+
+            # centroid_y vs undp_y (vary undp_y, hold undp_x at mean)
+            axs[1, 1].scatter(undp_y, cent_y, s=20, color="purple")
+            Y_line = np.column_stack([np.full_like(undp_y_range, undp_x_mean), undp_y_range])
+            axs[1, 1].plot(undp_y_range, reg_y.predict(Y_line), 'r--', linewidth=1)
+            axs[1, 1].set_xlabel("undp_y [um]")
+            axs[1, 1].set_ylabel("centroid_y [px]")
+            axs[1, 1].set_title("centroid_y vs undp_y")
+
+            fig.tight_layout()
+            plot_path = str(out_dir / f"calib_scatter_{on_diagnostic}_{ts}.png")
+            fig.savefig(plot_path, dpi=120)
+            plt.close(fig)
+            print(f"[calibrate] Wrote scatter plot: {plot_path}")
+        except Exception as exc:
+            print(f"[calibrate] Warning: failed to save plot: {exc}")
+        return plot_path
+
+    def _load_calibration(self, on_diagnostic: Diagnostics) -> Optional[dict]:
+        """Load most recent calibration coefficients for the given diagnostic."""
+        try:
+            root = Path(__file__).parent.parent.parent / "logs" / "xopt" / "calibration"
+            root.mkdir(parents=True, exist_ok=True)
+            candidates = sorted(root.glob(f"calib_{on_diagnostic}_und_yag_*.json"))
+            if not candidates:
+                return None
+            with open(candidates[-1], "r") as f:
+                return json.load(f)
+        except Exception:
+            return None
+
+    def check_calibration(
+        self,
+        on_diagnostic: Diagnostics = "dg1",
+        xopt_obj: Optional[Xopt] = None,
+        threshold_sigma: float = 2.0,
+    ) -> bool:
+        """
+        Predict centroid from current undp_x, undp_y using latest calibration.
+        Return True if error < threshold_sigma * calibration sigma, else False.
+        """
+        calib = self._load_calibration(on_diagnostic)
+        if calib is None:
+            print(f"[check_calibration] No calibration found for {on_diagnostic}")
+            return False
+        print(f"[check_calibration] Loading calibration for {on_diagnostic} from {calib.get('timestamp')}")
+        try:
+            from .xopt_scans import init_devices
+            und = init_devices()["und_abs"]
+            curr_xy = (float(und.xpos.get()), float(und.ypos.get()))
+        except Exception:
+            print(f"[check_calibration] Failed to get current undulator position")
+            return False
+
+        pred = self._predict_centroid(curr_xy, calib)
+
+        if xopt_obj is None:
+            print(f"[check_calibration] No xopt_obj provided")
+            return False
+        df_curr = pd.DataFrame([{UNDP_KEY_X: curr_xy[0], UNDP_KEY_Y: curr_xy[1]}])
+        res = xopt_obj.evaluate_data(df_curr)
+        meas = (float(res["centroid_x"].iat[-1]), float(res["centroid_y"].iat[-1]))
+
+        err = float(np.hypot(pred[0] - meas[0], pred[1] - meas[1]))
+        expected_error = float(calib["sigma_px"])
+        return err < threshold_sigma * expected_error
+
+
+    @validate_w_lowercase_args
+    def calibrate(
+        self,
+        xopt_obj: Xopt,
+        on_diagnostic: Diagnostics = "dg1",
+        grid_bins: int = 5,
+    ) -> dict:
+        """
+        Run grid scan over undp_x/undp_y, fit linear model, save coefficients.
+        Returns the calibration dict.
+        """
+        # Set safe bounds for undulator
+        xopt_obj.vocs.variables[UNDP_KEY_X] = [0, 200]
+        xopt_obj.vocs.variables[UNDP_KEY_Y] = [-450, -200]
+
+        # Build grid in the VOCS variable space, then evaluate via connected evaluator
+        df_grid = xopt_obj.vocs.grid_inputs(n=grid_bins)
+        print(f"[calibrate] Grid inputs generated: shape={df_grid.shape}")
+        df_snake = snake_order(df_grid)
+        print(f"[calibrate] Snaked grid: shape={df_snake.shape}")
+        res = xopt_obj.evaluate_data(df_snake)
+        print(f"[calibrate] Evaluated snaked grid: shape={res.shape}; columns={list(res.columns)}")
+        print(res.head())
+
+        print(f"[calibrate] Fitting linear regression models...")
+        X = res[[UNDP_KEY_X, UNDP_KEY_Y]].to_numpy(dtype=float)
+        yx = res["centroid_x"].to_numpy(dtype=float)
+        yy = res["centroid_y"].to_numpy(dtype=float)
+        
+        reg_x = LinearRegression().fit(X, yx)
+        reg_y = LinearRegression().fit(X, yy)
+        
+        coeff_x = np.concatenate([[reg_x.intercept_], reg_x.coef_])
+        coeff_y = np.concatenate([[reg_y.intercept_], reg_y.coef_])
+
+        pred_x = reg_x.predict(X)
+        pred_y = reg_y.predict(X)
+        err_px = np.hypot(pred_x - yx, pred_y - yy)
+        sigma_px = float(np.std(err_px))
+        sigma_x = float(np.std(pred_x - yx))
+        sigma_y = float(np.std(pred_y - yy))
+
+        print(f"[calibrate] coeff_x: a0={float(coeff_x[0]):.3f}, a1={float(coeff_x[1]):.3f}, a2={float(coeff_x[2]):.3f}")
+        print(f"[calibrate] coeff_y: b0={float(coeff_y[0]):.3f}, b1={float(coeff_y[1]):.3f}, b2={float(coeff_y[2]):.3f}")
+        print(f"[calibrate] sigma_px={sigma_px:.2f}, sigma_x={sigma_x:.2f}, sigma_y={sigma_y:.2f}")
+
+        ts = datetime.datetime.now().strftime("%y-%m-%d-%H:%M:%S")
+        out_dir = Path(__file__).parent.parent.parent / "logs" / "xopt" / "calibration"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        grid_csv = None
+        try:
+            grid_csv = str(out_dir / f"calib_grid_{on_diagnostic}_{ts}.csv")
+            res[[UNDP_KEY_X, UNDP_KEY_Y, "centroid_x", "centroid_y"]].to_csv(grid_csv, index=False)
+            print(f"[calibrate] Wrote grid preview CSV: {grid_csv}")
+        except Exception as exc:
+            print(f"[calibrate] Warning: failed to write grid CSV: {exc}")
+
+        plot_path = self._save_calibration_plots(
+            res=res,
+            reg_x=reg_x,
+            reg_y=reg_y,
+            out_dir=out_dir,
+            on_diagnostic=on_diagnostic,
+            ts=ts,
+        )
+
+        calib = {
+            "diagnostic": on_diagnostic,
+            "timestamp": datetime.datetime.now().isoformat(timespec="seconds"),
+            "coeff_x": [float(v) for v in coeff_x.tolist()],
+            "coeff_y": [float(v) for v in coeff_y.tolist()],
+            "sigma_px": sigma_px,
+            "sigma_x": sigma_x,
+            "sigma_y": sigma_y,
+            "grid_bins": int(grid_bins),
+            "grid_csv": grid_csv,
+            "plot_path": plot_path,
+        }
+        out_path = out_dir / f"calib_{on_diagnostic}_und_yag_{ts}.json"
+        try:
+            with open(out_path, "w") as f:
+                json.dump(calib, f, indent=2)
+        except Exception:
+            # Best-effort persistence; continue even if write fails
+            ...
+        return calib
+
+
+    def _calib(self, xopt, goal, on_diagnostic, using_device, mover, grid_bins=5):
+        """Calibrate, fit linear model, solve for undulator position"""
+        if mover != "und":
+            raise ValueError(f"Only 'und' mover is supported for calibration.")
+        if using_device != "yag":
+            raise ValueError(f"Only 'yag' device is supported for calibration.")
+        if not isinstance(goal, tuple) or len(goal) != 2:
+            raise ValueError(f"Goal must be a tuple of two floats.")
+
+        from .xopt_scans import evaluator_move
+        
+        print(f"[_calib] Checking calibration freshness...")
+        fresh = self.check_calibration(on_diagnostic=on_diagnostic, xopt_obj=xopt, threshold_sigma=2.0)
+        if fresh: 
+            calib = self._load_calibration(on_diagnostic)
+            print(f"[_calib] Calibration is fresh, using calibration from {calib.get('timestamp')}")
+        else:
+            print(f"[_calib] Calibration is stale, running calibrate() with grid_bins={grid_bins}...")
+            calib = self.calibrate(xopt_obj=xopt, on_diagnostic=on_diagnostic, grid_bins=grid_bins)
+
+        print(f"[_calib] Solving for undulator position to achieve goal {goal}...")
+        undp_xy = self._undp_solve(goal, calib)
+        print(f"[_calib] Moving to undulator position {undp_xy}...")
+        evaluator_move(mover=mover, input={UNDP_KEY_X: undp_xy[0], UNDP_KEY_Y: undp_xy[1]})
+        return xopt
+
+    def _turbo(self, xopt, path_plot, xopt_rand_evaluate, xopt_steps, mover, xopt_turbo_option):
+        """Execute turbo optimization method."""
+        from .xopt_scans import evaluator_move, get_variables
+        
+        xopt.random_evaluate(
+            n_samples=xopt_rand_evaluate,
+            custom_bounds=get_variables(mover=mover, narrow=True),
+        )
+        print(xopt.data)
+        xopt_eval_plot = UpdatingXoptVisualizeModelPlot(xopt)
+
+        # Seed the path plot with all the random points
+        if path_plot is not None:
+            x_series = xopt.data.get("centroid_x")
+            y_series = xopt.data.get("centroid_y")
+            path_plot.add_points([(xpt, ypt) for xpt, ypt in zip(x_series, y_series)])
+
+        for num in range(xopt_steps):
+            print(f"Step {num + 1}")
+            try:
+                xopt.step()
+                xopt_eval_plot.refresh()
+                if path_plot is not None:
+                    path_plot.add_point(
+                        (xopt.data.get("centroid_x").iat[-1], xopt.data.get("centroid_y").iat[-1])
+                    )
+            except RuntimeError:
+                trb = traceback.format_exc()
+                if "turbo requires at least one valid point in the training dataset" in str(trb):
+                    raise FeasibilityError(
+                        f"No feasible points within acceptable region. "
+                        f"Try adjusting constraints in 'xopt_scans.get_xopt_obj'.\n"
+                        f"Current constraints: {xopt.vocs.constraints}"
+                    )
+                else:
+                    # Raise if it's something else
+                    raise
+            except ValueError:
+                trb = traceback.format_exc()
+                if xopt_turbo_option == "safety" and "no data available to build model" in str(trb):
+                    raise FeasibilityError(
+                        f"No feasible points within TuRBO trust region. "
+                        f"Try adjusting constraints in 'xopt_scans.get_xopt_obj'.\n"
+                        f"Current constraints: {xopt.vocs.constraints}"
+                    )
+                else:
+                    # Raise if it's something else
+                    raise
+
+            print(xopt.data)
+        try:
+            _, val, params = xopt.vocs.select_best(xopt.data)
+        except IndexError:
+            # Make error more user-friendly/readable
+            raise FeasibilityError(
+                f"No feasible points within acceptable region. "
+                f"Try adjusting constraints in 'xopt_scans.get_xopt_obj'.\n"
+                f"Current constraints: {xopt.vocs.constraints}"
+            )
+
+        print(f"Best objective value {val}")
+        print(f"Best point {params}")
+        evaluator_move(
+            mover=mover,
+            input=params,
+        )
+        ax = xopt.data.plot(y=xopt.vocs.objective_names)
+        ax.set_xlabel("steps")
+        ax.set_ylabel("objective (to minimize)")
+        xopt_eval_plot.refresh()
+        if path_plot is not None:
+            path_plot.refresh()
+        return xopt
+
     @validate_w_lowercase_args
     def align(
             self,
             with_goal: Optional[float] = None,
             on_diagnostic: Diagnostics = "dg1",
-            with_method: Methods = "xopt",
+            with_package: Methods = "xopt",
+            with_method: str = "turbo",
             using_device: Devices = "yag",
             mover: Movers = "mirr",
             xopt_turbo_option: Turbo = "safety",
@@ -31,7 +356,8 @@ class Beam:
             with_goal_2d: Optional[tuple[float, float]] = None,
             xopt_obj: Optional[Xopt] = None,
             save_run: bool = True,
-            num_frames: int = 1
+            num_frames: int = 1,
+            grid_bins: int = 5
             ):
         """Perform Beam Alignment
 
@@ -41,8 +367,10 @@ class Beam:
             1D Goal to align to. This can be omitted if other goal arguments are used.
         on_diagnostic : str, optional
             Diagnostic to use for alignment. Options: "xcs1, dg1, dg2". Default is "dg1".
+        with_package : str, optional
+            Package to use for alignment. Options: "blop, xopt". Default is "xopt".
         with_method : str, optional
-            Method to use for alignment. Options: "blop, xopt". Default is "xopt".
+            Method to use for optimization. Options: "turbo, calib". Default is "turbo".
         using_device : str, optional
             Device to use for alignment. Options: "yag, wave8". Default is "yag".
         mover : str, optional
@@ -70,13 +398,15 @@ class Beam:
         num_frames: int, optional
             Number of frames to average for YAG image collection. Default is 1 (no averaging).
             Only applies when using_device is "yag".
+        grid_bins: int, optional
+            Number of grid bins for calibration. Default is 5.
         """
         # Validate goal with not doing 2d optimization using camera markers
         if (using_device=="wave8" or not use_2d_markers) and not with_goal:
             raise ValueError("Must provide parameter with_goal (float) for running YAG or wave8 optimization.")
 
         path_plot = None
-        if with_method == "xopt":
+        if with_package == "xopt":
             from .xopt_scans import get_xopt_obj, evaluator_move, get_variables
             # Allow the loading of an already instantiated xopt object, e.g. to take more steps
             if xopt_obj:
@@ -117,88 +447,33 @@ class Beam:
                 )
                 if using_device == "yag":
                     print("Generating path plot")
-                    path_plot = UpdatingDeviceCentroidPathPlot(
-                        imager=select_diagnostic("yag", on_diagnostic),
-                        goal=select_goal(
+                    goal = select_goal(
                             device_type=using_device,
                             location=on_diagnostic,
                             goal=with_goal,
                             goal_2d=with_goal_2d,
                             use_2d_markers=use_2d_markers,
-                        ),
+                        )
+                    path_plot = UpdatingDeviceCentroidPathPlot(
+                        imager=select_diagnostic("yag", on_diagnostic),
+                        goal= goal,
                         constraints=constraint_data.yag.get(on_diagnostic),
                     )
                     xopt._cached_path_plot = path_plot
-                xopt.random_evaluate(
-                    n_samples=xopt_rand_evaluate,
-                    custom_bounds=get_variables(mover=mover, narrow=True),
+            if with_method == "turbo":
+                return self._turbo(xopt, path_plot, xopt_rand_evaluate, xopt_steps, mover, xopt_turbo_option)
+            elif with_method == "calib":
+                return self._calib(
+                    xopt=xopt,
+                    goal=goal,
+                    on_diagnostic=on_diagnostic,
+                    using_device=using_device,
+                    mover=mover,
+                    grid_bins=grid_bins,
                 )
-            print(xopt.data)
-            xopt_eval_plot = UpdatingXoptVisualizeModelPlot(xopt)
-
-            # Seed the path plot with all the random points
-            if path_plot is not None:
-                x_series = xopt.data.get("centroid_x")
-                y_series = xopt.data.get("centroid_y")
-                path_plot.add_points([(xpt, ypt) for xpt, ypt in zip(x_series, y_series)])
-
-            for num in range(xopt_steps):
-                print(f"Step {num + 1}")
-                try:
-                    xopt.step()
-                    xopt_eval_plot.refresh()
-                    if path_plot is not None:
-                        path_plot.add_point(
-                            (xopt.data.get("centroid_x").iat[-1], xopt.data.get("centroid_y").iat[-1])
-                        )
-                except RuntimeError:
-                    trb = traceback.format_exc()
-                    if "turbo requires at least one valid point in the training dataset" in str(trb):
-                        raise FeasibilityError(
-                            f"No feasible points within acceptable region. "
-                            f"Try adjusting constraints in 'xopt_scans.get_xopt_obj'.\n"
-                            f"Current constraints: {xopt.vocs.constraints}"
-                        )
-                    else:
-                        # Raise if it's something else
-                        raise
-                except ValueError:
-                    trb = traceback.format_exc()
-                    if xopt_turbo_option == "safety" and "no data available to build model" in str(trb):
-                        raise FeasibilityError(
-                            f"No feasible points within TuRBO trust region. "
-                            f"Try adjusting constraints in 'xopt_scans.get_xopt_obj'.\n"
-                            f"Current constraints: {xopt.vocs.constraints}"
-                        )
-                    else:
-                        # Raise if it's something else
-                        raise
-
-                print(xopt.data)
-            try:
-                _, val, params = xopt.vocs.select_best(xopt.data)
-            except IndexError:
-                # Make error more user-friendly/readable
-                raise FeasibilityError(
-                    f"No feasible points within acceptable region. "
-                    f"Try adjusting constraints in 'xopt_scans.get_xopt_obj'.\n"
-                    f"Current constraints: {xopt.vocs.constraints}"
-                )
-
-            print(f"Best objective value {val}")
-            print(f"Best point {params}")
-            evaluator_move(
-                mover=mover,
-                input=params,
-            )
-            ax = xopt.data.plot(y=xopt.vocs.objective_names)
-            ax.set_xlabel("steps")
-            ax.set_ylabel("objective (to minimize)")
-            xopt_eval_plot.refresh()
-            if path_plot is not None:
-                path_plot.refresh()
-            return xopt
-        elif with_method == "blop":
+            else:
+                raise ValueError(f"Invalid method: {with_method}. Only 'turbo' and 'calib' are supported.")
+        elif with_package == "blop":
             from .blop_scans import get_blop_agent
             try:
                 from mfx.db import RE
@@ -211,7 +486,7 @@ class Beam:
             agent.plot_objectives()
             return agent
         else:
-            raise ValueError("Only 'xopt' and 'blop' methods are supported.")
+            raise ValueError("Only 'xopt' and 'blop' packages are supported.")
 
     @validate_w_lowercase_args
     def scan(

--- a/mfx/optimize/beamline_hw.py
+++ b/mfx/optimize/beamline_hw.py
@@ -46,18 +46,24 @@ def init_devices(force: bool = False) -> dict[str, Device]:
         devices[name] = client.load_device(name=name)
 
     # Happi IPMs do not currently have wave8s, add manually
-    for stand in ("dg1", "dg2"):
-        name = f"mfx_{stand}_wave8"
-        devices[name] = Wave8(f"MFX:{stand.upper()}:BMMON", name=name)
-        devices[name].kind = "hinted"
+
+    devices["xcs_wave8"] = Wave8("HXX:DG1:BMMON:", name="mfx_xcs_wave8")
+    devices["xcs_wave8"].kind = "hinted"
+    devices["xcs_yag1"] = YagCamera("XCS:GIGE:YAG1:", name="mfx_xcs_yag1")
+    devices["xcs_yag1"].kind = "hinted"
+    
+    devices["mfx_dg1_wave8"] = Wave8(f"MFX:DG1:W8:01", name="mfx_dg1_wave8")
+    devices["mfx_dg1_wave8"].kind = "hinted"
+    devices["mfx_dg1_yag"] = YagCamera(f"MFX:GIGE:DG1:YAG:", name="mfx_dg1_yag")
+    devices["mfx_dg1_yag"].kind = "hinted"
+
+    devices["mfx_dg2_wave8"] = Wave8(f"MFX:DG2:BMMON", name="mfx_dg2_wave8")
+    devices["mfx_dg2_wave8"].kind = "hinted"
+    devices["mfx_dg2_yag"] = YagCamera(f"MFX:GIGE:DG2:YAG:", name="mfx_dg2_yag")
+    devices["mfx_dg2_yag"].kind = "hinted"
 
     # Happi PIMs don't work how I want them to, add manually
-    for stand in ("dg1", "dg2"):
-        name = f"mfx_{stand}_yag"
-        devices[name] = YagCamera(f"MFX:GIGE:{stand.upper()}:YAG:", name=name)
-        devices[name].kind = "hinted"
 
-    devices["xcs_yag1"] = YagCamera("XCS:GIGE:YAG1:", name="xcs_yag1")
     devices["mfx_ip_yag"] = YagCamera("MFX:GIGE:LBL:01:", name="mfx_ip1_yag")
     devices["mfx_ip_yag"].kind = "hinted"
 
@@ -85,8 +91,10 @@ def sim_devices() -> dict[str, Device]:
     und_abs = UndPointAbs2DSim()
     devices["und_abs"] = und_abs
     devices["und_del"] = und_abs.delta_xy
-    dg1_wave8_offset = random.uniform(-1, 1)
-    dg2_wave8_offset = random.uniform(-1, 1)
+    dg1_wave8_x_offset = random.uniform(-1, 1)
+    dg2_wave8_x_offset = random.uniform(-1, 1)
+    dg1_wave8_y_offset = random.uniform(-1, 1)
+    dg2_wave8_y_offset = random.uniform(-1, 1)
     xcs_yag_offset = random.uniform(-5, 5)
     dg1_yag_offset = random.uniform(-10, 10)
     dg2_yag_offset = random.uniform(-20, 20)
@@ -101,25 +109,49 @@ def sim_devices() -> dict[str, Device]:
             devices["und_abs"].position[1] - undp_y0
         )
 
-    def get_fake_dg1_wave8() -> float:
+    def get_fake_dg1_wave8_x() -> float:
         mdpitch, undp_dx, _ = get_offsets()
-        return mdpitch - undp_dx/200 + DG1_WAVE8_XPOS + dg1_wave8_offset + random.uniform(-0.1, 0.1)
+        return mdpitch - undp_dx/200 + DG1_WAVE8_XPOS + dg1_wave8_x_offset + random.uniform(-0.1, 0.1)
 
-    def get_fake_dg2_wave8() -> float:
+    def get_fake_dg2_wave8_x() -> float:
         mdpitch, undp_dx, _ = get_offsets()
-        return mdpitch - undp_dx/200 + DG2_WAVE8_XPOS + dg2_wave8_offset + random.uniform(-0.1, 0.1)
+        return mdpitch - undp_dx/200 + DG2_WAVE8_XPOS + dg2_wave8_x_offset + random.uniform(-0.1, 0.1)
+
+    def get_fake_dg1_wave8_y() -> float:
+        _, _, undp_dy = get_offsets()
+        return - undp_dy/200 + dg1_wave8_y_offset + random.uniform(-0.1, 0.1)
+
+    def get_fake_dg2_wave8_y() -> float:
+        _, _, undp_dy = get_offsets()
+        return - undp_dy/200 + dg2_wave8_y_offset + random.uniform(-0.1, 0.1)
 
     devices["mfx_dg1_wave8"] = SimpleNamespace(
         xpos=SynSignal(
-            func=get_fake_dg1_wave8,
+            func=get_fake_dg1_wave8_x,
             name="mfx_dg1_wave8_xpos"
-        )
+        ),
+        ypos=SynSignal(
+            func=get_fake_dg1_wave8_y,
+            name="mfx_dg1_wave8_ypos"
+        ),
+        sum=SynSignal(
+            func=lambda: random.uniform(0, 1000),
+            name="mfx_dg1_wave8_sum",
+        ),
     )
     devices["mfx_dg2_wave8"] = SimpleNamespace(
         xpos=SynSignal(
-            func=get_fake_dg2_wave8,
+            func=get_fake_dg2_wave8_x,
             name="mfx_dg2_wave8_xpos"
-        )
+        ),
+        ypos=SynSignal(
+            func=get_fake_dg2_wave8_y,
+            name="mfx_dg2_wave8_ypos"
+        ),
+        sum=SynSignal(
+            func=lambda: random.uniform(0, 1000),
+            name="mfx_dg2_wave8_sum",
+        ),
     )
     devices["mfx_dg1_yag"] = FakeYagCamera("", name="mfx_dg1_yag")
     devices["mfx_dg2_yag"] = FakeYagCamera("", name="mfx_dg2_yag")

--- a/mfx/optimize/type_checking.py
+++ b/mfx/optimize/type_checking.py
@@ -10,7 +10,8 @@ from typing import Literal
 from pydantic import ConfigDict, validate_call
 
 Diagnostics = Literal["xcs1", "dg1", "dg2", "ip"]
-Methods = Literal["xopt", "blop"]
+Packages = Literal["xopt", "blop"]
+Methods = Literal["turbo", "calib"]
 Devices = Literal["yag", "wave8"]
 Movers = Literal["mirr", "und"]
 Turbo = Literal["safety", "optimize"]

--- a/mfx/optimize/user_select.py
+++ b/mfx/optimize/user_select.py
@@ -45,7 +45,7 @@ def select_diagnostic(
         if location in ("dg1", "dg2"):
             return devices[f"mfx_{location}_wave8"]
         else:
-            raise ValueError(f"Invalid wave8 {location}, expected dg1 or dg2")
+            return devices["xcs_wave8"]
     else:
         raise RuntimeError(
             f"Invalid device_type {device_type} selected, pydantic broke?"
@@ -99,13 +99,13 @@ def select_goal(
     if goal is not None:
         return goal
     
-    # goal_2d is compatible only with yags
+    # goal_2d is compatible with yags and wave8
     if goal_2d is not None:
-        if device_type == "yag":
+        if device_type in ("yag", "wave8"):
             return goal_2d
         else:
             raise ValueError(
-                f"goal_2d is only compatible with yag, not with {device_type}! "
+                f"goal_2d is only compatible with yag or wave8, not with {device_type}! "
                 "Try providing goal (float) instead."
             )
 

--- a/mfx/optimize/utils.py
+++ b/mfx/optimize/utils.py
@@ -1,7 +1,7 @@
 """
 Utility functions for MFX optimization.
 """
-
+from __future__ import annotations
 import logging
 import matplotlib.pyplot as plt
 import numpy as np
@@ -17,18 +17,19 @@ from xopt.generators.bayesian.visualize import (
     _get_model_predictions,
 )
 
-
 def _to_numpy(x):
     """Convert torch.Tensor or array-like to numpy.ndarray safely."""
     if isinstance(x, np.ndarray):
         return x
     try:
         import torch as _torch  # local import to avoid hard dep at import time
+
         if isinstance(x, _torch.Tensor):
             return x.detach().cpu().numpy()
     except Exception:
         pass
     return np.asarray(x)
+
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -52,7 +53,9 @@ def set_yag_constraints(
         New ROI radius in pixels. If None, leaves unchanged.
     """
     if location not in constraint_data.yag:
-        raise KeyError(f"Unknown YAG location '{location}'. Known: {list(constraint_data.yag.keys())}")
+        raise KeyError(
+            f"Unknown YAG location '{location}'. Known: {list(constraint_data.yag.keys())}"
+        )
     yag_constr = constraint_data.yag[location]
     if roi_center is not None:
         logger.info(f"Setting YAG '{location}' ROI center to {roi_center}")
@@ -84,6 +87,7 @@ def set_und_constraints(
         logger.info(f"Setting Undulator max_travel_distance to {max_travel_distance}")
         und.max_travel_distance = float(max_travel_distance)
 
+
 def plot_yag_optimization_setup(
     roi_center: tuple[int, int] = None,
     roi_radius: int = None,
@@ -93,7 +97,7 @@ def plot_yag_optimization_setup(
 ) -> tuple[np.ndarray, tuple[float, float]]:
     """
     Plot YAG optimization setup with ROI center, goal, and beam centroid.
-    
+
     Parameters
     ----------
     roi_center : tuple[int, int], optional
@@ -108,7 +112,7 @@ def plot_yag_optimization_setup(
         Figure size for the plot, by default (10, 8)
     show_plot : bool, optional
         Whether to display the plot, by default True
-        
+
     Returns
     -------
     tuple[np.ndarray, tuple[float, float]]
@@ -118,7 +122,7 @@ def plot_yag_optimization_setup(
     #     logger.info("Initializing simulated devices...")
     #     sim_devices()
     #     logger.info("Simulated devices initialized.")
-    
+
     if roi_center is None:
         print("No ROI center provided, using constraint data")
         roi_center = constraint_data.yag[yag_location].roi_center
@@ -128,52 +132,91 @@ def plot_yag_optimization_setup(
     if goal_2d is None:
         print("No goal 2D provided, using center of ROI")
         goal_2d = roi_center
-    
+
     logger.info(f"ROI Center: {roi_center}")
     logger.info(f"ROI Radius: {roi_radius}")
     logger.info(f"Goal 2D: {goal_2d}")
-    
+
     # Get YAG image and process it to find beam centroid
     yag = select_diagnostic(device_type="yag", location=yag_location)
     yag.image1.shaped_image.trigger().wait(timeout=1)
     img = yag.image1.shaped_image.get()
-    
+
     # Fit the image to find beam centroid
     fit = ImageProjectionFit()
     fit_result = fit.fit_image(img)
     beam_centroid = (fit_result.centroid[0], fit_result.centroid[1])
-    
+
     logger.info(f"Beam Centroid: {beam_centroid}")
-    
+
     # Display image with crosses
     plt.figure(figsize=(10, 8))
     plt.imshow(img, cmap="gray")
-    
+
     # Add cross at ROI center (red)
-    plt.plot(roi_center[0], roi_center[1], 'r+', markersize=15, markeredgewidth=3, label='ROI Center')
-    plt.plot(roi_center[0], roi_center[1], 'ro', markersize=8, fillstyle='none', markeredgewidth=2)
-    
-    # Add cross at goal_2d (green) 
-    plt.plot(goal_2d[0], goal_2d[1], 'g+', markersize=15, markeredgewidth=3, label='Goal 2D')
-    plt.plot(goal_2d[0], goal_2d[1], 'go', markersize=8, fillstyle='none', markeredgewidth=2)
-    
+    plt.plot(
+        roi_center[0],
+        roi_center[1],
+        "r+",
+        markersize=15,
+        markeredgewidth=3,
+        label="ROI Center",
+    )
+    plt.plot(
+        roi_center[0],
+        roi_center[1],
+        "ro",
+        markersize=8,
+        fillstyle="none",
+        markeredgewidth=2,
+    )
+
+    # Add cross at goal_2d (green)
+    plt.plot(
+        goal_2d[0], goal_2d[1], "g+", markersize=15, markeredgewidth=3, label="Goal 2D"
+    )
+    plt.plot(
+        goal_2d[0], goal_2d[1], "go", markersize=8, fillstyle="none", markeredgewidth=2
+    )
+
     # Add cross at beam centroid (blue)
-    plt.plot(beam_centroid[0], beam_centroid[1], 'b+', markersize=15, markeredgewidth=3, label='Beam Centroid')
-    plt.plot(beam_centroid[0], beam_centroid[1], 'bo', markersize=8, fillstyle='none', markeredgewidth=2)
-    
+    plt.plot(
+        beam_centroid[0],
+        beam_centroid[1],
+        "b+",
+        markersize=15,
+        markeredgewidth=3,
+        label="Beam Centroid",
+    )
+    plt.plot(
+        beam_centroid[0],
+        beam_centroid[1],
+        "bo",
+        markersize=8,
+        fillstyle="none",
+        markeredgewidth=2,
+    )
+
     # Add ROI circle using constraint data
-    circle = plt.Circle(roi_center, roi_radius,
-                       fill=False, color='red', linestyle='--', alpha=0.7, label='ROI Boundary')
+    circle = plt.Circle(
+        roi_center,
+        roi_radius,
+        fill=False,
+        color="red",
+        linestyle="--",
+        alpha=0.7,
+        label="ROI Boundary",
+    )
     plt.gca().add_patch(circle)
-    
+
     plt.legend()
-    plt.title('YAG Image with ROI Center and Goal')
-    plt.xlabel('X Position (pixels)')
-    plt.ylabel('Y Position (pixels)')
-    
+    plt.title("YAG Image with ROI Center and Goal")
+    plt.xlabel("X Position (pixels)")
+    plt.ylabel("Y Position (pixels)")
+
     if show_plot:
         plt.show()
-    
+
     return img, beam_centroid
 
 
@@ -193,10 +236,10 @@ def plot_gp_landscape(
 ):
     """
     Plot the Gaussian Process approximation of the objective landscape.
-    
+
     This function visualizes what the GP thinks the optimization landscape looks like
     after being seeded with data points from random_evaluate().
-    
+
     Parameters
     ----------
     opt : Xopt
@@ -206,13 +249,15 @@ def plot_gp_landscape(
     figsize : tuple[int, int], optional
         Figure size for the plot, by default (12, 5)
     """
-    if not hasattr(opt, 'generator'):
-        raise ValueError("Provided object does not look like an Xopt instance (missing generator)")
+    if not hasattr(opt, "generator"):
+        raise ValueError(
+            "Provided object does not look like an Xopt instance (missing generator)"
+        )
 
     # Train or retrieve the underlying GP model from the generator
     # This is the supported pattern in Xopt examples
     model = opt.generator.train_model()
-    
+
     # Get variable bounds from VOCS
     vocs = opt.vocs
     variables = vocs.variables
@@ -222,7 +267,7 @@ def plot_gp_landscape(
 
     # Torch dtype/device kwargs (CPU + double precision)
     tkwargs = {"dtype": torch.double, "device": torch.device("cpu")}
-    
+
     if len(var_names) == 1:
         # 1D case
         var_name = var_names[0]
@@ -241,42 +286,54 @@ def plot_gp_landscape(
         mean = _to_numpy(mean_t).squeeze()
         std = _to_numpy(std_t).squeeze()
         x_plot = _to_numpy(input_mesh.squeeze(1))
-        
+
         # Plot
         fig, (ax1, ax2) = plt.subplots(1, 2, figsize=figsize)
-        
+
         # Mean prediction
-        ax1.plot(x_plot, mean, 'b-', label='GP Mean', linewidth=2)
-        ax1.fill_between(x_plot, mean - 2*std, mean + 2*std, 
-                        alpha=0.3, color='blue', label='±2σ Confidence')
-        
+        ax1.plot(x_plot, mean, "b-", label="GP Mean", linewidth=2)
+        ax1.fill_between(
+            x_plot,
+            mean - 2 * std,
+            mean + 2 * std,
+            alpha=0.3,
+            color="blue",
+            label="±2σ Confidence",
+        )
+
         # Plot data points
-        if hasattr(opt, 'data') and not opt.data.empty:
+        if hasattr(opt, "data") and not opt.data.empty:
             data_x = opt.data[var_name].values
-            data_y = opt.data['objective'].values
-            ax1.scatter(data_x, data_y, color='red', s=50, zorder=5, label='Data Points')
-        
+            data_y = opt.data["objective"].values
+            ax1.scatter(
+                data_x, data_y, color="red", s=50, zorder=5, label="Data Points"
+            )
+
         ax1.set_xlabel(var_name)
-        ax1.set_ylabel('Objective')
-        ax1.set_title('GP Mean Prediction')
+        ax1.set_ylabel("Objective")
+        ax1.set_title("GP Mean Prediction")
         ax1.legend()
         ax1.grid(True, alpha=0.3)
-        
+
         # Standard deviation (uncertainty)
-        ax2.plot(x_plot, std, 'r-', linewidth=2, label='GP Uncertainty')
+        ax2.plot(x_plot, std, "r-", linewidth=2, label="GP Uncertainty")
         ax2.set_xlabel(var_name)
-        ax2.set_ylabel('Standard Deviation')
-        ax2.set_title('GP Uncertainty')
+        ax2.set_ylabel("Standard Deviation")
+        ax2.set_title("GP Uncertainty")
         ax2.legend()
         ax2.grid(True, alpha=0.3)
-        
+
     elif len(var_names) == 2:
         # 2D case
         var1_name, var2_name = var_names
 
         # Build input mesh using Xopt utilities (handles transforms/ordering)
         input_mesh = _generate_input_mesh(
-            vocs, [var1_name, var2_name], reference_point=None, n_grid=resolution, tkwargs=tkwargs
+            vocs,
+            [var1_name, var2_name],
+            reference_point=None,
+            n_grid=resolution,
+            tkwargs=tkwargs,
         )
 
         # Predict for the desired output
@@ -293,39 +350,45 @@ def plot_gp_landscape(
         x1 = _to_numpy(input_mesh[:, 0]).reshape(resolution, resolution)
         x2 = _to_numpy(input_mesh[:, 1]).reshape(resolution, resolution)
         X1_np, X2_np = x1, x2
-        
+
         # Plot
         fig, (ax1, ax2) = plt.subplots(1, 2, figsize=figsize)
-        
+
         # Mean prediction
-        im1 = ax1.contourf(X1_np, X2_np, mean, levels=20, cmap='viridis')
+        im1 = ax1.contourf(X1_np, X2_np, mean, levels=20, cmap="viridis")
         ax1.set_xlabel(var1_name)
         ax1.set_ylabel(var2_name)
-        ax1.set_title('GP Mean Prediction')
-        plt.colorbar(im1, ax=ax1, label='Objective')
-        
+        ax1.set_title("GP Mean Prediction")
+        plt.colorbar(im1, ax=ax1, label="Objective")
+
         # Plot data points
-        if hasattr(opt, 'data') and not opt.data.empty:
+        if hasattr(opt, "data") and not opt.data.empty:
             data_x1 = opt.data[var1_name].values
             data_x2 = opt.data[var2_name].values
-            ax1.scatter(data_x1, data_x2, color='red', s=50, zorder=5, label='Data Points')
+            ax1.scatter(
+                data_x1, data_x2, color="red", s=50, zorder=5, label="Data Points"
+            )
             ax1.legend()
-        
+
         # Standard deviation (uncertainty)
-        im2 = ax2.contourf(X1_np, X2_np, std, levels=20, cmap='Reds')
+        im2 = ax2.contourf(X1_np, X2_np, std, levels=20, cmap="Reds")
         ax2.set_xlabel(var1_name)
         ax2.set_ylabel(var2_name)
-        ax2.set_title('GP Uncertainty')
-        plt.colorbar(im2, ax=ax2, label='Standard Deviation')
-        
+        ax2.set_title("GP Uncertainty")
+        plt.colorbar(im2, ax=ax2, label="Standard Deviation")
+
         # Plot data points on uncertainty plot too
-        if hasattr(opt, 'data') and not opt.data.empty:
-            ax2.scatter(data_x1, data_x2, color='black', s=50, zorder=5, label='Data Points')
+        if hasattr(opt, "data") and not opt.data.empty:
+            ax2.scatter(
+                data_x1, data_x2, color="black", s=50, zorder=5, label="Data Points"
+            )
             ax2.legend()
-    
+
     else:
-        raise ValueError(f"Can only plot 1D or 2D landscapes. Found {len(var_names)} variables: {var_names}")
-    
+        raise ValueError(
+            f"Can only plot 1D or 2D landscapes. Found {len(var_names)} variables: {var_names}"
+        )
+
     plt.tight_layout()
     plt.show()
 

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -383,7 +383,7 @@ def get_xopt_obj(
     #vocs.constraints = {}
     if device_type == "yag":
         # Create per run images directory
-        images_root = Path("/cds/home/opr/mfxopr")
+        images_root = Path.home() #Path("/cds/home/opr/mfxopr")
         images_root.mkdir(parents=True, exist_ok=True)
         run_dir_name = Path(dump_file).stem
         run_images_dir = images_root / run_dir_name
@@ -451,10 +451,10 @@ def get_xopt_obj(
 
 def test_write_permissions():
     """
-    Simple test function to check if we can write to /cds/home/opr/mfxopr
+    Simple test function to check if we can write to /cds/home/opr/mfxopr (or your home)
     """
 
-    test_dir = Path("/cds/home/opr/mfxopr")
+    test_dir = Path.home() #Path("/cds/home/opr/mfxopr")
     test_dir.mkdir(parents=True, exist_ok=True)
     test_file = test_dir / f"test_write.txt"
 

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -53,14 +53,9 @@ def get_variables(mover: Movers, narrow: bool = False):
             delta = constraint_data.mirr.range_delta
         variables[MP_KEY] = [center - delta, center + delta]
     elif mover == "und":
-        undp = init_devices()["und_abs"]
-        pos = undp.position
-        if narrow and constraint_data.und.max_travel_distance is not None:
-            delta = constraint_data.und.max_travel_distance
-        else:
-            delta = constraint_data.und.xy_delta
-        variables[UNDP_KEY_X] = [pos[0] - delta, pos[0] + delta]
-        variables[UNDP_KEY_Y] = [pos[1] - delta, pos[1] + delta]
+        # Use fixed absolute bounds for undulator positions
+        variables[UNDP_KEY_X] = [0, 200]
+        variables[UNDP_KEY_Y] = [-450, -200]
     return variables
 
 
@@ -272,11 +267,52 @@ def get_evaluator_yag_2d(
 
     def evaluate(input: dict[str, float]) -> dict[str, float | str]:
         evaluator_move(mover=mover, input=input)
-        time.sleep(10) # WAIT FOR MOTORS TO STOP MOTION 
+        time.sleep(5) # WAIT FOR MOTORS TO STOP MOTION 
         fit_result, npz_path = evaluate_yag_processing(yag, fit, num_frames=num_frames, save_dir=images_dir)
         results = evaluate_yag_results(yag, fit_result)
         results["objective"] = distance2d(fit_result.centroid, goal)
         results["image_npz_path"] = npz_path
+        try:
+            w8 = select_diagnostic("wave8", yag)
+            w8.xpos.trigger().wait(timeout=10)
+            w8.ypos.trigger().wait(timeout=10)
+            w8.sum.trigger().wait(timeout=10)
+            results["wave8_x"] = float(w8.xpos.get())
+            results["wave8_y"] = float(w8.ypos.get())
+            results["wave8_sum"] = float(w8.sum.get())
+        except Exception as exc:
+            print(f"Warning: failed to read wave8 x/y/sum: {exc}")
+        print(f"Distance from goal is {results['objective']}")
+        return results
+
+    return Evaluator(function=evaluate)
+
+
+@validate_w_lowercase_args
+def get_evaluator_wave8_2d(
+    wave8: Diagnostics,
+    goal: tuple[float, float],
+    mover: Movers,
+) -> Evaluator:
+    """
+    2D evaluator for wave8 using xpos and ypos.
+    """
+    def evaluate(input: dict[str, float]) -> dict[str, float]:
+        evaluator_move(mover=mover, input=input)
+        time.sleep(5) # WAIT FOR MOTORS TO STOP MOTION 
+        device = select_diagnostic("wave8", wave8)
+        device.xpos.trigger().wait(timeout=10)
+        device.ypos.trigger().wait(timeout=10)
+        device.sum.trigger().wait(timeout=10)
+        x = device.xpos.get()
+        y = device.ypos.get()
+        sum_ = device.sum.get()
+        results = {
+            "centroid_x": x,
+            "centroid_y": y,
+            "intensity": sum_,
+            "objective": distance2d((x, y), goal),
+        }
         print(f"Distance from goal is {results['objective']}")
         return results
 
@@ -369,11 +405,18 @@ def get_xopt_obj(
                 images_dir=str(run_images_dir),
             )
     else:
-        evaluator = get_evaluator_wave8(
-            wave8=location,
-            wave8_xpos=goal_value,
-            mover=mover,
-        )
+        if isinstance(goal_value, tuple):
+            evaluator = get_evaluator_wave8_2d(
+                wave8=location,
+                goal=goal_value,
+                mover=mover,
+            )
+        else:
+            evaluator = get_evaluator_wave8(
+                wave8=location,
+                wave8_xpos=goal_value,
+                mover=mover,
+            )
 
     generator = ExpectedImprovementGenerator(vocs=vocs, turbo_controller=xopt_generator_turbo_controller)
     generator.turbo_controller.restrict_model_data = False


### PR DESCRIPTION
Related to https://github.com/lcls-mlcv/prj-mgmt/issues/238

# Test on mfx-daq:
## 1. checkout branch 
```
cd /cds/group/pcds/pyps/apps/hutch-python/mfx/
git fetch --all
git checkout exafs-calib
```
## 2. test command in mfx3

### Calibrate (and fit)
```python
In [1]: und_abs((0,-450,0))
In [2]: from mfx.optimize.beam import Beam
In [3]: beam = Beam()
In [4]: beam.align(using_device="yag", on_diagnostic="xcs1", mover="und", use_2d_markers=True, with_method="calib")
```
We expect to see the beam go through a snake scan on the YAG and at the end the calibration plot will be displayed. This will also write a csv file somewhere (it will say where), probably here `/cds/group/pcds/pyps/apps/hutch-python/mfx/logs/xopt/calibration`.

### Test calibration
```python
In [5]: und_abs((0,-450,0))
In [6]: beam.align(using_device="yag", on_diagnostic="xcs1", mover="und", use_2d_markers=True, with_method="calib")
```
We expect to go to the goal in one step.

## 3. get back to normal
```
cd /cds/group/pcds/pyps/apps/hutch-python/mfx/
git fetch --all
git checkout 222-prepare-for-exafs
```