### PR TITLE
adding long_calib + tfs placeholder in long_escan

### DIFF
--- a/mfx/exafs.py
+++ b/mfx/exafs.py
@@ -2,6 +2,9 @@ import copy
 import numpy as np
 import sys
 from time import sleep
+import os
+import json
+from pathlib import Path
 
 class Exafs:
     from pcdsdevices.beam_stats import BeamEnergyRequest, BeamEnergyRequestACRWait
@@ -257,6 +260,89 @@ class Exafs:
                 if not success:
                     self.logger.warning(f"Intensity-based alignment failed at energy {energy:.4f} keV")
 
+    def _align_ondulator(self, on_diagnostic, using_device, with_method, grid_bins):
+        """
+        Perform ondulator (undulator) alignment using beam alignment system.
+        
+        This method uses the Beam.align() function to align the ondulator.
+        If with_method="calib", it will use calibration if available, otherwise run calibration.
+        If with_method="turbo", it will use turbo optimization.
+        
+        Parameters
+        ----------
+        on_diagnostic : str
+            Diagnostic location (e.g., "dg1", "dg2", "xcs1")
+        using_device : str
+            Device to use ("yag" or "wave8")
+        with_method : str
+            Alignment method ("calib" or "turbo")
+        grid_bins : int
+            Number of grid bins for calibration (if using "calib" method)
+        """
+        try:
+            from mfx.optimize.beam import Beam
+            from mfx.optimize.user_select import select_goal
+            
+            self.logger.info(f"Aligning ondulator on {on_diagnostic} using {using_device} with method {with_method}")
+            beam = Beam()
+            
+            # Get the goal for the diagnostic if needed
+            # For YAG with calib method, we might not need a specific goal, but let's get a default
+            goal = None
+            goal_2d = None
+            if using_device == "yag":
+                # Try to get a default goal for YAG
+                try:
+                    goal_info = select_goal(
+                        device_type=using_device,
+                        location=on_diagnostic,
+                        goal=None,
+                        goal_2d=None,
+                        use_2d_markers=False,
+                    )
+                    if isinstance(goal_info, tuple):
+                        goal_2d = goal_info
+                    else:
+                        goal = goal_info
+                except Exception:
+                    # If we can't get a goal, use use_2d_markers to bypass the requirement
+                    pass
+            
+            # Perform alignment
+            # The align() method handles calibration automatically if method is "calib"
+            align_kwargs = {
+                "on_diagnostic": on_diagnostic,
+                "using_device": using_device,
+                "mover": "und",
+                "with_method": with_method,
+                "grid_bins": grid_bins,
+                "save_run": False,  # Don't save runs during scan
+            }
+            
+            # Add goal parameters if we have them, or use use_2d_markers for YAG
+            if using_device == "yag" and goal is None and goal_2d is None:
+                align_kwargs["use_2d_markers"] = True
+            else:
+                if goal is not None:
+                    align_kwargs["with_goal"] = goal
+                if goal_2d is not None:
+                    align_kwargs["with_goal_2d"] = goal_2d
+            
+            result = beam.align(**align_kwargs)
+            
+            self.logger.info(f"Ondulator alignment completed on {on_diagnostic}")
+            
+        except Exception as e:
+            self.logger.warning(f"Ondulator alignment failed: {e}")
+            # Don't raise - allow scan to continue
+
+    def _move_tfs_to_energy(self, energy_eV, track_focus_data):
+        """
+        Placeholder for Transfocator move using track_focus results.
+        Currently does nothing; to be implemented.
+        """
+        return
+
     def _move_k_if_necessary(self, energy_keV, k_energy, energy_0_keV, k_stepsize, k_offset, reverse, min_k_keV):
         """Move K if necessary and manage DAQ state."""
         from mfx.db import daq
@@ -342,6 +428,180 @@ class Exafs:
         self._return_to_start(energy_start, k_energy_start)
         self.logger.warning('Finished with all runs thank you for choosing the MFX beamline!\n')
 
+    def long_calib(
+            self,
+            simulate: bool = False,
+            start_eV: float = 7000.0,
+            end_eV: float = 7500.0,
+            energy_steps: int = 6,
+            vernier_events_per_step: int = 120,
+            ondulator_on_diagnostic: str = "dg1",
+            ondulator_grid_bins: int = 5,
+            ondulator_using_device: str = "yag",
+            debug: bool = False):
+        """Perform calibration scan over energy range for both vernier and ondulator.
+        
+        This function performs calibrations in a single energy loop:
+        1. At each energy: collects vernier offset data and runs ondulator calibration
+        2. After the loop: fits a single vernier calibration model from all collected offset data
+        
+        Parameters:
+        -----------
+        simulate : bool, optional
+            Whether to run in simulation mode. Default: False
+            
+        start_eV : float, optional
+            Starting energy for calibration range in eV. Default: 7000.0
+            
+        end_eV : float, optional
+            Ending energy for calibration range in eV. Default: 7500.0
+            
+        energy_steps : int, optional
+            Number of energy points to visit. Default: 6
+            
+        vernier_events_per_step : int, optional
+            Number of events to average for vernier offset measurement. Default: 120
+            
+        ondulator_on_diagnostic : str, optional
+            Diagnostic location for ondulator calibration. Options: "xcs1", "dg1", "dg2". Default: "dg1"
+            
+        ondulator_grid_bins : int, optional
+            Number of grid bins for ondulator calibration. Default: 5
+            
+        ondulator_using_device : str, optional
+            Device to use for ondulator calibration. Options: "yag", "wave8". Default: "yag"
+            
+        debug : bool, optional
+            Enable debug output. Default: False
+        """
+        from mfx.optimize.vernier_calibration import VernierCalibration
+        from mfx.optimize.beam import Beam
+        from mfx.optimize.xopt_scans import get_xopt_obj
+        from mfx.optimize.user_select import select_goal
+        
+        self.simulate = simulate
+        
+        # Store initial position
+        energy_start = self.dccm.energy_with_vernier.energy()
+        
+        # Initialize calibration objects
+        vernier_calib = VernierCalibration()
+        beam = Beam()
+        
+        # Generate energy list
+        energies = np.linspace(start_eV, end_eV, energy_steps)
+        
+        # Storage for vernier calibration data
+        vernier_data_points = []
+        
+        self.logger.info(f"Starting long calibration scan from {start_eV:.2f} to {end_eV:.2f} eV ({energy_steps} steps)")
+        
+        try:
+            # Single loop through energies
+            for i, target_energy in enumerate(energies):
+                self.logger.info(f"\n{'='*60}")
+                self.logger.info(f"Calibration step {i+1}/{energy_steps} at energy {target_energy:.2f} eV")
+                self.logger.info(f"{'='*60}")
+                
+                energy_keV = target_energy / 1000.0
+                
+                # Move DCCM and Vernier to target energy
+                self.logger.info(f"Moving DCCM and Vernier to {target_energy:.2f} eV ({energy_keV:.4f} keV)")
+                self._move_dccm_energy_with_vernier(energy_keV)
+                
+                # Collect vernier offset data at this energy
+                self.logger.info(f"\n--- Collecting vernier offset data at {target_energy:.2f} eV ---")
+                try:
+                    vernier_data = vernier_calib.collect_offset_data_at_energy(
+                        events=vernier_events_per_step
+                    )
+                    vernier_data_points.append(vernier_data)
+                    self.logger.info(f"Vernier data collected at {target_energy:.2f} eV")
+                except Exception as e:
+                    self.logger.error(f"Failed to collect vernier data at {target_energy:.2f} eV: {e}")
+                    if not debug:
+                        raise
+                    continue
+                
+                # Run ondulator calibration at this energy
+                self.logger.info(f"\n--- Running ondulator calibration at {target_energy:.2f} eV ---")
+                try:
+                    # Create xopt_obj for ondulator calibration
+                    # We need to get the goal for the diagnostic
+                    goal = select_goal(
+                        device_type=ondulator_using_device,
+                        location=ondulator_on_diagnostic,
+                        goal=None,
+                        goal_2d=None,
+                        use_2d_markers=False,
+                    )
+                    
+                    # Create xopt object for calibration
+                    xopt_obj = get_xopt_obj(
+                        device_type=ondulator_using_device,
+                        location=ondulator_on_diagnostic,
+                        mover="und",
+                        goal=goal if not isinstance(goal, tuple) else None,
+                        goal_2d=goal if isinstance(goal, tuple) else None,
+                        xopt_generator_turbo_controller="optimize",
+                        max_iter=2000,
+                        dump_file=None,
+                        num_frames=1,
+                    )
+                    
+                    # Run calibration at this energy
+                    # This will do a grid scan of undulator positions and fit
+                    # the relationship: centroid = f(undulator_x, undulator_y)
+                    ondulator_calib_result = beam.calibrate(
+                        xopt_obj=xopt_obj,
+                        on_diagnostic=ondulator_on_diagnostic,
+                        grid_bins=ondulator_grid_bins
+                    )
+                    self.logger.info(f"Ondulator calibration completed at {target_energy:.2f} eV")
+                except Exception as e:
+                    self.logger.error(f"Ondulator calibration failed at {target_energy:.2f} eV: {e}")
+                    if not debug:
+                        raise
+                    continue
+                
+                self.logger.info(f"Completed calibration step {i+1}/{energy_steps} at {target_energy:.2f} eV")
+            
+            # ============================================================
+            # Fit vernier calibration model from all collected data
+            # ============================================================
+            self.logger.info(f"\n{'='*60}")
+            self.logger.info(f"Fitting vernier calibration model from {len(vernier_data_points)} data points")
+            self.logger.info(f"{'='*60}")
+            
+            if vernier_data_points:
+                try:
+                    vernier_calib_result = vernier_calib.fit_calibration_from_data(vernier_data_points)
+                    self.logger.info(f"Vernier calibration model fitted successfully")
+                    self.logger.info(f"Calibration model: offset = {vernier_calib_result.get('coeff_offset', 'N/A')}")
+                except Exception as e:
+                    self.logger.error(f"Failed to fit vernier calibration model: {e}")
+                    if not debug:
+                        raise
+            else:
+                self.logger.warning("No vernier data points collected - skipping vernier calibration fit")
+        
+        except KeyboardInterrupt:
+            self.logger.warning("[*] Calibration interrupted by user")
+            # Try to fit vernier model with collected data so far
+            if vernier_data_points:
+                try:
+                    self.logger.info("Fitting vernier calibration from partial data...")
+                    vernier_calib.fit_calibration_from_data(vernier_data_points)
+                except Exception:
+                    pass
+        
+        # Return to initial position
+        self.logger.info(f"\nReturning to initial energy: {energy_start:.4f} keV")
+        self._move_dccm_energy_with_vernier(energy_start)
+        
+        self.logger.warning('Finished long calibration scan!\n')
+        return
+
     def long_escan(
             self,
             simulate: bool = False,
@@ -366,6 +626,11 @@ class Exafs:
             k_offset: int = 0,
             tchk = False,
             use_vernier_calibration: bool = True,
+            align_ondulator: bool = False,
+            ondulator_on_diagnostic: str = "dg1",
+            ondulator_using_device: str = "yag",
+            ondulator_with_method: str = "calib",
+            ondulator_grid_bins: int = 5,
             debug: bool = False):
         """Perform EXAFS scan.
 
@@ -421,10 +686,38 @@ class Exafs:
             use_vernier_calibration: bool, optional
                 If True (default), use vernier calibration if available, otherwise use 
                 intensity-based alignment. If False, always use intensity-based alignment.
+                
+            align_ondulator: bool, optional
+                If True, perform ondulator alignment at each energy step. Default: False
+                
+            ondulator_on_diagnostic: str, optional
+                Diagnostic location for ondulator alignment. Options: "xcs1", "dg1", "dg2". Default: "dg1"
+                
+            ondulator_using_device: str, optional
+                Device to use for ondulator alignment. Options: "yag", "wave8". Default: "yag"
+                
+            ondulator_with_method: str, optional
+                Method to use for ondulator alignment. Options: "turbo", "calib". Default: "calib"
+                
+            ondulator_grid_bins: int, optional
+                Number of grid bins for ondulator calibration (if using "calib" method). Default: 5
         """
         from mfx.autorun import post
 
         self.simulate = simulate
+
+        # Load track_focus results from current working directory, if available
+        track_focus_data = None
+        try:
+            track_focus_path = Path(os.getcwd()) / "track_focus_results.json"
+            if track_focus_path.exists():
+                with open(track_focus_path, "r") as tf:
+                    track_focus_data = json.load(tf)
+                self.logger.info(f"Loaded track_focus results from {track_focus_path}")
+            else:
+                self.logger.info("No track_focus_results.json found in current directory; proceeding without TFS guidance.")
+        except Exception as e:
+            self.logger.warning(f"Failed to load track_focus_results.json: {e}")
 
         energies, wait_times = self._build_energy_and_wait_time(
             energies_list, wait_time_list, start_eV, end_eV, min_k, max_k, element, debug
@@ -453,6 +746,8 @@ class Exafs:
                     energy_keV = energy / 1000.0
 
                     # Move TFS to energy
+                    # Placeholder: will use track_focus_data to position TFS once implemented
+                    self._move_tfs_to_energy(energy_eV=energy, track_focus_data=track_focus_data)
                     
                     # Move DCCM and Vernier to energy
                     self._move_dccm_energy_with_vernier(energy_keV)
@@ -468,6 +763,13 @@ class Exafs:
                     # Move XRT spectrometer camera if necessary
 
                     # Adjust undulator pointing on DCCM
+                    if align_ondulator and not self.simulate:
+                        self._align_ondulator(
+                            on_diagnostic=ondulator_on_diagnostic,
+                            using_device=ondulator_using_device,
+                            with_method=ondulator_with_method,
+                            grid_bins=ondulator_grid_bins
+                        )
 
                     # Wait before moving on
                     self._wait(wait_time)

--- a/mfx/exafs.py
+++ b/mfx/exafs.py
@@ -223,6 +223,7 @@ class Exafs:
             try:
                 from mfx.optimize.beamline_hw import sim_devices
                 sim_devices()
+                print("[align_vernier_to_dccm] Simulation devices initialized")
             except Exception:
                 # Continue even if sim init fails; other simulation guards remain in place
                 ...
@@ -303,9 +304,10 @@ class Exafs:
             try:
                 from mfx.optimize.beamline_hw import sim_devices
                 sim_devices()
+                print("[align_undulator] Simulation devices initialized")
             except Exception:
-                # Continue even if sim init fails; other simulation guards remain in place
-                ...
+                print("[align_undulator] WARNING: Failed to set simulation devices. Returning.")
+                return
         
         try:
             from mfx.optimize.beam import Beam
@@ -315,7 +317,10 @@ class Exafs:
                 using_device=using_device,
                 with_method=with_method,
                 grid_bins=grid_bins,
-                use_2d_markers=True
+                use_2d_markers=True,
+                mover = "und"
+                with_method = "calib",
+                grid_bins = 5
             )
         except Exception as e:
             self.logger.warning(f"undulator alignment failed: {e}")

--- a/mfx/exafs.py
+++ b/mfx/exafs.py
@@ -454,19 +454,17 @@ class Exafs:
         if self.simulate:
             try:
                 from mfx.optimize.beamline_hw import sim_devices
-                sim_devices()
+                _dev = sim_devices()
                 print("Simulated devices initialized")
             except Exception:
-                # Continue even if sim init fails; other simulation guards remain in place
-                ...
+                self.logger.warning("Failed to initialize simulated devices")
+                return
         
         # Store initial position (keV), handling simulation
         try:
             if self.simulate:
                 # Prefer simulated device reading via optimize.beamline_hw if available
                 try:
-                    from mfx.optimize.beamline_hw import init_devices
-                    _dev = init_devices()
                     # vernier_dccm_energy reported in eV
                     energy_start = float(_dev["vernier_dccm_energy"].get()) / 1000.0
                 except Exception:
@@ -494,7 +492,8 @@ class Exafs:
                 energy_start_eV=start_eV,
                 energy_end_eV=end_eV,
                 energy_steps=energy_steps,
-                events_per_step=vernier_events_per_step
+                events_per_step=vernier_events_per_step, 
+                simulate=simulate
             )
             self.logger.info(f"Vernier calibration completed successfully")
             self.logger.info(f"Calibration model: offset = {vernier_calib_result.get('coeff_offset', 'N/A')}")

--- a/mfx/exafs.py
+++ b/mfx/exafs.py
@@ -455,6 +455,7 @@ class Exafs:
             try:
                 from mfx.optimize.beamline_hw import sim_devices
                 sim_devices()
+                print("Simulated devices initialized")
             except Exception:
                 # Continue even if sim init fails; other simulation guards remain in place
                 ...

--- a/mfx/exafs.py
+++ b/mfx/exafs.py
@@ -481,8 +481,37 @@ class Exafs:
         
         self.simulate = simulate
         
-        # Store initial position
-        energy_start = self.dccm.energy_with_vernier.energy()
+        # If simulating, force simulated devices to avoid any real hardware motion
+        if self.simulate:
+            try:
+                from mfx.optimize.beamline_hw import sim_devices as _sim_bl_hw
+                _sim_bl_hw()
+            except Exception:
+                # Continue even if sim init fails; other simulation guards remain in place
+                ...
+        
+        # Store initial position (keV), handling simulation
+        try:
+            if self.simulate:
+                # Prefer simulated device reading via optimize.beamline_hw if available
+                try:
+                    from mfx.optimize.beamline_hw import init_devices as _init_bl_hw
+                    _dev = _init_bl_hw()
+                    # vernier_dccm_energy reported in eV
+                    energy_start = float(_dev["vernier_dccm_energy"].get()) / 1000.0
+                except Exception:
+                    # Fallback to hutch_python sim motors if present
+                    try:
+                        # sim.fast_motor1 is used in _move_dccm_energy_with_vernier
+                        energy_start = float(self.sim.fast_motor1())
+                    except Exception:
+                        # Sensible default
+                        energy_start = float(start_eV) / 1000.0
+            else:
+                energy_start = self.dccm.energy_with_vernier.energy()
+        except Exception:
+            # Last-resort fallback: use requested start energy
+            energy_start = float(start_eV) / 1000.0
         
         # Initialize calibration objects
         vernier_calib = VernierCalibration()

--- a/mfx/exafs.py
+++ b/mfx/exafs.py
@@ -215,56 +215,75 @@ class Exafs:
         use_vernier_calibration : bool
             Whether to use calibration if available
         """
-        if tchk and not self.simulate:
-            from mfx.optimize.vernier_calibration import VernierCalibration
-            from mfx.dccm import DCCM
-            
-            vernier_calib = VernierCalibration()
-            
-            # Check if calibration exists and should be used
-            calib = vernier_calib._load_calibration()
-            use_calibration = use_vernier_calibration and calib is not None
-            
-            if use_calibration:
-                self.logger.info(f"Using existing calibration from {calib.get('timestamp')}")
-                # Method 1: Use calibration
-                # First, move DCCM alone to target energy (not with vernier)
-                self.logger.info(f"Moving DCCM alone to {energy:.4f} keV")
+        if not tchk:
+            return
+        
+        # If simulating, force simulated devices to avoid any real hardware motion
+        if self.simulate:
+            try:
+                from mfx.optimize.beamline_hw import sim_devices
+                sim_devices()
+            except Exception:
+                # Continue even if sim init fails; other simulation guards remain in place
+                ...
+        
+        from mfx.optimize.vernier_calibration import VernierCalibration
+        from mfx.dccm import DCCM
+        
+        vernier_calib = VernierCalibration()
+        
+        # Check if calibration exists and should be used
+        calib = vernier_calib._load_calibration()
+        use_calibration = use_vernier_calibration and calib is not None
+        
+        if use_calibration:
+            self.logger.info(f"Using existing calibration from {calib.get('timestamp')}")
+            # Method 1: Use calibration
+            # First, move DCCM alone to target energy (not with vernier)
+            self.logger.info(f"Moving DCCM alone to {energy:.4f} keV")
+            if self.simulate:
+                # In simulation, use sim motor for DCCM energy
+                self.sim.fast_motor1.mv(energy / 1000.0)
+            else:
                 dccm = DCCM(name='DCCM')
                 dccm.energy.mv(energy / 1000.0)  # DCCM uses keV
-                
-                # Then align vernier using calibration prediction
-                self.logger.info("Aligning vernier using calibration")
-                success = vernier_calib.move_to_energy_with_calibration()
-                if not success:
-                    self.logger.warning(f"Calibration-based alignment failed at energy {energy:.4f} keV")
+            
+            # Then align vernier using calibration prediction
+            self.logger.info("Aligning vernier using calibration")
+            success = vernier_calib.move_to_energy_with_calibration()
+            if not success:
+                self.logger.warning(f"Calibration-based alignment failed at energy {energy:.4f} keV")
+        else:
+            if use_vernier_calibration and calib is None:
+                self.logger.info("No calibration found - using intensity-based alignment")
+            elif not use_vernier_calibration:
+                self.logger.info("use_vernier_calibration=False - using intensity-based alignment")
+            
+            # Method 2: No calibration - use intensity scan
+            # First move DCCM with vernier to approximate position
+            self.logger.info(f"Moving DCCM with vernier to {energy:.4f} keV")
+            if self.simulate:
+                # In simulation, use sim motor for DCCM+vernier energy
+                self.sim.fast_motor1.mv(energy / 1000.0)
             else:
-                if use_vernier_calibration and calib is None:
-                    self.logger.info("No calibration found - using intensity-based alignment")
-                elif not use_vernier_calibration:
-                    self.logger.info("use_vernier_calibration=False - using intensity-based alignment")
-                
-                # Method 2: No calibration - use intensity scan
-                # First move DCCM with vernier to approximate position
-                self.logger.info(f"Moving DCCM with vernier to {energy:.4f} keV")
                 dccm = DCCM(name='DCCM')
                 dccm.energy_with_vernier.mv(energy / 1000.0)  # DCCM uses keV
-                
-                # Then align to DCCM using intensity scan
-                self.logger.info("Performing intensity-based vernier alignment")
-                success = vernier_calib.align_to_dccm(
-                    energy_range_eV=10.0,
-                    energy_steps=11,
-                    events_per_step=12
-                )
-                if not success:
-                    self.logger.warning(f"Intensity-based alignment failed at energy {energy:.4f} keV")
+            
+            # Then align to DCCM using intensity scan
+            self.logger.info("Performing intensity-based vernier alignment")
+            success = vernier_calib.align_to_dccm(
+                energy_range_eV=10.0,
+                energy_steps=11,
+                events_per_step=12
+            )
+            if not success:
+                self.logger.warning(f"Intensity-based alignment failed at energy {energy:.4f} keV")
 
-    def _align_ondulator(self, on_diagnostic, using_device, with_method, grid_bins):
+    def _align_undulator(self, on_diagnostic, using_device, with_method, grid_bins):
         """
-        Perform ondulator (undulator) alignment using beam alignment system.
+        Perform undulator (undulator) alignment using beam alignment system.
         
-        This method uses the Beam.align() function to align the ondulator.
+        This method uses the Beam.align() function to align the undulator.
         If with_method="calib", it will use calibration if available, otherwise run calibration.
         If with_method="turbo", it will use turbo optimization.
         
@@ -279,61 +298,27 @@ class Exafs:
         grid_bins : int
             Number of grid bins for calibration (if using "calib" method)
         """
+        # If simulating, force simulated devices to avoid any real hardware motion
+        if self.simulate:
+            try:
+                from mfx.optimize.beamline_hw import sim_devices
+                sim_devices()
+            except Exception:
+                # Continue even if sim init fails; other simulation guards remain in place
+                ...
+        
         try:
             from mfx.optimize.beam import Beam
-            from mfx.optimize.user_select import select_goal
-            
-            self.logger.info(f"Aligning ondulator on {on_diagnostic} using {using_device} with method {with_method}")
             beam = Beam()
-            
-            # Get the goal for the diagnostic if needed
-            # For YAG with calib method, we might not need a specific goal, but let's get a default
-            goal = None
-            goal_2d = None
-            if using_device == "yag":
-                # Try to get a default goal for YAG
-                try:
-                    goal_info = select_goal(
-                        device_type=using_device,
-                        location=on_diagnostic,
-                        goal=None,
-                        goal_2d=None,
-                        use_2d_markers=False,
-                    )
-                    if isinstance(goal_info, tuple):
-                        goal_2d = goal_info
-                    else:
-                        goal = goal_info
-                except Exception:
-                    # If we can't get a goal, use use_2d_markers to bypass the requirement
-                    pass
-            
-            # Perform alignment
-            # The align() method handles calibration automatically if method is "calib"
-            align_kwargs = {
-                "on_diagnostic": on_diagnostic,
-                "using_device": using_device,
-                "mover": "und",
-                "with_method": with_method,
-                "grid_bins": grid_bins,
-                "save_run": False,  # Don't save runs during scan
-            }
-            
-            # Add goal parameters if we have them, or use use_2d_markers for YAG
-            if using_device == "yag" and goal is None and goal_2d is None:
-                align_kwargs["use_2d_markers"] = True
-            else:
-                if goal is not None:
-                    align_kwargs["with_goal"] = goal
-                if goal_2d is not None:
-                    align_kwargs["with_goal_2d"] = goal_2d
-            
-            result = beam.align(**align_kwargs)
-            
-            self.logger.info(f"Ondulator alignment completed on {on_diagnostic}")
-            
+            beam.align(
+                on_diagnostic=on_diagnostic,
+                using_device=using_device,
+                with_method=with_method,
+                grid_bins=grid_bins,
+                use_2d_markers=True
+            )
         except Exception as e:
-            self.logger.warning(f"Ondulator alignment failed: {e}")
+            self.logger.warning(f"undulator alignment failed: {e}")
             # Don't raise - allow scan to continue
 
     def _move_tfs_to_energy(self, energy_eV, track_focus_data):
@@ -435,15 +420,11 @@ class Exafs:
             end_eV: float = 7500.0,
             energy_steps: int = 6,
             vernier_events_per_step: int = 120,
-            ondulator_on_diagnostic: str = "dg1",
-            ondulator_grid_bins: int = 5,
-            ondulator_using_device: str = "yag",
             debug: bool = False):
-        """Perform calibration scan over energy range for both vernier and ondulator.
+        """Perform calibration scan over energy range for vernier.
         
-        This function performs calibrations in a single energy loop:
-        1. At each energy: collects vernier offset data and runs ondulator calibration
-        2. After the loop: fits a single vernier calibration model from all collected offset data
+        This function calls VernierCalibration.calibrate() to perform a calibration scan
+        over the specified energy range.
         
         Parameters:
         -----------
@@ -462,30 +443,18 @@ class Exafs:
         vernier_events_per_step : int, optional
             Number of events to average for vernier offset measurement. Default: 120
             
-        ondulator_on_diagnostic : str, optional
-            Diagnostic location for ondulator calibration. Options: "xcs1", "dg1", "dg2". Default: "dg1"
-            
-        ondulator_grid_bins : int, optional
-            Number of grid bins for ondulator calibration. Default: 5
-            
-        ondulator_using_device : str, optional
-            Device to use for ondulator calibration. Options: "yag", "wave8". Default: "yag"
-            
         debug : bool, optional
             Enable debug output. Default: False
         """
         from mfx.optimize.vernier_calibration import VernierCalibration
-        from mfx.optimize.beam import Beam
-        from mfx.optimize.xopt_scans import get_xopt_obj
-        from mfx.optimize.user_select import select_goal
         
         self.simulate = simulate
         
         # If simulating, force simulated devices to avoid any real hardware motion
         if self.simulate:
             try:
-                from mfx.optimize.beamline_hw import sim_devices as _sim_bl_hw
-                _sim_bl_hw()
+                from mfx.optimize.beamline_hw import sim_devices
+                sim_devices()
             except Exception:
                 # Continue even if sim init fails; other simulation guards remain in place
                 ...
@@ -495,8 +464,8 @@ class Exafs:
             if self.simulate:
                 # Prefer simulated device reading via optimize.beamline_hw if available
                 try:
-                    from mfx.optimize.beamline_hw import init_devices as _init_bl_hw
-                    _dev = _init_bl_hw()
+                    from mfx.optimize.beamline_hw import init_devices
+                    _dev = init_devices()
                     # vernier_dccm_energy reported in eV
                     energy_start = float(_dev["vernier_dccm_energy"].get()) / 1000.0
                 except Exception:
@@ -513,116 +482,28 @@ class Exafs:
             # Last-resort fallback: use requested start energy
             energy_start = float(start_eV) / 1000.0
         
-        # Initialize calibration objects
+        # Initialize calibration object
         vernier_calib = VernierCalibration()
-        beam = Beam()
-        
-        # Generate energy list
-        energies = np.linspace(start_eV, end_eV, energy_steps)
-        
-        # Storage for vernier calibration data
-        vernier_data_points = []
         
         self.logger.info(f"Starting long calibration scan from {start_eV:.2f} to {end_eV:.2f} eV ({energy_steps} steps)")
         
         try:
-            # Single loop through energies
-            for i, target_energy in enumerate(energies):
-                self.logger.info(f"\n{'='*60}")
-                self.logger.info(f"Calibration step {i+1}/{energy_steps} at energy {target_energy:.2f} eV")
-                self.logger.info(f"{'='*60}")
-                
-                energy_keV = target_energy / 1000.0
-                
-                # Move DCCM and Vernier to target energy
-                self.logger.info(f"Moving DCCM and Vernier to {target_energy:.2f} eV ({energy_keV:.4f} keV)")
-                self._move_dccm_energy_with_vernier(energy_keV)
-                
-                # Collect vernier offset data at this energy
-                self.logger.info(f"\n--- Collecting vernier offset data at {target_energy:.2f} eV ---")
-                try:
-                    vernier_data = vernier_calib.collect_offset_data_at_energy(
-                        events=vernier_events_per_step
-                    )
-                    vernier_data_points.append(vernier_data)
-                    self.logger.info(f"Vernier data collected at {target_energy:.2f} eV")
-                except Exception as e:
-                    self.logger.error(f"Failed to collect vernier data at {target_energy:.2f} eV: {e}")
-                    if not debug:
-                        raise
-                    continue
-                
-                # Run ondulator calibration at this energy
-                self.logger.info(f"\n--- Running ondulator calibration at {target_energy:.2f} eV ---")
-                try:
-                    # Create xopt_obj for ondulator calibration
-                    # We need to get the goal for the diagnostic
-                    goal = select_goal(
-                        device_type=ondulator_using_device,
-                        location=ondulator_on_diagnostic,
-                        goal=None,
-                        goal_2d=None,
-                        use_2d_markers=False,
-                    )
-                    
-                    # Create xopt object for calibration
-                    xopt_obj = get_xopt_obj(
-                        device_type=ondulator_using_device,
-                        location=ondulator_on_diagnostic,
-                        mover="und",
-                        goal=goal if not isinstance(goal, tuple) else None,
-                        goal_2d=goal if isinstance(goal, tuple) else None,
-                        xopt_generator_turbo_controller="optimize",
-                        max_iter=2000,
-                        dump_file=None,
-                        num_frames=1,
-                    )
-                    
-                    # Run calibration at this energy
-                    # This will do a grid scan of undulator positions and fit
-                    # the relationship: centroid = f(undulator_x, undulator_y)
-                    ondulator_calib_result = beam.calibrate(
-                        xopt_obj=xopt_obj,
-                        on_diagnostic=ondulator_on_diagnostic,
-                        grid_bins=ondulator_grid_bins
-                    )
-                    self.logger.info(f"Ondulator calibration completed at {target_energy:.2f} eV")
-                except Exception as e:
-                    self.logger.error(f"Ondulator calibration failed at {target_energy:.2f} eV: {e}")
-                    if not debug:
-                        raise
-                    continue
-                
-                self.logger.info(f"Completed calibration step {i+1}/{energy_steps} at {target_energy:.2f} eV")
-            
-            # ============================================================
-            # Fit vernier calibration model from all collected data
-            # ============================================================
-            self.logger.info(f"\n{'='*60}")
-            self.logger.info(f"Fitting vernier calibration model from {len(vernier_data_points)} data points")
-            self.logger.info(f"{'='*60}")
-            
-            if vernier_data_points:
-                try:
-                    vernier_calib_result = vernier_calib.fit_calibration_from_data(vernier_data_points)
-                    self.logger.info(f"Vernier calibration model fitted successfully")
-                    self.logger.info(f"Calibration model: offset = {vernier_calib_result.get('coeff_offset', 'N/A')}")
-                except Exception as e:
-                    self.logger.error(f"Failed to fit vernier calibration model: {e}")
-                    if not debug:
-                        raise
-            else:
-                self.logger.warning("No vernier data points collected - skipping vernier calibration fit")
+            # Call the calibrate method which handles the entire scan and fitting
+            vernier_calib_result = vernier_calib.calibrate(
+                energy_start_eV=start_eV,
+                energy_end_eV=end_eV,
+                energy_steps=energy_steps,
+                events_per_step=vernier_events_per_step
+            )
+            self.logger.info(f"Vernier calibration completed successfully")
+            self.logger.info(f"Calibration model: offset = {vernier_calib_result.get('coeff_offset', 'N/A')}")
         
         except KeyboardInterrupt:
             self.logger.warning("[*] Calibration interrupted by user")
-            # Try to fit vernier model with collected data so far
-            if vernier_data_points:
-                try:
-                    self.logger.info("Fitting vernier calibration from partial data...")
-                    vernier_calib.fit_calibration_from_data(vernier_data_points)
-                except Exception:
-                    pass
+        except Exception as e:
+            self.logger.error(f"Failed to complete vernier calibration: {e}")
+            if not debug:
+                raise
         
         # Return to initial position
         self.logger.info(f"\nReturning to initial energy: {energy_start:.4f} keV")
@@ -655,11 +536,11 @@ class Exafs:
             k_offset: int = 0,
             tchk = False,
             use_vernier_calibration: bool = True,
-            align_ondulator: bool = False,
-            ondulator_on_diagnostic: str = "dg1",
-            ondulator_using_device: str = "yag",
-            ondulator_with_method: str = "calib",
-            ondulator_grid_bins: int = 5,
+            undulator_point: bool = False,
+            undulator_on_diagnostic: str = "dg1",
+            undulator_using_device: str = "yag",
+            undulator_with_method: str = "calib",
+            undulator_grid_bins: int = 5,
             debug: bool = False):
         """Perform EXAFS scan.
 
@@ -716,20 +597,20 @@ class Exafs:
                 If True (default), use vernier calibration if available, otherwise use 
                 intensity-based alignment. If False, always use intensity-based alignment.
                 
-            align_ondulator: bool, optional
-                If True, perform ondulator alignment at each energy step. Default: False
+            undulator_point: bool, optional
+                If True, perform undulator alignment at each energy step. Default: False
                 
-            ondulator_on_diagnostic: str, optional
-                Diagnostic location for ondulator alignment. Options: "xcs1", "dg1", "dg2". Default: "dg1"
+            undulator_on_diagnostic: str, optional
+                Diagnostic location for undulator alignment. Options: "xcs1", "dg1", "dg2". Default: "dg1"
                 
-            ondulator_using_device: str, optional
-                Device to use for ondulator alignment. Options: "yag", "wave8". Default: "yag"
+            undulator_using_device: str, optional
+                Device to use for undulator alignment. Options: "yag", "wave8". Default: "yag"
                 
-            ondulator_with_method: str, optional
-                Method to use for ondulator alignment. Options: "turbo", "calib". Default: "calib"
+            undulator_with_method: str, optional
+                Method to use for undulator alignment. Options: "turbo", "calib". Default: "calib"
                 
-            ondulator_grid_bins: int, optional
-                Number of grid bins for ondulator calibration (if using "calib" method). Default: 5
+            undulator_grid_bins: int, optional
+                Number of grid bins for undulator calibration (if using "calib" method). Default: 5
         """
         from mfx.autorun import post
 
@@ -768,6 +649,13 @@ class Exafs:
                 )
                 if not daq_success:
                     break
+                if undulator_point:
+                    self._align_undulator(
+                        on_diagnostic=undulator_on_diagnostic,
+                        using_device=undulator_using_device,
+                        with_method=undulator_with_method,
+                        grid_bins=undulator_grid_bins
+                    )
 
                 # Start Energy scan
                 for ii, (energy, wait_time) in enumerate(zip(energies, wait_times)):
@@ -792,13 +680,6 @@ class Exafs:
                     # Move XRT spectrometer camera if necessary
 
                     # Adjust undulator pointing on DCCM
-                    if align_ondulator and not self.simulate:
-                        self._align_ondulator(
-                            on_diagnostic=ondulator_on_diagnostic,
-                            using_device=ondulator_using_device,
-                            with_method=ondulator_with_method,
-                            grid_bins=ondulator_grid_bins
-                        )
 
                     # Wait before moving on
                     self._wait(wait_time)

--- a/mfx/optimize/beamline_hw.py
+++ b/mfx/optimize/beamline_hw.py
@@ -80,7 +80,7 @@ def init_devices(force: bool = False) -> dict[str, Device]:
     devices["und_del"] = und_abs.delta_xy
 
     # Add vernier calibration devices
-    devices["vernier_dccm_energy"] = EpicsSignalRO("MFX:DCCM:ENERGY", name="vernier_dccm_energy")
+
     devices["vernier_energy"] = OnePVMotor("MFX:USER:MCC:EPHOT:SET1", name="vernier_energy")
     devices["vernier_intensity"] = EpicsSignalRO("MFX:DG1:W8:01:SUM", name="vernier_intensity")
 
@@ -481,12 +481,9 @@ def sim_devices() -> dict[str, Device]:
     def wrapper_intensity():
         return get_fake_intensity()
     
-    # Create the signal devices - use wrapper to ensure fresh evaluation
-    devices["vernier_dccm_energy"] = SynSignal(func=wrapper_dccm, name="vernier_dccm_energy")
+    # For simulation, prefer using read_dccm_energy() helper rather than a fake PV.
+    # Keep intensity as a SynSignal for scans.
     devices["vernier_intensity"] = SynSignal(func=wrapper_intensity, name="vernier_intensity")
-    
-    # Mark these as hinted so they're included in scans
-    devices["vernier_dccm_energy"].kind = "hinted"
     devices["vernier_intensity"].kind = "hinted"
 
     print("Generated fake dg1 and dg2 signals and images")
@@ -514,3 +511,34 @@ def get_alignment_scan_mode():
 def get_calibration_scan_mode():
     """Get the calibration scan mode flag."""
     return _calibration_scan_mode
+
+
+# Helper API: preferred way to read DCCM energy in both real and simulation
+def read_dccm_energy() -> float:
+    """
+    Read the current DCCM energy in eV.
+
+    - In simulation (sim_devices() initialized): returns the simulated tracker value
+    - In real hardware: instantiates DCCM and reads the pseudo motor energy (keV),
+      then converts to eV.
+    """
+    # If simulation tracker exists, use it
+    global _dccm_tracker
+    try:
+        if _dccm_tracker is not None:
+            return float(_dccm_tracker.value)
+    except Exception:
+        ...
+
+    # Real hardware path: use DCCM device
+    try:
+        from mfx.dccm import DCCM
+        dccm = DCCM(name="DCCM")
+        # dccm.energy is in keV; convert to eV
+        keV = float(dccm.energy())
+        return keV * 1000.0
+    except Exception:
+        print(f"[read_dccm_energy] WARNING: Could not import DCCM device: {e}")
+        return 0.0
+    # If all else fails, return a reasonable default
+    return 0.0

--- a/mfx/optimize/vernier_calibration.py
+++ b/mfx/optimize/vernier_calibration.py
@@ -375,7 +375,6 @@ class VernierCalibration:
             # This ensures SynSignals get the current motor position
             tracker = None
             get_intensity_func = None
-            get_dccm_func = None
             try:
                 # Try to get the tracker from the vernier device (simulation mode)
                 if hasattr(vernier_energy_pv, 'pos_tracker'):
@@ -416,7 +415,7 @@ class VernierCalibration:
                         return
                     
                     try:
-                        dccm_energy = float(get_dccm_func())
+                        dccm_energy = float(read_dccm_energy())
                     except Exception as e:
                         print(f"[calibrate] Failed to get DCCM energy: {e}")
                         return
@@ -788,7 +787,6 @@ class VernierCalibration:
             # For simulation mode, get tracker and functions from devices
             tracker = None
             get_intensity_func = None
-            get_dccm_func = None
             try:
                 if hasattr(vernier_energy_pv, 'pos_tracker'):
                     tracker = vernier_energy_pv.pos_tracker

--- a/mfx/optimize/vernier_calibration.py
+++ b/mfx/optimize/vernier_calibration.py
@@ -218,11 +218,10 @@ class VernierCalibration:
         try:
             # Get devices from beamline_hw
             devices = init_devices()
-            dccm_energy_pv = devices["vernier_dccm_energy"]
             vernier_energy_pv = devices["vernier_energy"]
             
             # Get current DCCM energy (this is what we're trying to reach)
-            current_dccm_energy = float(dccm_energy_pv.get())
+            current_dccm_energy = float(read_dccm_energy())
             
             # Get current vernier energy
             current_vernier_energy = float(vernier_energy_pv.position)
@@ -384,8 +383,6 @@ class VernierCalibration:
                     # Get the underlying functions for direct calls in simulation
                     if hasattr(intensity_pv, '_func'):
                         get_intensity_func = intensity_pv._func
-                    if hasattr(dccm_energy_pv, '_func'):
-                        get_dccm_func = dccm_energy_pv._func
             except AttributeError:
                 pass
             
@@ -581,7 +578,7 @@ class VernierCalibration:
         
         # Read current positions
         try:
-            dccm_energy = float(dccm_energy_pv.get())
+            dccm_energy = float(read_dccm_energy())
             vernier_energy = float(vernier_energy_pv.position)
             # Average intensity over multiple readings
             intensities = []
@@ -798,8 +795,6 @@ class VernierCalibration:
                 # Get the underlying functions for direct calls in simulation
                 if hasattr(intensity_pv, '_func'):
                     get_intensity_func = intensity_pv._func
-                if hasattr(dccm_energy_pv, '_func'):
-                    get_dccm_func = dccm_energy_pv._func
             except AttributeError:
                 pass
             

--- a/mfx/optimize/vernier_calibration.py
+++ b/mfx/optimize/vernier_calibration.py
@@ -19,6 +19,7 @@ from .beamline_hw import (
     DG2_WAVE8_XPOS,
     IP_YAG_XPOS,
     init_devices,
+    read_dccm_energy,
 )
 
 
@@ -250,7 +251,8 @@ class VernierCalibration:
             return False
     
     def calibrate(self, energy_start_eV: float, energy_end_eV: float, 
-                  energy_steps: int = 10, events_per_step: int = 120) -> dict:
+                  energy_steps: int = 10, events_per_step: int = 120, 
+                  simulate: Optional[bool] = None) -> dict:
         """
         Run calibration scan to determine energy-vernier offset relationship.
         
@@ -264,6 +266,9 @@ class VernierCalibration:
             Number of energy steps in calibration scan
         events_per_step : int
             Number of events per step
+        simulate : bool, optional
+            Whether to run in simulation mode. If None, defaults to False (real hardware).
+            If True, uses simulated devices. If False, attempts to use real hardware.
             
         Returns
         -------
@@ -274,24 +279,34 @@ class VernierCalibration:
         print(f"[calibrate] Energy range: {energy_start_eV:.2f} - {energy_end_eV:.2f} eV")
         print(f"[calibrate] Steps: {energy_steps}")
         
+        # If simulating, force simulated devices to avoid any real hardware motion
+        if simulate:
+            try:
+                from .beamline_hw import sim_devices
+                sim_devices()
+            except Exception:
+                print("[calibrate] WARNING: Failed to set simulation devices. Returning.")
+                return
+
         # Get devices from beamline_hw (will be real or simulated based on sim_devices() call)
         devices = init_devices()
-        dccm_energy_pv = devices["vernier_dccm_energy"]
         vernier_energy_pv = devices["vernier_energy"]
         intensity_pv = devices["vernier_intensity"]
         
-        # Check if we're in simulation mode
-        try:
-            from mfx.db import RE, daq
-            is_simulation = False
-        except ImportError:
-            is_simulation = True
-            print("[calibrate] Simulation mode detected")
+        # Determine simulation mode from argument
+        is_simulation = simulate if simulate is not None else False
+        if is_simulation:
+            print("[calibrate] Simulation mode enabled")
+        
+        # Try to import real hardware (will be used if not simulating)
+        if not is_simulation:
+            try:
+                from mfx.db import RE, daq
+            except ImportError:
+                pass  # Continue without RE/daq if import fails
         
         # For real hardware, import DCCM device to move both DCCM and vernier together
         dccm_motor = None
-        energy_start_keV = None
-        energy_end_keV = None
         if not is_simulation:
             try:
                 from mfx.dccm import DCCM
@@ -318,12 +333,15 @@ class VernierCalibration:
             "vernier_energy": []
         }
         
-        # Perform calibration scan
-        # RE and daq already imported above when checking simulation mode
+        # Import RE and daq based on simulation mode
         if is_simulation:
             from bluesky import RunEngine
             RE = RunEngine({})
             daq = FakeDaq()
+        else:
+            # RE and daq should be imported above if real hardware is available
+            # If not available, they won't exist and will cause an error later (which is fine)
+            pass
         
         try:
             import bluesky.plans as bp
@@ -414,7 +432,7 @@ class VernierCalibration:
                         return
                     
                     try:
-                        dccm_energy = float(dccm_energy_pv.get())
+                        dccm_energy = float(read_dccm_energy())
                     except Exception as e:
                         print(f"[calibrate] Failed to read DCCM energy: {e}")
                         return
@@ -556,10 +574,8 @@ class VernierCalibration:
         dict
             Dictionary with keys: "dccm_energy", "vernier_energy", "vernier_offset", "intensity"
         """
-        from .beamline_hw import init_devices
         
         devices = init_devices()
-        dccm_energy_pv = devices["vernier_dccm_energy"]
         vernier_energy_pv = devices["vernier_energy"]
         intensity_pv = devices["vernier_intensity"]
         
@@ -671,7 +687,7 @@ class VernierCalibration:
         return calib
     
     def align_to_dccm(self, energy_range_eV: float = 10.0, energy_steps: int = 11,
-                     events_per_step: int = 12) -> bool:
+                     events_per_step: int = 12, simulate: Optional[bool] = None) -> bool:
         """
         Align vernier to current DCCM energy using intensity-based optimization.
         
@@ -687,21 +703,33 @@ class VernierCalibration:
             Number of steps in alignment scan
         events_per_step : int
             Number of events per step
+        simulate : bool, optional
+            Whether to run in simulation mode. If None, defaults to False (real hardware).
+            If True, uses simulated devices. If False, attempts to use real hardware.
             
         Returns
         -------
         bool
             True if alignment was successful, False otherwise
         """
+
+        if simulate:
+            try:
+                from .beamline_hw import sim_devices
+                sim_devices()
+                print("[align_to_dccm] Simulation mode enabled")
+            except Exception:
+                print("[align_to_dccm] WARNING: Failed to set simulation devices. Returning.")
+                return 
+            
         # Get devices from beamline_hw (will be real or simulated based on sim_devices() call)
         devices = init_devices()
-        dccm_energy_pv = devices["vernier_dccm_energy"]
         vernier_energy_pv = devices["vernier_energy"]
         intensity_pv = devices["vernier_intensity"]
         
         # Get current DCCM energy
         print(f"[align_to_dccm] Reading current DCCM energy...")
-        current_dccm_energy = float(dccm_energy_pv.get())
+        current_dccm_energy = float(read_dccm_energy())
         print(f"[align_to_dccm] Current DCCM energy: {current_dccm_energy:.2f} eV")
         
         # Update DCCM tracker to current DCCM energy (important for simulation mode)
@@ -723,14 +751,22 @@ class VernierCalibration:
         
         print(f"[align_to_dccm] Scanning vernier from {scan_start:.2f} to {scan_end:.2f} eV (range: ±{energy_range_eV/2:.1f} eV around DCCM at {current_dccm_energy:.2f} eV)")
         
-        # Perform intensity-based alignment scan
-        try:
-            from mfx.db import RE, daq
-        except ImportError:
+        # Determine simulation mode from argument
+        is_simulation = simulate if simulate is not None else False
+        if is_simulation:
+            print("[align_to_dccm] Simulation mode enabled")
+        
+        # Import RE and daq based on simulation mode
+        if is_simulation:
             from bluesky import RunEngine
             RE = RunEngine({})
             daq = FakeDaq()
-            print("[align_to_dccm] Cannot import mfx.db - running in simulation mode")
+        else:
+            # Try to import real hardware
+            try:
+                from mfx.db import RE, daq
+            except ImportError:
+                pass  # Continue without RE/daq if import fails
         
         try:
             import bluesky.plans as bp
@@ -855,7 +891,7 @@ class VernierCalibration:
             # Verify final positions
             if best_vernier_energy is not None:
                 # Verify final DCCM energy
-                final_dccm_energy = float(dccm_energy_pv.get())
+                final_dccm_energy = float(read_dccm_energy())
                 final_vernier_actual = float(vernier_energy_pv.position)
                 final_offset = final_vernier_actual - final_dccm_energy
                 
@@ -873,7 +909,7 @@ class VernierCalibration:
             print(f"[align_to_dccm] Error during alignment: {exc}")
             return False
     
-    def move_to_energy_with_calibration(self) -> bool:
+    def move_to_energy_with_calibration(self, simulate: Optional[bool] = None) -> bool:
         """
         Move vernier to align with current DCCM energy using calibration to correct for offset.
         
@@ -892,7 +928,13 @@ class VernierCalibration:
         """
         print(f"[move_to_energy_with_calibration] Aligning vernier to current DCCM energy")
         
-        # Load calibration
+        if simulate:
+            try:
+                from .beamline_hw import sim_devices
+                sim_devices()
+            except Exception:
+                ...
+# Load calibration
         calib = self._load_calibration()
         if not calib:
             print(f"[move_to_energy_with_calibration] No calibration found")
@@ -902,11 +944,10 @@ class VernierCalibration:
         
         # Get devices from beamline_hw
         devices = init_devices()
-        dccm_energy_pv = devices["vernier_dccm_energy"]
         vernier_energy_pv = devices["vernier_energy"]
         
         # Get current DCCM energy
-        current_dccm_energy = float(dccm_energy_pv.get())
+        current_dccm_energy = float(read_dccm_energy())
         print(f"[move_to_energy_with_calibration] Current DCCM energy: {current_dccm_energy:.2f} eV")
         
         # Calculate what vernier command is needed to achieve vernier = DCCM
@@ -919,7 +960,7 @@ class VernierCalibration:
             vernier_energy_pv.move(vernier_command).wait()
             
             # Verify final positions
-            final_dccm_energy = float(dccm_energy_pv.get())
+            final_dccm_energy = float(read_dccm_energy())
             final_vernier_actual = float(vernier_energy_pv.position)
             final_offset = final_vernier_actual - final_dccm_energy
             

--- a/mfx/optimize/vernier_calibration.py
+++ b/mfx/optimize/vernier_calibration.py
@@ -539,7 +539,7 @@ class VernierCalibration:
         
         return calib
     
-    def collect_offset_data_at_energy(self, events: int = 120) -> dict:
+    def measure_offset_at_energy(self, events: int = 120) -> dict:
         """
         Collect vernier offset data at the current energy.
         
@@ -593,7 +593,7 @@ class VernierCalibration:
         
         return data
     
-    def fit_calibration_from_data(self, data_points: list[dict]) -> dict:
+    def fit(self, data_points: list[dict]) -> dict:
         """
         Fit vernier calibration model from collected data points.
         

--- a/mfx/optimize/vernier_calibration.py
+++ b/mfx/optimize/vernier_calibration.py
@@ -539,6 +539,137 @@ class VernierCalibration:
         
         return calib
     
+    def collect_offset_data_at_energy(self, events: int = 120) -> dict:
+        """
+        Collect vernier offset data at the current energy.
+        
+        This is a helper method for collecting data point-by-point when
+        energy is controlled externally (e.g., in a loop).
+        
+        Parameters
+        ----------
+        events : int
+            Number of events to average for intensity measurement
+            
+        Returns
+        -------
+        dict
+            Dictionary with keys: "dccm_energy", "vernier_energy", "vernier_offset", "intensity"
+        """
+        from .beamline_hw import init_devices
+        
+        devices = init_devices()
+        dccm_energy_pv = devices["vernier_dccm_energy"]
+        vernier_energy_pv = devices["vernier_energy"]
+        intensity_pv = devices["vernier_intensity"]
+        
+        # Read current positions
+        try:
+            dccm_energy = float(dccm_energy_pv.get())
+            vernier_energy = float(vernier_energy_pv.position)
+            # Average intensity over multiple readings
+            intensities = []
+            for _ in range(events):
+                try:
+                    intensities.append(float(intensity_pv.get()))
+                except Exception:
+                    pass
+            intensity = np.mean(intensities) if intensities else float(intensity_pv.get())
+        except Exception as e:
+            print(f"[collect_offset_data_at_energy] Failed to read data: {e}")
+            raise
+        
+        offset = vernier_energy - dccm_energy
+        
+        data = {
+            "dccm_energy": dccm_energy,
+            "vernier_energy": vernier_energy,
+            "vernier_offset": offset,
+            "intensity": intensity
+        }
+        
+        print(f"[collect_offset_data_at_energy] Collected: dccm={dccm_energy:.2f} eV, "
+              f"vernier={vernier_energy:.2f} eV, offset={offset:.2f} eV, intensity={intensity:.2f}")
+        
+        return data
+    
+    def fit_calibration_from_data(self, data_points: list[dict]) -> dict:
+        """
+        Fit vernier calibration model from collected data points.
+        
+        Parameters
+        ----------
+        data_points : list[dict]
+            List of data dictionaries, each with keys: "dccm_energy", "vernier_offset", etc.
+            
+        Returns
+        -------
+        dict
+            Calibration dictionary containing coefficients and metadata
+        """
+        if not data_points:
+            raise ValueError("No data points provided for calibration")
+        
+        # Convert to DataFrame
+        df = pd.DataFrame(data_points)
+        print(f"[fit_calibration_from_data] Fitting model from {len(df)} data points")
+        
+        # Fit model: offset = a0 + a1 * target_energy
+        # Where target_energy is the DCCM energy (what we're trying to reach)
+        X = df["dccm_energy"].values.reshape(-1, 1)
+        y_offset = df["vernier_offset"].values
+        
+        reg_offset = LinearRegression().fit(X, y_offset)
+        
+        # Calculate coefficients
+        coeff_offset = np.concatenate([[reg_offset.intercept_], reg_offset.coef_])
+        
+        # Calculate prediction errors
+        pred_offset = reg_offset.predict(X)
+        err_offset = np.abs(pred_offset - y_offset)
+        sigma_offset = float(np.std(err_offset))
+        
+        print(f"[fit_calibration_from_data] Offset coefficients: a0={coeff_offset[0]:.3f}, a1={coeff_offset[1]:.6f}")
+        print(f"[fit_calibration_from_data] Offset sigma: {sigma_offset:.3f} eV")
+        
+        # Save calibration data
+        ts = datetime.datetime.now().strftime("%y-%m-%d-%H:%M:%S")
+        
+        # Save raw data
+        csv_path = str(self.calib_dir / f"vernier_calib_data_{ts}.csv")
+        df.to_csv(csv_path, index=False)
+        print(f"[fit_calibration_from_data] Saved calibration data: {csv_path}")
+        
+        # Save plots
+        plot_path = self._save_calibration_plots(df, reg_offset, self.calib_dir, ts)
+        
+        # Get energy range from data
+        energy_start_eV = float(df["dccm_energy"].min())
+        energy_end_eV = float(df["dccm_energy"].max())
+        
+        # Create calibration dictionary
+        calib = {
+            "timestamp": datetime.datetime.now().isoformat(timespec="seconds"),
+            "coeff_offset": [float(v) for v in coeff_offset.tolist()],
+            "sigma_offset": sigma_offset,
+            "energy_range": [energy_start_eV, energy_end_eV],
+            "energy_steps": len(df),
+            "data_csv": csv_path,
+            "plot_path": plot_path,
+            "num_points": len(df)
+        }
+        
+        # Save calibration
+        calib_path = self.calib_dir / f"vernier_calib_{ts}.json"
+        try:
+            with open(calib_path, "w") as f:
+                json.dump(calib, f, indent=2)
+            print(f"[fit_calibration_from_data] Saved calibration: {calib_path}")
+        except Exception as exc:
+            print(f"[fit_calibration_from_data] Warning: failed to save calibration: {exc}")
+        
+        return calib
+    
     def align_to_dccm(self, energy_range_eV: float = 10.0, energy_steps: int = 11,
                      events_per_step: int = 12) -> bool:
         """


### PR DESCRIPTION
Added long_calib workflow, vernier helper functions, and TFS placeholder integration

### Summary
- Introduces long_calib to coordinate per-energy ondulator calibration and deferred vernier model fitting.
- Adds two helper functions to vernier calibration to support collecting point-wise data and fitting the model post-hoc.
- Prepares long_escan for Transfocator integration by reading track_focus output and adding a placeholder move.

### Changes

#### exafs.Exafs.long_calib
- Orchestrates a single-pass energy loop:
  - For each energy:
    - Moves DCCM+Vernier to the target energy.
    - Collects vernier offset/intensity data point at that energy.
    - Runs ondulator (undulator) calibration at that fixed energy using Xopt (grid-based fit of centroid vs undulator x/y).
  - After the loop:
    - Fits a single vernier calibration model offset = f(dccm_energy) from the collected data points.
    - Persists calibration artifacts consistent with existing vernier calibration format.

- Key behavior:
  - Uses `mfx.optimize.vernier_calibration.VernierCalibration.collect_offset_data_at_energy` to capture one offset datum per energy.
  - Uses `mfx.optimize.vernier_calibration.VernierCalibration.fit_calibration_from_data` to fit one global offset model across energies.
  - Uses `mfx.optimize.beam.Beam.calibrate` for ondulator calibration per energy (creates an `xopt_obj` with appropriate goal/device).

#### exafs.Exafs.long_escan
- Reads Transfocator track-focus outputs at the start of a scan:
  - Loads `track_focus_results.json` from the current working directory if present; logs status otherwise.
- Adds a placeholder call where TFS should be moved during energy stepping:
  - `self._move_tfs_to_energy(energy_eV=energy, track_focus_data=track_focus_data)`

#### exafs.Exafs._move_tfs_to_energy (placeholder)
- New no-op method to be implemented later:
  - Receives current `energy_eV` and optional `track_focus_data`.
  - Intended to position TFS using the precomputed track-focus schedule.

#### mfx.optimize.vernier_calibration (new helpers)
- Added two functions to support long_calib’s flow:
  - `collect_offset_data_at_energy(events=120)`:
    - Reads and returns a dict with `dccm_energy`, `vernier_energy`, `vernier_offset`, and averaged `intensity`.
    - Designed for point-wise data collection when energy is controlled externally.
  - `fit_calibration_from_data(data_points: list[dict])`:
    - Fits linear model `offset = a0 + a1 * dccm_energy` from the collected points.
    - Saves CSV, plot, and JSON calibration with the same schema used elsewhere.
