### PR TITLE
Executing TFS alignment in long_escan 

### DIFF
--- a/mfx/exafs.py
+++ b/mfx/exafs.py
@@ -5,7 +5,7 @@ from time import sleep
 from pathlib import Path
 import json
 from tfs.sim_transfocator import make_tfs_sim
-from tfs.transfocator import Transfocator as tfs
+from tfs.transfocator import Transfocator
 
 class Exafs:
     from pcdsdevices.beam_stats import BeamEnergyRequest, BeamEnergyRequestACRWait
@@ -277,16 +277,14 @@ class Exafs:
         return track_focus_data
 
     def _init_tfs(self, energies):
+        tfs = Transfocator("MFX:LENS", name='MFX Transfocator')
         if self.simulate:
             self.tfs = make_tfs_sim(tfs)
         else:
             self.tfs = tfs
 
-        track_focus_data = self._get_track_focus_data()
-        if track_focus_data is None:
-            self.logger.warning("No track_focus_data found; generating new track_focus_data in simulation.")
-            sim_tfs = make_tfs_sim(tfs)
-            track_focus_data = sim_tfs.track_focus(energies=energies, show=True)
+        sim_tfs = make_tfs_sim(tfs)
+        track_focus_data = sim_tfs.track_focus(energies=energies, show=True)
         return track_focus_data
 
     def _move_tfs_to_energy(self, energy_eV, track_focus_data):

--- a/mfx/exafs.py
+++ b/mfx/exafs.py
@@ -2,6 +2,9 @@ import copy
 import numpy as np
 import sys
 from time import sleep
+from pathlib import Path
+import json
+from tfs.sim_transfocator import make_tfs_sim
 
 class Exafs:
     from pcdsdevices.beam_stats import BeamEnergyRequest, BeamEnergyRequestACRWait
@@ -19,6 +22,7 @@ class Exafs:
         self.exafs_energy_range_builder = EXAFSEnergyRangeBuilder()
         self.simulate = False
         self.sim = sim.get_hw()
+        self.tfs = None
 
     # DG1 IPM SUM PV (read-only)
     ipm_sum = EpicsSignalRO("MFX:DG1:W8:01:SUM", name="dg1_sum")
@@ -256,6 +260,63 @@ class Exafs:
                 )
                 if not success:
                     self.logger.warning(f"Intensity-based alignment failed at energy {energy:.4f} keV")
+    
+    def _get_track_focus_data(self):
+        track_focus_data = None
+        try:
+            track_focus_path = Path.home() / "track_focus_results.json"
+            if track_focus_path.exists():
+                with open(track_focus_path, "r") as tf:
+                    track_focus_data = json.load(tf)
+                self.logger.info(f"Loaded track_focus results from {track_focus_path}")
+            else:
+                self.logger.info("No track_focus_results.json found in home directory; returning None.")
+        except Exception as e:
+            self.logger.warning(f"Failed to load track_focus_results.json: {e}")
+        return track_focus_data
+
+    def _init_tfs(self, energies):
+        if self.simulate:
+            self.tfs = make_tfs_sim(tfs)
+        else:
+            self.tfs = tfs
+
+        track_focus_data = self._get_track_focus_data()
+        if track_focus_data is None:
+            self.logger.warning("No track_focus_data found; generating new track_focus_data in simulation.")
+            sim_tfs = make_tfs_sim(tfs)
+            track_focus_data = sim_tfs.track_focus(energies=energies, show=True)
+        return track_focus_data
+
+    def _move_tfs_to_energy(self, energy_eV, track_focus_data):
+        if track_focus_data is not None:
+            energy_eV = float(energy_eV)
+            for data in track_focus_data:
+                if data["energy"] == energy_eV:
+                    z_position = data["z_position"]
+                    inserted_lenses = data["inserted_lenses"]
+                    break
+            if z_position is not None:
+                self.logger.info(f"Moving TFS to {z_position:.3f} mm")
+                self.tfs.translation.mv(z_position)
+            for lens in self.tfs.lenses:
+                if lens.prefix in inserted_lenses:
+                    self.logger.info(f"Inserting lens {lens.prefix}")
+                    if lens.inserted:
+                        self.logger.info(f"Lens {lens.prefix} already inserted")
+                        continue
+                    lens.insert()
+                else:
+                    self.logger.info(f"Removing lens {lens.prefix}")
+                    if not lens.inserted:
+                        self.logger.info(f"Lens {lens.prefix} already removed")
+                        continue
+                    lens.remove()
+        else:
+            self.logger.warning("No track_focus_data found; how did you get here?.")
+            return
+
+
 
     def _move_k_if_necessary(self, energy_keV, k_energy, energy_0_keV, k_stepsize, k_offset, reverse, min_k_keV):
         """Move K if necessary and manage DAQ state."""
@@ -433,6 +494,8 @@ class Exafs:
         energy_start = self.dccm.energy_with_vernier.energy()
         k_energy_start = self.acr_energy_k.get().setpoint
 
+        track_focus_data = self._init_tfs(energies)
+
         try:
             for i in range(runs):
                 # Initialize energies
@@ -453,7 +516,7 @@ class Exafs:
                     energy_keV = energy / 1000.0
 
                     # Move TFS to energy
-                    
+                    self._move_tfs_to_energy(energy_eV=energy, track_focus_data=track_focus_data)
                     # Move DCCM and Vernier to energy
                     self._move_dccm_energy_with_vernier(energy_keV)
                     

--- a/mfx/exafs.py
+++ b/mfx/exafs.py
@@ -5,6 +5,7 @@ from time import sleep
 from pathlib import Path
 import json
 from tfs.sim_transfocator import make_tfs_sim
+from tfs.transfocator import Transfocator as tfs
 
 class Exafs:
     from pcdsdevices.beam_stats import BeamEnergyRequest, BeamEnergyRequestACRWait

--- a/tfs/sim_transfocator.py
+++ b/tfs/sim_transfocator.py
@@ -17,8 +17,14 @@ class SimLens(RealLens):
     def _do_move(self, state):
         if state.name == 'IN':
             self._insert.put(1)
+            self._inserted.put(1)
+            self._remove.put(0)
+            self._removed.put(0)
         elif state.name == 'OUT':
+            self._removed.put(1)
             self._remove.put(1)
+            self._insert.put(0)
+            self._inserted.put(0)
         else:
             raise ValueError("Invalid State {}".format(state))
 

--- a/tfs/sim_transfocator.py
+++ b/tfs/sim_transfocator.py
@@ -7,6 +7,20 @@ class SimLens(RealLens):
     _sig_z      = Cpt(FakeEpicsSignal,  ":Z",      auto_monitor=True)
     _sig_radius = Cpt(FakeEpicsSignal,  ":RADIUS", auto_monitor=True)
     _sig_focus  = Cpt(FakeEpicsSignal,  ":FOCUS",  auto_monitor=True)
+    _inserted   = Cpt(FakeEpicsSignal,  ":STATE")
+    _removed    = Cpt(FakeEpicsSignal,  ":OUT")
+    _insert     = Cpt(FakeEpicsSignal,  ":INSERT")
+    _remove     = Cpt(FakeEpicsSignal,  ":REMOVE")
+    _state_logic = {'_inserted': {0: 'defer',  1: 'IN'},
+                    '_removed': {0: 'defer', 1: 'OUT'}}
+
+    def _do_move(self, state):
+        if state.name == 'IN':
+            self._insert.put(1)
+        elif state.name == 'OUT':
+            self._remove.put(1)
+        else:
+            raise ValueError("Invalid State {}".format(state))
 
 class Stage(SynAxis):
     def attach(self, tfs_dev):

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -523,7 +523,7 @@ class MFXTransfocator(TransfocatorBase):
         - If the move would exceed the stage low limit, return to the top
           position and recompute the lens combo at that energy, then continue.
         """
-        if not energies:
+        if len(energies) == 0:
             print("No energies provided.")
             return None
 

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -527,6 +527,9 @@ class MFXTransfocator(TransfocatorBase):
             print("No energies provided.")
             return None
 
+        # cast energies to float to avoid json serialization issues
+        energies = [float(energy) for energy in energies]
+
         min_z_stage_mm, max_z_stage_mm = self.get_stage_limits(margin_mm)
         ref_z_stage_mm = self.mv_stage_to_pos(max_z_stage_mm)
         combo, ref_focal_length_um = self.set_reference_combo(energies[0], show=show)


### PR DESCRIPTION
This PR was developed in collaboration with @MartinaDelGaudio, it adds support for moving the TFS stage and inserting lenses within the `long_escan` loop. The code generates the `track_focus.json` file for the energy list produced by `_build_energy_and_wait_time` **using the simulated transfocator**. Then, for each energy, the stage is moved to the corresponding z-position specified in the JSON, and the appropriate lenses are inserted while removing the previous ones.

We tested this in simulation, which required adding the insertion logic to `sim_transfocator.py`.

```python
In [2]: exafs = Exafs()

In [3]: exafs.long_escan(simulate=True, start_eV=7050, end_eV=8000)
INFO     _build_energy_and_wait_time - Energy list: [7050.         7055.         7060.         7065.         7070.
 7075.         7080.         7085.         7090.         7095.
 7100.         7105.         7110.         7115.         7120.
 7119.2        7120.2        7121.2        7122.2        7123.2
 7124.2        7125.2        7126.2        7127.2        7128.2
 7129.2        7130.2        7131.2        7132.2        7133.2
 7134.2        7135.2        7136.2        7137.2        7138.2
 7139.2        7140.2        7141.2        7142.2        7143.2
 7144.2        7145.2        7145.23809524 7146.8        7148.43809524
 7150.15238095 7151.94285714 7153.80952381 7155.75238095 7157.77142857
 7159.86666667 7162.03809524 7164.28571429 7166.60952381 7169.00952381
 7171.48571429 7174.03809524 7176.66666667 7179.37142857 7182.15238095
 7185.00952381 7187.94285714 7190.95238095 7194.03809524 7197.2
 7200.43809524 7203.75238095 7207.14285714 7210.60952381 7214.15238095
 7217.77142857 7221.46666667 7225.23809524 7229.08571429 7233.00952381
 7237.00952381 7241.08571429 7245.23809524 7249.46666667 7253.77142857
 7258.15238095 7262.60952381 7267.14285714 7271.75238095 7276.43809524
 7281.2        7286.03809524 7290.95238095 7295.94285714 7301.00952381
 7306.15238095 7311.37142857 7316.66666667 7322.03809524 7327.48571429
 7333.00952381 7338.60952381 7344.28571429 7350.03809524 7355.86666667
 7361.77142857 7367.75238095 7373.80952381 7379.94285714 7386.15238095
 7392.43809524 7398.8        7405.23809524 7411.75238095 7418.34285714
 7425.00952381 7431.75238095 7438.57142857 7445.46666667 7452.43809524
 7459.48571429 7466.60952381 7473.80952381 7481.08571429 7488.43809524
 7495.86666667 7503.37142857 7510.95238095 7518.60952381 7526.34285714
 7534.15238095 7542.03809524 7550.         7558.03809524 7566.15238095
 7574.34285714 7582.60952381 7590.95238095 7599.37142857 7607.86666667
 7616.43809524 7625.08571429 7633.80952381 7642.60952381 7651.48571429
 7660.43809524 7669.46666667 7678.57142857 7687.75238095 7697.00952381
 7706.34285714 7715.75238095 7725.23809524 7734.8        7744.43809524
 7754.15238095 7763.94285714 7773.80952381 7783.75238095 7793.77142857
 7803.86666667 7814.03809524 7824.28571429 7834.60952381 7845.00952381
 7855.48571429 7866.03809524 7876.66666667 7887.37142857 7898.15238095
 7909.00952381 7919.94285714 7930.95238095 7942.03809524 7953.2
 7964.43809524 7975.75238095 7987.14285714 7998.60952381 8010.15238095]; Wait time list: [ 0.5         0.5         0.5         0.5         0.5         0.5
  0.5         0.5         0.5         0.5         0.5         0.5
  0.5         0.5         0.5         1.          1.          1.
  1.          1.          1.          1.          1.          1.
  1.          1.          1.          1.          1.          1.
  1.          1.          1.          1.          1.          1.
  1.          1.          1.          1.          1.          1.
  0.5         0.5003509   0.50077286  0.5012744   0.50186451  0.50255264
  0.50334873  0.50426316  0.50530678  0.50649094  0.50782741  0.50932846
  0.51100683  0.51287569  0.51494872  0.51724005  0.51976428  0.52253646
  0.52557213  0.52888729  0.5324984   0.53642241  0.5406767   0.54527916
  0.55024811  0.55560235  0.56136117  0.56754428  0.57417191  0.58126473
  0.58884386  0.59693092  0.60554799  0.6147176   0.62446277  0.63480696
  0.64577413  0.65738868  0.66967549  0.68265991  0.69636775  0.71082528
  0.72605927  0.74209691  0.7589659   0.77669438  0.79531097  0.81484475
  0.83532528  0.85678256  0.8792471   0.90274983  0.92732219  0.95299605
  0.97980378  1.00777819  1.03695258  1.0673607   1.09903678  1.1320155
  1.16633203  1.202022    1.23912149  1.27766706  1.31769576  1.35924506
  1.40235293  1.44705781  1.49339858  1.54141462  1.59114576  1.64263229
  1.69591499  1.75103508  1.80803426  1.86695472  1.92783907  1.99073042
  2.05567236  2.1227089   2.19188456  2.26324431  2.33683358  2.41269829
  2.49088482  2.57143999  2.65441112  2.73984599  2.82779284  2.91830038
  3.01141778  3.1071947   3.20568125  3.306928    3.41098601  3.51790678
  3.6277423   3.74054502  3.85636786  3.9752642   4.09728788  4.22249324
  4.35093505  4.48266857  4.61774951  4.75623407  4.8981789   5.04364112
  5.19267833  5.34534857  5.50171038  5.66182274  5.82574511  5.99353743
  6.16526008  6.34097392  6.52074028  6.70462096  6.89267822  7.08497479
  7.28157387  7.48253911  7.68793467  7.89782512  8.11227554  8.33135147
  8.5551189   8.7836443   9.01699461  9.25523723  9.49844003  9.74667135
 10.        ]
Stage limits: low=-0.409 mm, high=299.591 mm, margin=10.000 mm
Moving stage to position: z=289.591mm
Stage moved to position: z=289.591mm
Pre-focussing lens for 7050.0 eV:
SimLens(SIM::DIA:01, name=tfs_sim_prefocus_bot)
Radius: 750.0 um

Pre-focussing lens for 7050.0 eV:
SimLens(SIM::DIA:01, name=tfs_sim_prefocus_bot)
Radius: 750.0 um

+-------------+-----------+-----------+
| Prefix      | Radius    | Z         |
+-------------+-----------+-----------+
| SIM::DIA:01 | 750.00000 | 418.59385 |
| SIM::TFS:07 | 62.50000  | 454.46485 |
| SIM::TFS:08 | 50.00000  | 454.53985 |
| SIM::TFS:09 | 50.00000  | 454.61385 |
| SIM::TFS:10 | 50.00000  | 454.68985 |
+-------------+-----------+-----------+
INFO     find_best_combo - Difference to desired focus position: 55217.31 mm
INFO     find_best_combo - Given Energy: 7050.0 eV
INFO     find_best_combo - Given Sample Position: 400.37 mm
INFO     find_best_combo - Calculated Radius: 13.16 um
INFO     estimate_beam_fwhm - waist: 2.105e-10
INFO     estimate_beam_fwhm - rayleigh_range: 7.917e-07
INFO     estimate_beam_fwhm - size_fwhm: 1100.72 um

INFO     find_best_combo - Calculated Focal Length: 0.9582234695343292 m

Reference energy: 7050.00 eV, reference focal length: 0.958 um
Energy 7050.00 eV: computed focal length = 0.958 um, target z = 289.591 mm.
Moving stage to 289.591 mm.
Energy 7055.00 eV: computed focal length = 0.960 um, target z = 288.230 mm.
Moving stage to 288.230 mm.
Energy 7060.00 eV: computed focal length = 0.961 um, target z = 286.867 mm.
Moving stage to 286.867 mm.
Energy 7065.00 eV: computed focal length = 0.962 um, target z = 285.504 mm.
Moving stage to 285.504 mm.

...

Tracking complete. Final energy: 8010.15 eV, stage position: 10.462 mm.
Lenses currently inserted: ['SIM::DIA:01', 'SIM::TFS:07', 'SIM::TFS:08', 'SIM::TFS:09', 'SIM::TFS:10']
Tracking results saved to /cds/home/a/aminelam/track_focus_results.json
INFO     _log_move - Moving fast_motor1 from 0 to 7.05
INFO     _initialize_energies_and_move - Moving k to initial energy for beginning of scan 7050
INFO     _log_move - Moving slow_motor1 from 0 to 7050.0
INFO     long_escan - Energy: 7050.0000, Time: 0.5
INFO     _move_tfs_to_energy - Moving TFS to 289.591 mm
INFO     _move_tfs_to_energy - Removing lens SIM::DIA:03
INFO     _move_tfs_to_energy - Lens SIM::DIA:03 already removed
INFO     _move_tfs_to_energy - Removing lens SIM::DIA:02
INFO     _move_tfs_to_energy - Lens SIM::DIA:02 already removed
INFO     _move_tfs_to_energy - Inserting lens SIM::DIA:01
INFO     _move_tfs_to_energy - Removing lens SIM::TFS:02
INFO     _move_tfs_to_energy - Lens SIM::TFS:02 already removed
INFO     _move_tfs_to_energy - Removing lens SIM::TFS:03
INFO     _move_tfs_to_energy - Lens SIM::TFS:03 already removed
INFO     _move_tfs_to_energy - Removing lens SIM::TFS:04
INFO     _move_tfs_to_energy - Lens SIM::TFS:04 already removed
INFO     _move_tfs_to_energy - Removing lens SIM::TFS:05
INFO     _move_tfs_to_energy - Lens SIM::TFS:05 already removed
INFO     _move_tfs_to_energy - Removing lens SIM::TFS:06
INFO     _move_tfs_to_energy - Lens SIM::TFS:06 already removed
INFO     _move_tfs_to_energy - Inserting lens SIM::TFS:07
INFO     _move_tfs_to_energy - Inserting lens SIM::TFS:08
INFO     _move_tfs_to_energy - Inserting lens SIM::TFS:09
INFO     _move_tfs_to_energy - Inserting lens SIM::TFS:10
INFO     _log_move - Moving fast_motor1 from 7.05 to 7.05
INFO     long_escan - Energy: 7055.0000, Time: 0.5
INFO     _move_tfs_to_energy - Moving TFS to 288.230 mm
INFO     _move_tfs_to_energy - Removing lens SIM::DIA:03
INFO     _move_tfs_to_energy - Lens SIM::DIA:03 already removed

```