### PR TITLE
Avoid forbidden combos and optionally enforce not using prefocusing lenses.

### DIFF
--- a/tfs/offline_calculator.py
+++ b/tfs/offline_calculator.py
@@ -132,7 +132,7 @@ class TFS_Calculator(object):
 
             # Step 1bis
             if avoid_forbidden:
-                if check_forbidden(pre_focus_lens.radius, energy, lens_combo.tfs_radius):
+                if self.check_forbidden(pre_focus_lens.radius, energy, lens_combo.tfs_radius):
                     continue
             combos.append(lens_combo)
 

--- a/tfs/offline_calculator.py
+++ b/tfs/offline_calculator.py
@@ -63,7 +63,28 @@ class TFS_Calculator(object):
     def get_combo_image(combo, z_obj=0.0):
         return combo.image(z_obj)
 
-    def find_solution(self, target, energy, n=4, z_obj=0.0):
+    def check_forbidden(self, pre_focus_lens_radius, energy, radius):
+        from transfocate.table.info import data as spreadsheet_data
+
+        LENS_MAP = {
+            750: "LENS1_750",
+            428: "LENS2_428",
+            333: "LENS3_333"
+        }
+        lens = LENS_MAP.get(int(pre_focus_lens_radius), "NO_LENS")
+
+        lens_data = spreadsheet_data[lens]
+        closest_energy_idx = (lens_data['energy'] - energy).abs().idxmin()
+        closest_row = lens_data.loc[closest_energy_idx]
+
+        forbidden = closest_row['trip_min'] <= radius <= closest_row['trip_max']
+        log_level = logger.error if forbidden else logger.info
+        log_level(f"TFS Configuration is {'Forbidden' if forbidden else 'Allowed'}")
+
+        return forbidden
+
+    def find_solution(self, target, energy, n=4, z_obj=0.0,
+                      avoid_forbidden=True, enable_prefocus=True):
         """
         Find a combination to reach a specific focus
 
@@ -94,26 +115,36 @@ class TFS_Calculator(object):
         3) Pick the combo with the smallest difference
         """
 
-        # Step 1
-        pre_focus_lens = self.get_pre_focus_lens(energy)
-        if pre_focus_lens is None:
-            combos = self.combos
-        else:
+        pre_focus_lens = None
+        if enable_prefocus:
             pre_focus_lens = self.get_pre_focus_lens(energy)
-            combos = []
-            for combo in self.combos:
+
+        combos = []
+        diff = []
+        for combo in self.combos:
+
+            # Step 1
+            if pre_focus_lens is None:
+                lens_combo = combo
+            else:
                 c = LensConnect(pre_focus_lens)
                 lens_combo = LensConnect.connect(c, combo)
-                combos.append(lens_combo)
 
-        # Step 2
-        diff = []
-        for ii, combo in enumerate(self.combos):
+            # Step 1bis
+            if avoid_forbidden:
+                if check_forbidden(pre_focus_lens.radius, energy, lens_combo.tfs_radius):
+                    continue
+            combos.append(lens_combo)
+
+            # Step 2
             if combo.nlens > n:
                 continue
             image = combo.image(z_obj, energy)
             diff.append(np.abs(image - target))
 
         # Step 3
-        solution = combos[np.argmin(diff)]
-        return solution, np.min(diff), pre_focus_lens
+        best_allowed_combo_idx = np.argmin(diff)
+        smallest_diff = diff[best_allowed_combo_idx]
+        best_combo_solution = combos[best_allowed_combo_idx]
+
+        return best_combo_solution, smallest_diff

--- a/tfs/offline_calculator.py
+++ b/tfs/offline_calculator.py
@@ -118,6 +118,9 @@ class TFS_Calculator(object):
         pre_focus_lens = None
         if enable_prefocus:
             pre_focus_lens = self.get_pre_focus_lens(energy)
+            pre_focus_lens_radius = pre_focus_lens.radius
+        if pre_focus_lens is None:
+            pre_focus_lens_radius = -1
 
         combos = []
         diff = []
@@ -132,7 +135,7 @@ class TFS_Calculator(object):
 
             # Step 1bis
             if avoid_forbidden:
-                if self.check_forbidden(pre_focus_lens.radius, energy, lens_combo.tfs_radius):
+                if self.check_forbidden(pre_focus_lens_radius, energy, lens_combo.tfs_radius):
                     continue
             combos.append(lens_combo)
 

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -188,43 +188,7 @@ class MFXTransfocator(TransfocatorBase):
         self.tfs_09.remove()
         self.tfs_10.remove()
 
-
-    def check_forbidden(self, pre_focus_lens_radius, energy, radius): 
-        from transfocate.table.info import data as spreadsheet_data
-
-        if int(pre_focus_lens_radius) == 750:
-            lens = "LENS1_750"
-        elif int(pre_focus_lens_radius) == 428:
-            lens = "LENS2_428"
-        elif int(pre_focus_lens_radius) == 333:
-            lens = "LENS3_333"
-        else:
-            lens = "NO_LENS"
-
-        lens_to_spreadsheet_df = {
-            0: spreadsheet_data["NO_LENS"],
-            1: spreadsheet_data["LENS1_750"],
-            2: spreadsheet_data["LENS2_428"],
-            3: spreadsheet_data["LENS3_333"],
-        }
-
-        df=spreadsheet_data[lens]
-        closest_energy = (df['energy'] - energy).abs().idxmin()
-        trip_min = df['trip_min'].loc[closest_energy]
-        trip_max = df['trip_max'].loc[closest_energy]
-
-        if radius >= trip_min and radius <= trip_max:
-            forbidden = True
-            logger.error("TFS Configuration is Forbidden")
-        else:
-            forbidden = False
-            logger.info("TFS Configuration is Allowed")
-
-        return forbidden
-
-
     def find_best_combo(self, target=None, energy_eV=None, n=4, z_obj=0, show=True, exclusions=[], **kwargs):
-
         """
         Calculate the best lens array to hit the nominal sample point
 
@@ -262,7 +226,7 @@ class MFXTransfocator(TransfocatorBase):
             logging.warning(f"please double-check that {energy} is in eV, not keV.")
         target = target or self.nominal_sample
         calc = TFS_Calculator(tfs_lenses=self.tfs_lenses, prefocus_lenses=self.xrt_lenses,exclusions=exclusions)
-        combo, diff, pre_focus_lens = calc.find_solution(target, energy, n, z_obj, **kwargs)
+        combo, diff = calc.find_solution(target, energy, n, z_obj, **kwargs)
         if combo:
             print(combo)
             combo.show_info()
@@ -273,7 +237,6 @@ class MFXTransfocator(TransfocatorBase):
             logger.info(f'Calculated Radius: {round(radius, 2)} um')
             estimate_beam_fwhm(radius=radius, energy=energy)
             focal = focal_length(radius=radius, energy=energy)
-            self.check_forbidden(pre_focus_lens.radius, energy, radius)
 
             logger.info(f'Calculated Focal Length: {focal} m\n')
 
@@ -351,7 +314,6 @@ class MFXTransfocator(TransfocatorBase):
             logger.info(f'Calculated Radius: {round(radius, 2)} um')
             estimate_beam_fwhm(radius=radius, energy=energy)
             focal = focal_length(radius=radius, energy=energy)
-            self.check_forbidden(pre_focus_lens.radius, energy, radius)
 
             logger.info(f'Calculated Focal Length: {focal} um\n')
 
@@ -525,8 +487,12 @@ class MFXTransfocator(TransfocatorBase):
         print(f"Stage moved to position: z={z_mm:.3f}mm")
         return z_mm
 
-    def set_reference_combo(self, energy_eV, show=False):
-        combo = self.find_best_combo(energy_eV=energy_eV, show=show)
+    def set_reference_combo(self, energy_eV, show=False, **kwargs):
+        """
+        kwargs:
+            Passed to :meth:`.Calculator.find_solution`
+        """
+        combo = self.find_best_combo(energy_eV=energy_eV, show=show,  **kwargs)
         ref_focal_length_um = focal_length(combo.tfs_radius, energy=energy_eV)
         print(f"Reference energy: {energy_eV:.2f} eV, reference focal length: {ref_focal_length_um:.3f} um")
         return combo, ref_focal_length_um
@@ -547,7 +513,7 @@ class MFXTransfocator(TransfocatorBase):
             "z_position": target_z_mm
         })
 
-    def track_focus(self, energies, *, margin_mm=10.0, show=False):
+    def track_focus(self, energies, *, margin_mm=10.0, show=False, **kwargs):
         """
         Keep the focal length fixed over a provided list of energies by
         compensating with the translation stage. Lenses are NOT actuated.
@@ -559,6 +525,9 @@ class MFXTransfocator(TransfocatorBase):
           move the stage to compensate.
         - If the move would exceed the stage low limit, return to the top
           position and recompute the lens combo at that energy, then continue.
+
+        kwargs:
+            Passed to :meth:`.Calculator.find_solution`
         """
         if len(energies) == 0:
             print("No energies provided.")
@@ -569,21 +538,23 @@ class MFXTransfocator(TransfocatorBase):
 
         min_z_stage_mm, max_z_stage_mm = self.get_stage_limits(margin_mm)
         ref_z_stage_mm = self.mv_stage_to_pos(max_z_stage_mm)
-        combo, ref_focal_length_um = self.set_reference_combo(energies[0], show=show)
+        combo, ref_focal_length_um = self.set_reference_combo(energies[0], show=show, **kwargs)
         track_record = []
 
         for energy in energies:
-            target_z_stage_mm = self.get_z_stage_target(energy, combo, ref_focal_length_um, ref_z_stage_mm)
-            if target_z_stage_mm > min_z_stage_mm and target_z_stage_mm <= max_z_stage_mm:
+            target_z_stage_mm = self.get_z_stage_target(
+                energy, combo, ref_focal_length_um, ref_z_stage_mm
+            )
+            if min_z_stage_mm < target_z_stage_mm <= max_z_stage_mm:
                 self.mv_stage_to_target_pos(energy, combo, target_z_stage_mm, track_record)
             else:
                 shrinking_max_z_stage_mm = max_z_stage_mm
                 while shrinking_max_z_stage_mm > min_z_stage_mm:
                     self.mv_stage_to_pos(shrinking_max_z_stage_mm)
-                    combo = self.find_best_combo(energy_eV=energy, show=show)
+                    combo = self.find_best_combo(energy_eV=energy, show=show, **kwargs)
                     if combo:
                         new_target_z_stage_mm = self.get_z_stage_target(energy, combo, ref_focal_length_um, ref_z_stage_mm)
-                        if new_target_z_stage_mm > min_z_stage_mm and new_target_z_stage_mm <= max_z_stage_mm:
+                        if min_z_stage_mm < new_target_z_stage_mm <= max_z_stage_mm:
                             self.mv_stage_to_target_pos(energy, combo, new_target_z_stage_mm, track_record)
                             break
                     shrinking_max_z_stage_mm -= margin_mm


### PR DESCRIPTION
Added option to only try combos that are allowed. Also added option to disable prefocusing lenses.

# default behavior
Note that the logic is actually in the `find_solution()` method in `offline_calculator.py`.
```python
 combo = find_best_combo(avoid_forbidden=True, enable_prefocus=True)
```

# Tests

## Traditional behavior: include forbidden combos and enable prefocus

```python
In [1]: from tfs.sim_transfocator import make_tfs_sim

In [2]: tfs_sim = make_tfs_sim(tfs)

In [3]: energies = [7050, 7051, 7052, 7053, 7054, 7055, 7100, 7150, 7500, 7700, 8000]

In [4]: tfs_sim.track_focus(energies, margin_mm=5.0, show=True, avoid_forbidden=False, enable_prefocus=True)
Stage limits: low=-0.409 mm, high=299.591 mm, margin=5.000 mm
Moving stage to position: z=294.591mm
Stage moved to position: z=294.591mm
Pre-focussing lens for 7050.0 eV:
SimLens(SIM::DIA:01, name=tfs_sim_prefocus_bot)
Radius: 750.0 um

<tfs.lens.LensConnect object at 0x7f167ed12400>
+-------------+-----------+-----------+
| Prefix      | Radius    | Z         |
+-------------+-----------+-----------+
| SIM::DIA:01 | 750.00000 | 423.59605 |
| SIM::TFS:07 | 62.50000  | 459.46704 |
| SIM::TFS:08 | 50.00000  | 459.54204 |
| SIM::TFS:09 | 50.00000  | 459.61604 |
| SIM::TFS:10 | 50.00000  | 459.69204 |
+-------------+-----------+-----------+
INFO     find_best_combo - Difference to desired focus position: 60219.49 mm
INFO     find_best_combo - Given Energy: 7050.0 eV
INFO     find_best_combo - Given Sample Position: 400.37 mm
INFO     find_best_combo - Calculated Radius: 13.16 um
INFO     estimate_beam_fwhm - waist: 2.105e-10
INFO     estimate_beam_fwhm - rayleigh_range: 7.917e-07
INFO     estimate_beam_fwhm - size_fwhm: 1100.72 um

INFO     find_best_combo - Calculated Focal Length: 0.9582234695343292 m

Reference energy: 7050.00 eV, reference focal length: 0.958 um
Energy 7050.00 eV: computed focal length = 0.958 um, target z = 294.591 mm.
Moving stage to 294.591 mm.
Energy 7051.00 eV: computed focal length = 0.958 um, target z = 294.319 mm.
Moving stage to 294.319 mm.
Energy 7052.00 eV: computed focal length = 0.959 um, target z = 294.047 mm.
Moving stage to 294.047 mm.
Energy 7053.00 eV: computed focal length = 0.959 um, target z = 293.774 mm.
Moving stage to 293.774 mm.
Energy 7054.00 eV: computed focal length = 0.959 um, target z = 293.502 mm.
Moving stage to 293.502 mm.
Energy 7055.00 eV: computed focal length = 0.960 um, target z = 293.230 mm.
Moving stage to 293.230 mm.
Energy 7100.00 eV: computed focal length = 0.972 um, target z = 280.934 mm.
Moving stage to 280.934 mm.
Energy 7150.00 eV: computed focal length = 0.986 um, target z = 267.180 mm.
Moving stage to 267.180 mm.
Energy 7500.00 eV: computed focal length = 1.085 um, target z = 168.203 mm.
Moving stage to 168.203 mm.
Energy 7700.00 eV: computed focal length = 1.143 um, target z = 109.520 mm.
Moving stage to 109.520 mm.
Energy 8000.00 eV: computed focal length = 1.234 um, target z = 18.599 mm.
Moving stage to 18.599 mm.
Tracking complete. Final energy: 8000.00 eV, stage position: 18.599 mm.
Lenses currently inserted: ['SIM::DIA:01', 'SIM::TFS:07', 'SIM::TFS:08', 'SIM::TFS:09', 'SIM::TFS:10']
Tracking results saved to /cds/home/f/fpoitevi/track_focus_results.json
Out[4]:
[{'energy': 7050.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 294.5909499999999},
 {'energy': 7051.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 294.31875696088747},
 {'energy': 7052.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 294.0465253027442},
 {'energy': 7053.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 293.77425502558583},
 {'energy': 7054.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 293.50194612942914},
 {'energy': 7055.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 293.2295986142905},
 {'energy': 7100.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 280.9339900509762},
 {'energy': 7150.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 267.1804837169438},
 {'energy': 7500.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 168.20264961469576},
 {'energy': 7700.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 109.51989739203484},
 {'energy': 8000.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 18.599460679245908}]
```

## New behavior - avoid forbidden combos:
```python
In [4]: tfs_sim.track_focus(energies, margin_mm=5.0, show=True, avoid_forbidden=True, enable_prefocus=Tru
   ...: e)
Stage limits: low=-0.409 mm, high=299.591 mm, margin=5.000 mm
Moving stage to position: z=294.591mm
Stage moved to position: z=294.591mm
Pre-focussing lens for 7050.0 eV:
SimLens(SIM::DIA:01, name=tfs_sim_prefocus_bot)
Radius: 750.0 um

ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
ERROR    check_forbidden - TFS Configuration is Forbidden
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
I...
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
<tfs.lens.LensConnect object at 0x7fbdf5e404f0>
+-------------+-----------+-----------+
| Prefix      | Radius    | Z         |
+-------------+-----------+-----------+
| SIM::DIA:01 | 750.00000 | 423.59600 |
| SIM::TFS:07 | 62.50000  | 459.46699 |
| SIM::TFS:08 | 50.00000  | 459.54199 |
| SIM::TFS:09 | 50.00000  | 459.61599 |
| SIM::TFS:10 | 50.00000  | 459.69199 |
+-------------+-----------+-----------+
INFO     find_best_combo - Difference to desired focus position: 60219.44 mm
INFO     find_best_combo - Given Energy: 7050.0 eV
INFO     find_best_combo - Given Sample Position: 400.37 mm
INFO     find_best_combo - Calculated Radius: 13.16 um
INFO     estimate_beam_fwhm - waist: 2.105e-10
INFO     estimate_beam_fwhm - rayleigh_range: 7.917e-07
INFO     estimate_beam_fwhm - size_fwhm: 1100.72 um

INFO     find_best_combo - Calculated Focal Length: 0.9582234695343292 m

Reference energy: 7050.00 eV, reference focal length: 0.958 um
Energy 7050.00 eV: computed focal length = 0.958 um, target z = 294.591 mm.
Moving stage to 294.591 mm.
Energy 7051.00 eV: computed focal length = 0.958 um, target z = 294.319 mm.
Moving stage to 294.319 mm.
Energy 7052.00 eV: computed focal length = 0.959 um, target z = 294.047 mm.
Moving stage to 294.047 mm.
Energy 7053.00 eV: computed focal length = 0.959 um, target z = 293.774 mm.
Moving stage to 293.774 mm.
Energy 7054.00 eV: computed focal length = 0.959 um, target z = 293.502 mm.
Moving stage to 293.502 mm.
Energy 7055.00 eV: computed focal length = 0.960 um, target z = 293.230 mm.
Moving stage to 293.230 mm.
Energy 7100.00 eV: computed focal length = 0.972 um, target z = 280.934 mm.
Moving stage to 280.934 mm.
Energy 7150.00 eV: computed focal length = 0.986 um, target z = 267.180 mm.
Moving stage to 267.180 mm.
Energy 7500.00 eV: computed focal length = 1.085 um, target z = 168.203 mm.
Moving stage to 168.203 mm.
Energy 7700.00 eV: computed focal length = 1.143 um, target z = 109.520 mm.
Moving stage to 109.520 mm.
Energy 8000.00 eV: computed focal length = 1.234 um, target z = 18.599 mm.
Moving stage to 18.599 mm.
Tracking complete. Final energy: 8000.00 eV, stage position: 18.599 mm.
Lenses currently inserted: ['SIM::DIA:01', 'SIM::TFS:07', 'SIM::TFS:08', 'SIM::TFS:09', 'SIM::TFS:10']
Tracking results saved to /cds/home/f/fpoitevi/track_focus_results.json
Out[4]:
[{'energy': 7050.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 294.5909499999999},
 {'energy': 7051.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 294.31875696088747},
 {'energy': 7052.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 294.0465253027442},
 {'energy': 7053.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 293.77425502558583},
 {'energy': 7054.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 293.50194612942914},
 {'energy': 7055.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 293.2295986142905},
 {'energy': 7100.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 280.9339900509762},
 {'energy': 7150.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 267.1804837169438},
 {'energy': 7500.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 168.20264961469576},
 {'energy': 7700.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 109.51989739203484},
 {'energy': 8000.0,
  'inserted_lenses': ['SIM::DIA:01',
   'SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 18.599460679245908}]
```

## New behavior - avoid forbidden combos and disable prefocusing

```python
In [4]: tfs_sim.track_focus(energies, margin_mm=5.0, show=True, avoid_forbidden=True, enable_prefocus=Fal
   ...: se)
Stage limits: low=-0.409 mm, high=299.591 mm, margin=5.000 mm
Moving stage to position: z=294.591mm
Stage moved to position: z=294.591mm
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
ERROR    check_forbidden - TFS Configuration is Forbidden
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
ERROR    check_forbidden - TFS Configuration is Forbidden
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
ERROR    check_forbidden - TFS Configuration is Forbidden
ERROR    check_forbidden - TFS Configuration is Forbidden
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
...
INFO     check_forbidden - TFS Configuration is Allowed
INFO     check_forbidden - TFS Configuration is Allowed
<tfs.lens.LensConnect object at 0x7f81521ef8e0>
+-------------+----------+-----------+
| Prefix      | Radius   | Z         |
+-------------+----------+-----------+
| SIM::TFS:07 | 62.50000 | 459.46704 |
| SIM::TFS:08 | 50.00000 | 459.54204 |
| SIM::TFS:09 | 50.00000 | 459.61604 |
| SIM::TFS:10 | 50.00000 | 459.69204 |
+-------------+----------+-----------+
INFO     find_best_combo - Difference to desired focus position: 60219.49 mm
INFO     find_best_combo - Given Energy: 7050.0 eV
INFO     find_best_combo - Given Sample Position: 400.37 mm
INFO     find_best_combo - Calculated Radius: 13.16 um
INFO     estimate_beam_fwhm - waist: 2.105e-10
INFO     estimate_beam_fwhm - rayleigh_range: 7.917e-07
INFO     estimate_beam_fwhm - size_fwhm: 1100.72 um

INFO     find_best_combo - Calculated Focal Length: 0.9582234695343292 m

Reference energy: 7050.00 eV, reference focal length: 0.958 um
Energy 7050.00 eV: computed focal length = 0.958 um, target z = 294.591 mm.
Moving stage to 294.591 mm.
Energy 7051.00 eV: computed focal length = 0.958 um, target z = 294.319 mm.
Moving stage to 294.319 mm.
Energy 7052.00 eV: computed focal length = 0.959 um, target z = 294.047 mm.
Moving stage to 294.047 mm.
Energy 7053.00 eV: computed focal length = 0.959 um, target z = 293.774 mm.
Moving stage to 293.774 mm.
Energy 7054.00 eV: computed focal length = 0.959 um, target z = 293.502 mm.
Moving stage to 293.502 mm.
Energy 7055.00 eV: computed focal length = 0.960 um, target z = 293.230 mm.
Moving stage to 293.230 mm.
Energy 7100.00 eV: computed focal length = 0.972 um, target z = 280.934 mm.
Moving stage to 280.934 mm.
Energy 7150.00 eV: computed focal length = 0.986 um, target z = 267.180 mm.
Moving stage to 267.180 mm.
Energy 7500.00 eV: computed focal length = 1.085 um, target z = 168.203 mm.
Moving stage to 168.203 mm.
Energy 7700.00 eV: computed focal length = 1.143 um, target z = 109.520 mm.
Moving stage to 109.520 mm.
Energy 8000.00 eV: computed focal length = 1.234 um, target z = 18.599 mm.
Moving stage to 18.599 mm.
Tracking complete. Final energy: 8000.00 eV, stage position: 18.599 mm.
Lenses currently inserted: ['SIM::TFS:07', 'SIM::TFS:08', 'SIM::TFS:09', 'SIM::TFS:10']
Tracking results saved to /cds/home/f/fpoitevi/track_focus_results.json
Out[4]:
[{'energy': 7050.0,
  'inserted_lenses': ['SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 294.5909499999999},
 {'energy': 7051.0,
  'inserted_lenses': ['SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 294.31875696088747},
 {'energy': 7052.0,
  'inserted_lenses': ['SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 294.0465253027442},
 {'energy': 7053.0,
  'inserted_lenses': ['SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 293.77425502558583},
 {'energy': 7054.0,
  'inserted_lenses': ['SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 293.50194612942914},
 {'energy': 7055.0,
  'inserted_lenses': ['SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 293.2295986142905},
 {'energy': 7100.0,
  'inserted_lenses': ['SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 280.9339900509762},
 {'energy': 7150.0,
  'inserted_lenses': ['SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 267.1804837169438},
 {'energy': 7500.0,
  'inserted_lenses': ['SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 168.20264961469576},
 {'energy': 7700.0,
  'inserted_lenses': ['SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 109.51989739203484},
 {'energy': 8000.0,
  'inserted_lenses': ['SIM::TFS:07',
   'SIM::TFS:08',
   'SIM::TFS:09',
   'SIM::TFS:10'],
  'z_position': 18.599460679245908}]
```