### PR TITLE
Calib bound fix

### DIFF
--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -140,6 +140,13 @@ class Beam:
         if xopt_obj is None:
             print(f"[check_calibration] No xopt_obj provided")
             return False
+        bounds_undp_x, bounds_undp_y = xopt_obj.vocs.variables[UNDP_KEY_X], xopt_obj.vocs.variables[UNDP_KEY_Y]
+        
+        if curr_xy[0] < bounds_undp_x[0] or curr_xy[0] > bounds_undp_x[1] or curr_xy[1] < bounds_undp_y[0] or curr_xy[1] > bounds_undp_y[1]:
+            print(f"[check_calibration] Current undulator position {curr_xy} outside VOCS bounds {bounds_undp_x, bounds_undp_y}")
+            print(f"[check_calibration] Cannot use calibration for this position, returning False")
+            return False
+
         df_curr = pd.DataFrame([{UNDP_KEY_X: curr_xy[0], UNDP_KEY_Y: curr_xy[1]}])
         res = xopt_obj.evaluate_data(df_curr)
         meas = (float(res["centroid_x"].iat[-1]), float(res["centroid_y"].iat[-1]))

--- a/mfx/optimize/xopt_scans.py
+++ b/mfx/optimize/xopt_scans.py
@@ -54,8 +54,8 @@ def get_variables(mover: Movers, narrow: bool = False):
         variables[MP_KEY] = [center - delta, center + delta]
     elif mover == "und":
         # Use fixed absolute bounds for undulator positions
-        variables[UNDP_KEY_X] = [0, 200]
-        variables[UNDP_KEY_Y] = [-450, -200]
+        variables[UNDP_KEY_X] = [-100, 150]
+        variables[UNDP_KEY_Y] = [-750, -350]
     return variables
 
 


### PR DESCRIPTION
This PR introduces a bugfix for issue #256. The traceback of the bug is in: https://pswww.slac.stanford.edu/lgbk/lgbk/mfx101344525/elogs/6906ae6a3db2ad76a14bc64c

Looking at the traceback, we loaded the calibration file and then called `check_calibration()`. `In check_calibration()`, we read the current undulator position, which at the beginning is `(0, -200)`, and called `xopt_obj.evaluate_data()` on that point. The problem was that the `xopt` bounds were:
`variables = {'undp_x': [-100.0, 150.0], 'undp_y': [-750.0, -350.0]}
`
so the y coordinate we tried to evaluate was outside the bounds of `undp_y`. This caused the `validate_input_data()` error at the end of the traceback.

To fix this, we now check if the undulator position is within the bounds of the `xopt` object before calling `xopt_obj.evaluate_data()`. If the position is outside of the bounds, we consider the calibration file stale and recalibrate from scratch. The first step in `calibrate()` then brings the undulator back within bounds. 

We also updated the undulator bounds based on the new mapping made by @fredericpoitevin. 
**Important**: Since we changed the bounds, we should set the starting undulator position to `(-100, -350)` instead of `(0, -200)` before calling `beam.align()` to avoid a large jump at the beginning.

We tested the fix in simulation by setting the undulator position outside of the xopt bounds:
```python
In [1]: sim_und.xpos.get()
Out[1]: 500.0

In [2]: sim_und.ypos.get()
Out[2]: 200.0
```

Then we called `beam.align()` (see the outputs starting with `[check_calibration]`)

```python
In [20]: beam.align(using_device='yag', on_diagnostic='dg1', mover='und', use_2d_markers=True, with_method='calib')
Loading Xopt object.
variables={'undp_x': [-100.0, 150.0], 'undp_y': [-750.0, -350.0]} constraints={'roi_radius': ['LESS_THAN', 180.0]} objectives={'objective': 'MINIMIZE'} constants={} observables=[]
Max travel distances [0.3, 0.1875]
variables={'undp_x': [-100.0, 150.0], 'undp_y': [-750.0, -350.0]} constraints={'roi_radius': ['LESS_THAN', 180.0]} objectives={'objective': 'MINIMIZE'} constants={} observables=[]
Generating path plot
[_calib] Checking calibration freshness...
[check_calibration] Loading calibration for dg1 from 2025-11-02T15:36:10
[check_calibration] Current undulator position (500.0, 200.0) outside VOCS bounds ([-100.0, 150.0], [-750.0, -350.0])
[check_calibration] Cannot use calibration for this position, returning False
[_calib] Calibration is stale, running calibrate() with grid_bins=5...
[calibrate] Grid inputs generated: shape=(25, 2)
[calibrate] Snaked grid: shape=(25, 2)
Trying (-100.0, -350.0)
/Users/aminelamouchi/mfx/.pixi/envs/optimize/lib/python3.13/site-packages/ophyd/signal.py:322: UserWarning: Signal.put no longer takes keyword arguments; These are ignored and will be deprecated. Received kwargs={'wait': False}
  warnings.warn(
image shape: (512, 512)
/Users/aminelamouchi/mfx/.pixi/envs/optimize/lib/python3.13/site-packages/lcls_tools/common/data/fit/projection.py:41: RuntimeWarning: invalid value encountered in divide
  normalized_data = (data_copy - np.min(data)) / (np.max(data) - np.min(data))
Trying (-37.5, -350.0)
image shape: (512, 512)
Distance from goal is 290.42638383275465
```
The calibration was considered stale and we generated a new one. 



