### PR TITLE
adding _move_und_in_chunks at the calib level

### DIFF
--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -39,7 +39,37 @@ class Beam:
         sol = np.linalg.solve(M, rhs)
         return (float(sol[0]), float(sol[1]))
 
-    
+    def _move_und_in_chunks(
+        self,
+        target_xy: tuple[float, float],
+        max_step: float = 50.0,
+        start_with_x: bool = True,
+    ) -> None:
+        """Move undulator in alternating chunks no larger than max_step per axis."""
+        from .xopt_scans import init_devices, evaluator_move
+
+        und = init_devices()["und_abs"]
+        curr_x = float(und.xpos.get())
+        curr_y = float(und.ypos.get())
+        tgt_x, tgt_y = float(target_xy[0]), float(target_xy[1])
+        move_x_next = bool(start_with_x)
+        eps = 1e-9
+        while (abs(tgt_x - curr_x) > eps) or (abs(tgt_y - curr_y) > eps):
+            if move_x_next and abs(tgt_x - curr_x) > eps:
+                dx = tgt_x - curr_x
+                step = np.sign(dx) * min(max_step, abs(dx))
+                curr_x = float(curr_x + step)
+            elif (not move_x_next) and abs(tgt_y - curr_y) > eps:
+                dy = tgt_y - curr_y
+                step = np.sign(dy) * min(max_step, abs(dy))
+                curr_y = float(curr_y + step)
+            else:
+                # If selected axis is already at target, switch axis
+                move_x_next = not move_x_next
+                continue
+            evaluator_move(mover="und", input={UNDP_KEY_X: curr_x, UNDP_KEY_Y: curr_y})
+            move_x_next = not move_x_next
+
     def _save_calibration_plots(self, res, reg_x, reg_y, out_dir, on_diagnostic, ts):
         """Save calibration plots to file."""
         plot_path = None
@@ -172,6 +202,18 @@ class Beam:
         print(f"[calibrate] Grid inputs generated: shape={df_grid.shape}")
         df_snake = snake_order(df_grid)
         print(f"[calibrate] Snaked grid: shape={df_snake.shape}")
+        # Pre-position to the first grid point in small alternating chunks
+        try:
+            start_x = float(df_snake.iloc[0][UNDP_KEY_X])
+            start_y = float(df_snake.iloc[0][UNDP_KEY_Y])
+            print(
+                f"[calibrate] Pre-positioning to first grid point ({start_x}, {start_y}) in chunks of 50..."
+            )
+            self._move_und_in_chunks(
+                (start_x, start_y), max_step=50.0, start_with_x=True
+            )
+        except Exception as exc:
+            print(f"[calibrate] Warning: failed to pre-position to grid start: {exc}")
         res = xopt_obj.evaluate_data(df_snake)
         print(f"[calibrate] Evaluated snaked grid: shape={res.shape}; columns={list(res.columns)}")
         print(res.head())
@@ -275,9 +317,10 @@ class Beam:
 
         print(f"[_calib] Solving for undulator position to achieve goal {goal}...")
         undp_xy = self._undp_solve(goal, calib)
-        print(f"[_calib] Moving to undulator position {undp_xy}...")
-        evaluator_move(
-            mover=mover, input={UNDP_KEY_X: undp_xy[0], UNDP_KEY_Y: undp_xy[1]}
+        print(f"[_calib] Moving to undulator position {undp_xy} in chunks of 50...")
+        # Move in alternating chunks to avoid large single steps
+        self._move_und_in_chunks(
+            (undp_xy[0], undp_xy[1]), max_step=50.0, start_with_x=True
         )
         return xopt
 


### PR DESCRIPTION
This PR was developed with @MartinaDelGaudio and implements the safety feature described in #259. We introduce the method `_move_und_in_chunks()`, which replaces `evaluator_move() `and splits large moves into chunks of at most 50.
We tested the feature in simulation by setting the undulator position to `(500, 500)`, well outside the VOCS bounds, and running `beam.align()`. The trajectory is correctly split into smaller steps and alternates between x and y directions. This is done both when moving to the start of a grid scan (in case of a stale calibration file) and during one-shot alignment (in case of a fresh calibration file).

```python
In [1]: sim_devices = sim_devices()

In [2]: sim_und = sim_devices["und_abs"]

In [3]: sim_und.xpos.set(500)
Out[3]: Status(obj=UnitConversionDerivedSignal(name='sim_2d_abs_xpos', parent='sim_2d_abs', value=151.16296468103812, timestamp=1762215012.064498, derived_from='x_raw_rbv'), done=False, success=False)

In [4]: sim_und.ypos.set(500)
Out[4]: Status(obj=UnitConversionDerivedSignal(name='sim_2d_abs_ypos', parent='sim_2d_abs', value=500.0, timestamp=1762215070.0568562, derived_from='y_raw_rbv'), done=True, success=True)

In [5]: beam.align(using_device='yag', on_diagnostic='dg1', mover='und', use_2d_markers=True, with_method='calib')
Loading Xopt object.
variables={'undp_x': [-100.0, 150.0], 'undp_y': [-750.0, -350.0]} constraints={'roi_radius': ['LESS_THAN', 180.0]} objectives={'objective': 'MINIMIZE'} constants={} observables=[]
Max travel distances [0.3, 0.1875]
variables={'undp_x': [-100.0, 150.0], 'undp_y': [-750.0, -350.0]} constraints={'roi_radius': ['LESS_THAN', 180.0]} objectives={'objective': 'MINIMIZE'} constants={} observables=[]
Generating path plot
[check_calibration] Loading calibration for dg1 from 2025-11-02T16:00:32
[check_calibration] Current undulator position (500.0, 500.0) outside VOCS bounds ([-100.0, 150.0], [-750.0, -350.0])
[check_calibration] Cannot use calibration for this position, returning False
[_calib] Calibration is stale, running calibrate() with grid_bins=5...
[calibrate] Grid inputs generated: shape=(25, 2)
[calibrate] Snaked grid: shape=(25, 2)
[calibrate] Pre-positioning to first grid point (-100.0, -350.0) in chunks of 50...
Trying (450.0, 500.0)
/Users/aminelamouchi/mfx/.pixi/envs/optimize/lib/python3.13/site-packages/ophyd/signal.py:322: UserWarning: Signal.put no longer takes keyword arguments; These are ignored and will be deprecated. Received kwargs={'wait': False}
  warnings.warn(
Trying (450.0, 450.0)
Trying (400.0, 450.0)
Trying (400.0, 400.0)
Trying (350.0, 400.0)
Trying (350.0, 350.0)
Trying (300.0, 350.0)
Trying (300.0, 300.0)
Trying (250.0, 300.0)
Trying (250.0, 250.0)
Trying (200.0, 250.0)
Trying (200.0, 200.0)
Trying (150.0, 200.0)
Trying (150.0, 150.0)
Trying (100.0, 150.0)
Trying (100.0, 100.0)
Trying (50.0, 100.0)
Trying (50.0, 50.0)
Trying (0.0, 50.0)
Trying (0.0, 0.0)
Trying (-50.0, 0.0)
Trying (-50.0, -50.0)
Trying (-100.0, -50.0)
Trying (-100.0, -100.0)
Trying (-100.0, -150.0)
Trying (-100.0, -200.0)
Trying (-100.0, -250.0)
Trying (-100.0, -300.0)
Trying (-100.0, -350.0)
Trying (-100.0, -350.0)
/Users/aminelamouchi/mfx/.pixi/envs/optimize/lib/python3.13/site-packages/ophyd/signal.py:322: UserWarning: Signal.put no longer takes keyword arguments; These are ignored and will be deprecated. Received kwargs={'wait': False}
  warnings.warn(
image shape: (512, 512)
/Users/aminelamouchi/mfx/.pixi/envs/optimize/lib/python3.13/site-packages/lcls_tools/common/data/fit/projection.py:82: OptimizeWarning: Initial guess is not within the specified bounds
  res = scipy.optimize.minimize(
Distance from goal is 288.51677960652495
Trying (-37.5, -350.0)
image shape: (512, 512)
Distance from goal is 289.3437311331216
Trying (25.0, -350.0)
image shape: (512, 512)
Distance from goal is 289.53882758563003
Trying (87.5, -350.0)
image shape: (512, 512)
Distance from goal is 189.06612300583924
Trying (150.0, -350.0)
image shape: (512, 512)
Distance from goal is 162.49712487941693
Trying (150.0, -450.0)
image shape: (512, 512)
Distance from goal is 168.4361746546746
Trying (87.5, -450.0)
image shape: (512, 512)
Distance from goal is 194.445253796096
Trying (25.0, -450.0)
image shape: (512, 512)
Distance from goal is 292.5451199624574
Trying (-37.5, -450.0)
image shape: (512, 512)
Distance from goal is 293.8666684144188
Trying (-100.0, -450.0)
image shape: (512, 512)
Distance from goal is 293.4247320508672
Trying (-100.0, -550.0)
image shape: (512, 512)
Distance from goal is 353.3741802261522
Trying (-37.5, -550.0)
image shape: (512, 512)
Distance from goal is 353.3741802261521
Trying (25.0, -550.0)
image shape: (512, 512)
Distance from goal is 353.3978271013626
Trying (87.5, -550.0)
image shape: (512, 512)
Distance from goal is 277.5920506944429
Trying (150.0, -550.0)
image shape: (512, 512)
Distance from goal is 259.2551694606699
Trying (150.0, -650.0)
image shape: (512, 512)
Distance from goal is 261.2131345832356
Trying (87.5, -650.0)
image shape: (512, 512)
Distance from goal is 276.0811276913715
Trying (25.0, -650.0)
image shape: (512, 512)
Distance from goal is 353.3741802261535
Trying (-37.5, -650.0)
image shape: (512, 512)
Distance from goal is 353.35053176841905
Trying (-100.0, -650.0)
image shape: (512, 512)
Distance from goal is 353.35053176841905
Trying (-100.0, -750.0)
image shape: (512, 512)
Distance from goal is 353.35053176841905
Trying (-37.5, -750.0)
image shape: (512, 512)
Distance from goal is 353.35053176841905
Trying (25.0, -750.0)
image shape: (512, 512)
Distance from goal is 353.37418022615765
Trying (87.5, -750.0)
image shape: (512, 512)
Distance from goal is 277.7643502360469
Trying (150.0, -750.0)
image shape: (512, 512)
Distance from goal is 261.3009708112813
[calibrate] Evaluated snaked grid: shape=(25, 15); columns=['undp_x', 'undp_y', 'centroid_x', 'centroid_y', 'rms_size_x', 'rms_size_y', 'total_intensity', 'roi_radius', 'objective', 'image_npz_path', 'wave8_x', 'wave8_y', 'wave8_sum', 'xopt_runtime', 'xopt_error']
   undp_x  undp_y  centroid_x  centroid_y  rms_size_x  ...   wave8_x   wave8_y   wave8_sum  xopt_runtime xopt_error
0  -100.0  -350.0    5.143443  399.269307    5.157971  ...  8.734954  0.302128  688.308888      5.231525      False
1   -37.5  -350.0    5.143443  400.916057    6.692848  ...  8.310331  0.374572  760.411879      5.286645      False
2    25.0  -350.0    5.110000  401.245412   20.860411  ...  8.010207  0.258920  696.665607      5.310321      False
3    87.5  -350.0  137.753080  403.321134   42.793655  ...  7.788441  0.312913  961.484866      5.289543      False
4   150.0  -350.0  322.230965  402.936854   42.785495  ...  7.467132  0.229783  692.744574      5.260271      False

[5 rows x 15 columns]
[calibrate] Fitting linear regression models...
[calibrate] coeff_x: a0=62.353, a1=1.237, a2=-0.004
[calibrate] coeff_y: b0=592.289, b1=0.003, b2=0.889
[calibrate] sigma_px=30.43, sigma_x=62.64, sigma_y=88.20
[calibrate] Wrote grid preview CSV: /Users/aminelamouchi/mfx/logs/xopt/calibration/calib_grid_dg1_25-11-03-16:13:27.csv
[calibrate] Wrote scatter plot: /Users/aminelamouchi/mfx/logs/xopt/calibration/calib_scatter_dg1_25-11-03-16:13:27.png
[_calib] Solving for undulator position to achieve goal (np.float64(255.0), np.float64(255.0))...
[_calib] Moving to undulator position (154.5442257306953, -380.00231175963603) in chunks of 50...
Trying (154.5442257306953, -750.0)
/Users/aminelamouchi/mfx/.pixi/envs/optimize/lib/python3.13/site-packages/ophyd/signal.py:322: UserWarning: Signal.put no longer takes keyword arguments; These are ignored and will be deprecated. Received kwargs={'wait': False}
  warnings.warn(
Trying (154.5442257306953, -700.0)
Trying (154.5442257306953, -650.0)
Trying (154.5442257306953, -600.0)
Trying (154.5442257306953, -550.0)
Trying (154.5442257306953, -500.0)
Trying (154.5442257306953, -450.0)
Trying (154.5442257306953, -400.0)
Trying (154.5442257306953, -380.00231175963603)
```