### PR TITLE
MFX-MEC Multiplexing 

### DIFF
--- a/mfx/optimize/mirror_pointing.py
+++ b/mfx/optimize/mirror_pointing.py
@@ -1,0 +1,182 @@
+from mfx.optimize.devices import YagCamera
+from mfx.optimize.beamline_hw import init_devices
+from lcls_tools.common.image.fit import ImageProjectionFit
+
+import numpy as np, matplotlib.pyplot as plt
+from epics import caget
+import argparse
+import time
+
+def get_yag_centroid(prefix, name, num_frames=10, timeout=10):
+    camera = YagCamera(prefix, name=name)
+    image_dev = camera.image1.shaped_image
+
+    images = []
+    for i in range(num_frames):
+        image_dev.trigger().wait(timeout=timeout)
+        image = image_dev.get()
+        images.append(image)
+    
+    averaged_image = np.mean(images, axis=0)
+
+    fitter = ImageProjectionFit()
+    result = fitter.fit_image(averaged_image)
+
+    return result.centroid
+
+
+def optimize_mirror_pointing(
+    instrument: str,
+    diagnostic_pvname: str,
+    window_size: float = 5.0,
+    num_frames: int = 10,
+    num_points: int = 10,
+):
+    """
+    Simple mirror pointing optimization.
+    
+    Parameters
+    ----------
+    instrument : str
+        "mfx" or "mec"
+    diagnostic_pvname : str
+        PV prefix for YAG camera (e.g., "MFX:GIGE:DG1:YAG:" or "MEC:GIGE:13:")
+    window_size : float
+        Window size around nominal position, default 5.0
+    num_frames : int
+        Number of frames to average, default 10
+    num_points : int
+        Number of points in scan, default 10
+    """
+    # Get nominal position
+    if instrument.lower() == "mfx":
+        pv_name = "MR1L4:PITCH:MFX:Coating1"
+    else:  # MEC
+        pv_name = "MR1L4:PITCH:MEC:Coating1"
+    nominal_position = caget(pv_name)
+    print(f"Nominal position: {nominal_position}")
+    
+    # Create mirror positions
+    mirror_bounds = [nominal_position - window_size, nominal_position + window_size]
+    mirror_positions = np.linspace(mirror_bounds[0], mirror_bounds[1], num_points)
+    
+    # Initialize devices
+    devices = init_devices()
+    mirror_device = devices["mr1l4_homs"]
+    
+    # Get YAG camera and goal
+    yag_camera = YagCamera(diagnostic_pvname, name=f"{instrument}_yag")
+    goal_x, goal_y = yag_camera.coords.standard_two_corners_target()
+    print(f"Goal position: ({goal_x}, {goal_y})")
+    
+    # Scan mirror positions and collect centroids
+    centroids_x = []
+    centroids_y = []
+    
+    for pos in mirror_positions:
+        print(f"Moving mirror to {pos}")
+        mirror_device.pitch.mv(pos)
+        time.sleep(2)  # Wait for motion to settle
+        
+        centroid = get_yag_centroid(
+            prefix=diagnostic_pvname,
+            name=f"{instrument}_yag",
+            num_frames=num_frames,
+        )
+        centroids_x.append(centroid[0])
+        centroids_y.append(centroid[1])
+        print(f"  Centroid: ({centroid[0]:.2f}, {centroid[1]:.2f})")
+    
+    # Fit lines
+    slope_x, intercept_x = np.polyfit(mirror_positions, centroids_x, 1)
+    slope_y, intercept_y = np.polyfit(mirror_positions, centroids_y, 1)
+    
+    # Solve for mirror position
+    mirror_solution_x = (goal_x - intercept_x) / slope_x
+    mirror_solution_y = (goal_y - intercept_y) / slope_y
+    
+    # Use the one with better fit (or average)
+    r2x = 1 - np.sum((centroids_x - (slope_x * mirror_positions + intercept_x))**2) / np.sum((centroids_x - np.mean(centroids_x))**2)
+    r2y = 1 - np.sum((centroids_y - (slope_y * mirror_positions + intercept_y))**2) / np.sum((centroids_y - np.mean(centroids_y))**2)
+    
+    print(f"R^2 x: {r2x:.3f}, R^2 y: {r2y:.3f}")
+    
+    if r2x >= r2y:
+        mirror_solution = mirror_solution_x
+        print(f"Using x fit (better R^2)")
+    else:
+        mirror_solution = mirror_solution_y
+        print(f"Using y fit (better R^2)")
+    
+    print(f"Mirror solution: {mirror_solution:.3f}")
+    
+    # Move to solution
+    print(f"Moving mirror to solution: {mirror_solution}")
+    mirror_device.pitch.mv(mirror_solution)
+    
+    # Plot results
+    plt.figure()
+    plt.plot(mirror_positions, centroids_x, 'o-', label='centroid_x')
+    plt.axvline(mirror_solution, color='r', linestyle='--', label='solution')
+    plt.axhline(goal_x, color='g', linestyle='--', label='goal_x')
+    plt.xlabel("mirror_position")
+    plt.ylabel("centroid_x")
+    plt.legend()
+    plt.show(block=False)
+    
+    plt.figure()
+    plt.plot(mirror_positions, centroids_y, 'o-', label='centroid_y')
+    plt.axvline(mirror_solution, color='r', linestyle='--', label='solution')
+    plt.axhline(goal_y, color='g', linestyle='--', label='goal_y')
+    plt.xlabel("mirror_position")
+    plt.ylabel("centroid_y")
+    plt.legend()
+    plt.show(block=False)
+    
+    return mirror_solution
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Mirror pointing optimization script")
+    parser.add_argument(
+        "--instrument", "-i",
+        choices=["mfx", "mec"],
+        default="mfx",
+        help="Instrument name (default: mfx)"
+    )
+    parser.add_argument(
+        "--diagnostic", "-d",
+        type=str,
+        required=True,
+        help="Diagnostic PV prefix (e.g., MFX:GIGE:DG1:YAG: or MEC:GIGE:13:)"
+    )
+    parser.add_argument(
+        "--window", "-w",
+        type=float,
+        default=5.0,
+        help="Window size around nominal position (default: 5.0)"
+    )
+    parser.add_argument(
+        "--num-frames", "-n",
+        type=int,
+        default=10,
+        help="Number of frames to average (default: 10)"
+    )
+    parser.add_argument(
+        "--num-points", "-p",
+        type=int,
+        default=10,
+        help="Number of points in scan (default: 10)"
+    )
+    args = parser.parse_args()
+    
+    optimize_mirror_pointing(
+        instrument=args.instrument,
+        diagnostic_pvname=args.diagnostic,
+        window_size=args.window,
+        num_frames=args.num_frames,
+        num_points=args.num_points,
+    ) 
+
+if __name__ == "__main__":
+    main()

--- a/mfx/optimize/undpoint.py
+++ b/mfx/optimize/undpoint.py
@@ -285,14 +285,27 @@ class SafeUndPointAbs2D(UndPointAbs2D):
     Absolute undulator pointing with safe segmented moves (both axes per step).
     """
 
+    def __init__(
+        self,
+        prefix: str,
+        *,
+        name: str,
+        max_step: Optional[float] = 50.0,
+        sleep_between: float = 2.0,
+        **kwargs,
+    ):
+        self._max_step = max_step
+        self._sleep_between = sleep_between
+        super().__init__(prefix, name=name, **kwargs)
+
     @validate_call
     def move(
         self,
         position: Union[tuple[float, float], float],
         y_abs: Optional[float] = None,
         wait: bool = True,
-        max_step: Optional[float] = 50.0,
-        sleep_between: float = 2.0,
+        max_step: Optional[float] = None,
+        sleep_between: Optional[float] = None,
         timeout: Optional[float] = None,
         moved_cb: Optional[Callable] = None,
     ):
@@ -303,6 +316,12 @@ class SafeUndPointAbs2D(UndPointAbs2D):
         each segment clamped to max_step in magnitude. Otherwise, perform a
         single absolute move via the base class.
         """
+        # use instance defaults if not provided
+        if max_step is None:
+            max_step = self._max_step
+        if sleep_between is None:
+            sleep_between = self._sleep_between
+
         target_abs = coerce_input_to_tuple(position, y_abs)
         dx_total, dy_total = self.get_delta_from_abs(target_abs)
 
@@ -358,9 +377,11 @@ class SafeUndPointAbs2DMFX(SafeUndPointAbs2D):
         prefix: str = "MFX:USER:MCC:UND",
         *,
         name: str = "mfx_undp_safe",
+        max_step: Optional[float] = 50.0,
+        sleep_between: float = 2.0,
         **kwargs,
     ):
-        super().__init__(prefix, name=name, **kwargs)
+        super().__init__(prefix, name=name, max_step=max_step, sleep_between=sleep_between, **kwargs)
 
 class UndPointDelta2DSim(UndPointDelta2D):
     """


### PR DESCRIPTION
Our goal is to enable automated beam steering between MFX and MEC instruments using the MR1L4 pitch mirror. As a first step, we're focusing on pointing (data collection and DAQ management are deferred). 

## Protocol

For each instrument (MFX and MEC), perform an independent calibration:

1. Read the nominal pitch value from the PV and move the mirror there
2. Scan the mirror pitch over a window (default +-5 urad) around the nominal position
3. At each scan point:
   - Trigger the YAG camera multiple times (default 10 frames)
   - Average the frames to reduce noise
   - Fit the image to get centroid position (cx, cy) in pixels
4. Fit linear models:
   - `centroid_x = slope_x * pitch + intercept_x`
   - `centroid_y = slope_y * pitch + intercept_y`
5. Use the goal marker position (from `yag_camera.coords.standard_two_corners_target()`) to solve for the optimal pitch:
   - `pitch_x = (goal_x - intercept_x) / slope_x`
   - `pitch_y = (goal_y - intercept_y) / slope_y`
   - Select the solution with better R^2 fit (this is because we don't know which of cx and cy corresponds to a horizontal motion of the beam, we know from experience that the YAG cameras are sometimes rotated, this allows to be rotation-agnostic)
6. Move the mirror to the calculated optimal position

## Usage

#### Python API

```python
from mfx.optimize.mirror_pointing import optimize_mirror_pointing

# Calibrate MFX
mfx_pitch = optimize_mirror_pointing(
    instrument="mfx",
    diagnostic_pvname="MFX:GIGE:DG2:YAG:",
    window_size=5.0,
    num_frames=10,
    num_points=10,
)

# Calibrate MEC
mec_pitch = optimize_mirror_pointing(
    instrument="mec",
    diagnostic_pvname="MEC:GIGE:13:",
    window_size=5.0,
    num_frames=10,
    num_points=10,
)
```

#### Command Line Interface

```bash
python -m mfx.optimize.mirror_pointing \
    --instrument mfx \
    --diagnostic "MFX:GIGE:DG1:YAG:" \
    --window 5.0 \
    --num-frames 10 \
    --num-points 10
```

**Arguments:**
- `--instrument` / `-i`: Instrument name (`mfx` or `mec`), default: `mfx`
- `--diagnostic` / `-d`: PV prefix for YAG camera
  - MFX: `"MFX:GIGE:DG1:YAG:"` or `"MFX:GIGE:DG2:YAG:"`
  - MEC: `"MEC:GIGE:13:"` (MEC_YAG3), `"MEC:GIGE:14:"` (MEC_YAG1), or `"MEC:GIGE:44:"` (MEC_YAG2)
- `--window` / `-w`: Window size around nominal position in μrad, default: `5.0`
- `--num-frames` / `-n`: Number of frames to average per measurement, default: `10`
- `--num-points` / `-p`: Number of scan points, default: `10`

## Notes

We can use the following YAG cameras as diagnostics

**MFX Options:**
- `MFX:GIGE:DG1:YAG:` (DG1 YAG)
- `MFX:GIGE:DG2:YAG:` (DG2 YAG, recommended by Matt)

**MEC Options:**
- `MEC:GIGE:13:` (MEC_YAG3, recommended by Matt but may not always be updating)
- `MEC:GIGE:14:` (MEC_YAG1, alternative)
- `MEC:GIGE:44:` (MEC_YAG2, alternative)

For the nominal setpoints, I hardcoded the following PVs:

  - MFX: `MR1L4:PITCH:MFX:Coating1` (typically ~-554.4 urad)
  - MEC: `MR1L4:PITCH:MEC:Coating1` (typically ~830.2 urad)

But Matt said there are also `Coating2` PVs for different energy ranges.