### PR TITLE
275 coyote commissioning

### DIFF
--- a/mfx/bash_utilities.py
+++ b/mfx/bash_utilities.py
@@ -1117,7 +1117,7 @@ class BashUtilities:
 
         logger.info("AMI launched")
 
-    def coyote_gui(self, debug: bool = False):
+    def coyote_gui(self, cfg: str = 'coyote', debug: bool = False):
         """
         Launch Coyote GUI with current experiment configuration.
 
@@ -1139,9 +1139,9 @@ class BashUtilities:
         logger.info("Launching Coyote GUI")
 
         cmd = (
-            "source pcds_conda; "
-            "cd /cds/group/pcds/epics-dev/zlentz/bsmtraj; "
-            "python -m bsmtraj.gui coyote"
+            f"source pcds_conda; "
+            f"cd /cds/group/pcds/epics-dev/zlentz/bsmtraj; "
+            f"python -m bsmtraj.gui {cfg}"
         )
 
         logger.warning(cmd)

--- a/mfx/bash_utilities.py
+++ b/mfx/bash_utilities.py
@@ -680,7 +680,7 @@ class BashUtilities:
 
         logger.info("DAQ stop initiated")
 
-    def lecroy(self, res: str = '2560x1440'):
+    def lecroy(self, res: str = '2560x1440', num: int = 1):
         """
         Open LeCroy oscilloscope remote desktop.
 
@@ -739,8 +739,10 @@ class BashUtilities:
         cmd = (
             f"xfreerdp -g {res} "
             f"-u lecroyuser -p pcds "
-            f"scope-ics-mfx-lecroy01"
+            f"scope-ics-mfx-lecroy0{num}"
         )
+
+        logger.warning(cmd)
 
         subprocess.Popen(
             cmd,
@@ -750,6 +752,41 @@ class BashUtilities:
         )
 
         logger.info("LeCroy RDP session launched")
+
+    def mirrors(self):
+        """
+        Open Mirror GUI.
+
+        Launches Matt's Dev Branch Mirror GUI.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+        Mirror GUI:
+        - Matt's Dev Branch Mirror GUI
+        - Used for mirror alignment and diagnostics
+        """
+        logger.info("Opening Mirror GUI")
+
+        cmd = ("~seaberg/screens/homs_overview/launcher.sh")
+
+        logger.warning(cmd)
+
+        subprocess.Popen(
+            cmd,
+            shell=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT
+        )
+
+        logger.info("Mirror GUI launched")
 
     def grabber(self):
         """

--- a/mfx/bash_utilities.py
+++ b/mfx/bash_utilities.py
@@ -1117,6 +1117,52 @@ class BashUtilities:
 
         logger.info("AMI launched")
 
+    def coyote_gui(self, debug: bool = False):
+        """
+        Launch Coyote GUI with current experiment configuration.
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+        GUI configuration File:
+        - Location: /cds/group/pcds/epics-dev/zlentz/bsmtraj/cfg_assembly/coyote.toml
+
+        Chip config folder:
+        - Location: /cds/group/pcds/epics-dev/zlentz/bsmtraj/cfg_chip
+
+        """
+
+        # Launch GUI
+        logger.info("Launching Coyote GUI")
+
+        cmd = (
+            "source pcds_conda; "
+            "cd /cds/group/pcds/epics-dev/zlentz/bsmtraj; "
+            "python -m bsmtraj.gui coyote"
+        )
+
+        logger.warning(cmd)
+        logger.warning(
+            'GUI configuration File: '
+            '/cds/group/pcds/epics-dev/zlentz/bsmtraj/cfg_assembly/coyote.toml')
+        logger.warning(
+            'Chip config folder: '
+            '/cds/group/pcds/epics-dev/zlentz/bsmtraj/cfg_chip')
+
+        if debug:
+            os.system(cmd)
+
+        else:
+            subprocess.Popen(
+                cmd,
+                shell=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT
+            )
+        logger.info("Coyote GUI launched successfully")
 
 # Convenience instance for direct import
 bs = BashUtilities()
@@ -1193,7 +1239,6 @@ def focus_scan(camera: str, record: bool = False, daq_num: int = 2):
 def startami(ami_num: int = 1, daq_num: int = 1):
     """Start AMI. See BashUtilities.startami()."""
     bs.startami(ami_num=ami_num, daq_num=daq_num)
-
 
 # Module initialization
 logger.info("Bash utilities loaded and ready")

--- a/mfx/beamline.py
+++ b/mfx/beamline.py
@@ -189,13 +189,13 @@ with safe_load("laser wp power"):
     from pcdsdevices.device import Component as Cpt
     from pcdsdevices.epics_motor import Newport
 
-    # Hack the LXE class to make it work with Newports
-    class LXE(LaserEnergyPositioner):
-        motor = Cpt(Newport, "")
+    # # Hack the LXE class to make it work with Newports
+    # class LXE(LaserEnergyPositioner):
+    #     motor = Cpt(Newport, "")
 
     lxe_calib_file = (f"/reg/neh/operator/mfxopr/experiments/{get_current_experiment('mfx')}/wpcalib")
     try:
-        lxe = LXE("MFX:LAS:MMN:08", calibration_file=lxe_calib_file, name="lxe")
+        lxe = Newport("MFX:LAS:MMN:08", calibration_file=lxe_calib_file, name="lxe")
     except OSError:
         print(f"Could not load file: {lxe_calib_file}")
         raise FileNotFoundError
@@ -232,9 +232,6 @@ with safe_load('add laser motor groups'):
     from pcdsdevices.usb_encoder import UsDigitalUsbEncoder
     from mfx.db import mfx_lxt_fast1, mfx_lxt_fast2
 
-    # James -should this now be set to mfx_lxt_fast2?
-    lxt_fast=mfx_lxt_fast1
-
     #opa_comp = Newport('MFX:LAS:MMN:01', name='opa_comp') # linear motor for OPA compressor
     # this is the timetool compensationn stage. You might want this one
 
@@ -264,12 +261,12 @@ with safe_load('add laser motor groups'):
             lxt_fast1_enc = UsDigitalUsbEncoder('MFX:USDUSB4:01:CH2', name='lxt_fast_enc1', linked_axis=mfx_lxt_fast1)
             lxt_fast2_enc = UsDigitalUsbEncoder('MFX:USDUSB4:01:CH1', name='lxt_fast_enc2', linked_axis=mfx_lxt_fast2)
 
-        # timing virtual motors for x-ray laser delay adjustment
-        lxt = lxt # virtual motor that moves the laser timing system phase shifter
-        txt = txt
-        lxt_ttc = lxt_ttc
-        lxt_fast1 = mfx_lxt_fast1
-        lxt_fast2 = mfx_lxt_fast2
+    # timing virtual motors for x-ray laser delay adjustment
+    lxt = lxt # virtual motor that moves the laser timing system phase shifter
+    txt = txt
+    lxt_ttc = lxt_ttc
+    lxt_fast1 = mfx_lxt_fast1
+    lxt_fast2 = mfx_lxt_fast2
 
 def mfx_reload(module_name):
     import importlib

--- a/mfx/beamline.py
+++ b/mfx/beamline.py
@@ -256,6 +256,10 @@ with safe_load('add laser motor groups'):
             mirlens_v = Newport('MFX:HRA:MMN:25', name='mirlens_v')
             mirlens_h = Newport('MFX:HRA:MMN:26', name='mirlens_h')
             mirlens_f = Newport('MFX:HRA:MMN:27', name='mirlens_f')
+            oap_f = Newport('MFX:HRA:MMN:28', name='oap_f')
+            oap_v = Newport('MFX:HRA:MMN:29', name='oap_v')
+            oap_h = Newport('MFX:HRA:MMN:30', name='oap_h')
+            focus_track = Newport('MFX:HRA:MMN:31', name='focus_track')
 
         with safe_load('Fast delay encoders'):
             lxt_fast1_enc = UsDigitalUsbEncoder('MFX:USDUSB4:01:CH2', name='lxt_fast_enc1', linked_axis=mfx_lxt_fast1)


### PR DESCRIPTION
Merging branch 275-coyote-commissioning, into run25 with the following changes:

Added newport motors to las class
f7e164d fixed lecroy added mirrors
3b8c0c1 fixed lxt_fast in beamline
6f0af9f Merge branch 'run25' of github.com:pcdshub/mfx into 275-coyote-commissioning
8a6c08e (origin/run25) Merge pull request #277 from rcjwoods/midIR_updates
01aed3a Added newport stages for lens and mir lens motion
358d9eb updates to beamline.py for 2nd fast delay stage
cca830c add cfg to coyote
a50ae30 Merge branch 'run25' of github.com:pcdshub/mfx into 275-coyote-commissioning
32449d6 Merge pull request #276 from pcdshub/mfx_mec_multiplexing
588f874 (origin/mfx_mec_multiplexing) undulator chunked motion bugfix
2bbcf70 (mfx_mec_multiplexing) Add mirror pointing optimization script
c7c8a07 add coyote gui to bs


Most of this is just bug fixes or adding things to bash_scripts.py but here are a few of the important one liners:
bs.coyote_gui(debug=True) ... Opens coyote GUI
und_abs_safe((-59,-427), wait=True) ... Moves undulator pointing in 50um increments
bs.lecroy(num=1) ... Opens either of the 2 lecroys full screen
bs.mirrors() ... Opens Matts newest Mirror GUI that monitors MR1L0 position