### PR TITLE
Bluesky MFX-MEC Multiplexing

### DIFF
--- a/mfx/optimize/auto_undpoint.py
+++ b/mfx/optimize/auto_undpoint.py
@@ -1,0 +1,92 @@
+from bluesky import RunEngine
+from bluesky.callbacks.best_effort import BestEffortCallback
+import bluesky.plans as bp
+import bluesky.plan_stubs as bps
+import numpy as np
+
+from mfx.optimize.devices import YagWithCentroid
+from mfx.optimize.beamline_hw import init_devices
+
+
+UNDULATOR_CONFIG = {
+    "xcs1": {"x": (0, 200), "y": (-450, -200), "pv": "XCS:GIGE:YAG1:"},
+    "dg1":  {"x": (-100, 150), "y": (-750, -350), "pv": "MFX:GIGE:DG1:YAG:"},
+    "dg2":  {"x": None, "y": None, "pv": "MFX:GIGE:DG2:YAG:"},
+}
+
+
+def optimize_undulator_pointing(
+    diagnostic="dg1",
+    grid_points=5,
+    num_frames=10,
+    sim=False,
+    safe=False,
+):
+    if diagnostic not in UNDULATOR_CONFIG:
+        raise ValueError(
+            f"Unknown diagnostic '{diagnostic}', expected one of {list(UNDULATOR_CONFIG)}"
+        )
+
+    config = UNDULATOR_CONFIG[diagnostic]
+    if config["x"] is None or config["y"] is None:
+        raise ValueError(f"Undulator ranges for '{diagnostic}' have not been determined yet.")
+
+    if sim:
+        from mfx.optimize.beamline_hw import sim_devices
+        devs = sim_devices()
+        und = devs["und_abs"]
+    else:
+        devs = init_devices(force=True)
+        if safe:
+            und = globals().get("und_abs_safe")
+            if und is None:
+                raise NameError("safe=True but und_abs_safe is not defined in globals().")
+        else:
+            und = devs["und_abs"]
+
+    yag = YagWithCentroid(config["pv"], name=f"mfx_{diagnostic}_yag")
+    yag.image1.kind = "omitted"
+    yag.num_frames = num_frames
+
+    goal_x, goal_y = yag.coords.standard_two_corners_target()
+
+    RE = RunEngine({})
+    RE.subscribe(BestEffortCallback())
+
+    scan_data = {"ux": [], "uy": [], "cx": [], "cy": []}
+
+    def collect(name, doc):
+        if name == "event":
+            d = doc["data"]
+            scan_data["ux"].append(d[und.xpos.name])
+            scan_data["uy"].append(d[und.ypos.name])
+            scan_data["cx"].append(d[f"{yag.name}_centroid_x"])
+            scan_data["cy"].append(d[f"{yag.name}_centroid_y"])
+
+    RE(
+        bp.grid_scan(
+            [yag],
+            und.xpos, *config["x"], grid_points,
+            und.ypos, *config["y"], grid_points,
+            snake_axes=True,
+        ),
+        collect,
+    )
+
+    A = np.column_stack([np.ones(len(scan_data["ux"])), scan_data["ux"], scan_data["uy"]])
+    cx = np.linalg.lstsq(A, scan_data["cx"], rcond=None)[0]
+    cy = np.linalg.lstsq(A, scan_data["cy"], rcond=None)[0]
+
+    print(f"centroid_x = {cx[0]:.2f} + {cx[1]:.4f}*ux + {cx[2]:.4f}*uy")
+    print(f"centroid_y = {cy[0]:.2f} + {cy[1]:.4f}*ux + {cy[2]:.4f}*uy")
+
+    M = np.array([[cx[1], cx[2]], [cy[1], cy[2]]])
+    rhs = np.array([goal_x - cx[0], goal_y - cy[0]])
+    sol = np.linalg.solve(M, rhs)
+
+    print(f"Solution: undp_x={sol[0]:.2f}, undp_y={sol[1]:.2f}")
+
+    RE(bps.mv(und.xpos, sol[0], und.ypos, sol[1]))
+    print(f"Moved undulator to ({sol[0]:.2f}, {sol[1]:.2f})")
+
+    return (sol[0], sol[1])

--- a/mfx/optimize/auto_undpoint.py
+++ b/mfx/optimize/auto_undpoint.py
@@ -1,6 +1,6 @@
 from bluesky import RunEngine
 from bluesky.callbacks.best_effort import BestEffortCallback
-import bluesky.plans as bp
+from bluesky.preprocessors import run_wrapper
 import bluesky.plan_stubs as bps
 import numpy as np
 
@@ -35,6 +35,7 @@ def optimize_undulator_pointing(
         from mfx.optimize.beamline_hw import sim_devices
         devs = sim_devices()
         und = devs["und_abs"]
+        yag = devs[f"mfx_{diagnostic}_yag"]
     else:
         devs = init_devices(force=True)
         if safe:
@@ -43,17 +44,13 @@ def optimize_undulator_pointing(
                 raise NameError("safe=True but und_abs_safe is not defined in globals().")
         else:
             und = devs["und_abs"]
+        yag = YagWithCentroid(config["pv"], name=f"mfx_{diagnostic}_yag")
 
-    # UnitConversionDerivedSignal.set() uses exact equality by default.
-    # Unit conversion (um <-> mm) introduces ~1e-13 um floating-point error
-    # for some values (e.g. -350 um), causing the set() completion thread to
-    # spin forever. A sub-nm tolerance switches the comparison to np.allclose.
-    und.xpos.tolerance = 1e-6
-    und.ypos.tolerance = 1e-6
-
-    yag = YagWithCentroid(config["pv"], name=f"mfx_{diagnostic}_yag")
     yag.image1.kind = "omitted"
     yag.num_frames = num_frames
+
+    # Keep the scan table clean: delta_xy internals are not useful readback.
+    und.delta_xy.kind = "omitted"
 
     goal_x, goal_y = yag.coords.standard_two_corners_target()
 
@@ -70,15 +67,17 @@ def optimize_undulator_pointing(
             scan_data["cx"].append(d[f"{yag.name}_centroid_x"])
             scan_data["cy"].append(d[f"{yag.name}_centroid_y"])
 
-    RE(
-        bp.grid_scan(
-            [yag],
-            und.xpos, *config["x"], grid_points,
-            und.ypos, *config["y"], grid_points,
-            snake_axes=True,
-        ),
-        collect,
-    )
+    x_vals = np.linspace(*config["x"], grid_points)
+    y_vals = np.linspace(*config["y"], grid_points)
+
+    def grid_plan():
+        for i, x in enumerate(x_vals):
+            row = y_vals if i % 2 == 0 else y_vals[::-1]
+            for y in row:
+                yield from bps.mv(und, (x, y))
+                yield from bps.trigger_and_read([und, yag])
+
+    RE(run_wrapper(grid_plan()), collect)
 
     cx_arr = np.array(scan_data["cx"])
     cy_arr = np.array(scan_data["cy"])
@@ -104,7 +103,7 @@ def optimize_undulator_pointing(
 
     print(f"Solution: undp_x={sol[0]:.2f}, undp_y={sol[1]:.2f}")
 
-    RE(bps.mv(und.xpos, sol[0], und.ypos, sol[1]))
+    und.move((sol[0], sol[1]), wait=True)
     print(f"Moved undulator to ({sol[0]:.2f}, {sol[1]:.2f})")
 
     return (sol[0], sol[1])

--- a/mfx/optimize/auto_undpoint.py
+++ b/mfx/optimize/auto_undpoint.py
@@ -9,15 +9,17 @@ from mfx.optimize.beamline_hw import init_devices
 
 
 UNDULATOR_CONFIG = {
-    "xcs1": {"x": (0, 200), "y": (-450, -200), "pv": "XCS:GIGE:YAG1:"},
+    "xcs1": {"x": (0, 200),    "y": (-450, -200), "pv": "XCS:GIGE:YAG1:"},
     "dg1":  {"x": (-100, 150), "y": (-750, -350), "pv": "MFX:GIGE:DG1:YAG:"},
-    "dg2":  {"x": None, "y": None, "pv": "MFX:GIGE:DG2:YAG:"},
+    "dg2":  {"x": (-100, 150), "y": (-750, -350), "pv": "MFX:GIGE:DG2:YAG:"},
 }
 
 
 def optimize_undulator_pointing(
     diagnostic="dg1",
+    mode="lscan",
     grid_points=5,
+    window=20.0,
     num_frames=10,
     sim=False,
     safe=False,
@@ -28,8 +30,6 @@ def optimize_undulator_pointing(
         )
 
     config = UNDULATOR_CONFIG[diagnostic]
-    if config["x"] is None or config["y"] is None:
-        raise ValueError(f"Undulator ranges for '{diagnostic}' have not been determined yet.")
 
     if sim:
         from mfx.optimize.beamline_hw import sim_devices
@@ -48,8 +48,6 @@ def optimize_undulator_pointing(
 
     yag.image1.kind = "omitted"
     yag.num_frames = num_frames
-
-    # Keep the scan table clean: delta_xy internals are not useful readback.
     und.delta_xy.kind = "omitted"
 
     goal_x, goal_y = yag.coords.standard_two_corners_target()
@@ -67,17 +65,34 @@ def optimize_undulator_pointing(
             scan_data["cx"].append(d[f"{yag.name}_centroid_x"])
             scan_data["cy"].append(d[f"{yag.name}_centroid_y"])
 
-    x_vals = np.linspace(*config["x"], grid_points)
-    y_vals = np.linspace(*config["y"], grid_points)
+    if mode == "lscan":
+        cur_x, cur_y = und.position
 
-    def grid_plan():
-        for i, x in enumerate(x_vals):
-            row = y_vals if i % 2 == 0 else y_vals[::-1]
-            for y in row:
-                yield from bps.mv(und, (x, y))
+        def scan_plan():
+            for x in np.linspace(cur_x - window, cur_x + window, grid_points):
+                yield from bps.mv(und, (x, cur_y))
+                yield from bps.trigger_and_read([und, yag])
+            for y in np.linspace(cur_y - window, cur_y + window, grid_points):
+                yield from bps.mv(und, (cur_x, y))
                 yield from bps.trigger_and_read([und, yag])
 
-    RE(run_wrapper(grid_plan()), collect)
+    elif mode == "grid":
+        if config["x"] is None or config["y"] is None:
+            raise ValueError(f"Undulator ranges for '{diagnostic}' have not been determined yet.")
+        x_vals = np.linspace(*config["x"], grid_points)
+        y_vals = np.linspace(*config["y"], grid_points)
+
+        def scan_plan():
+            for i, x in enumerate(x_vals):
+                row = y_vals if i % 2 == 0 else y_vals[::-1]
+                for y in row:
+                    yield from bps.mv(und, (x, y))
+                    yield from bps.trigger_and_read([und, yag])
+
+    else:
+        raise ValueError(f"Unknown mode '{mode}', expected 'lscan' or 'grid'")
+
+    RE(run_wrapper(scan_plan()), collect)
 
     cx_arr = np.array(scan_data["cx"])
     cy_arr = np.array(scan_data["cy"])

--- a/mfx/optimize/auto_undpoint.py
+++ b/mfx/optimize/auto_undpoint.py
@@ -73,9 +73,20 @@ def optimize_undulator_pointing(
         collect,
     )
 
-    A = np.column_stack([np.ones(len(scan_data["ux"])), scan_data["ux"], scan_data["uy"]])
-    cx = np.linalg.lstsq(A, scan_data["cx"], rcond=None)[0]
-    cy = np.linalg.lstsq(A, scan_data["cy"], rcond=None)[0]
+    cx_arr = np.array(scan_data["cx"])
+    cy_arr = np.array(scan_data["cy"])
+    ux_arr = np.array(scan_data["ux"])
+    uy_arr = np.array(scan_data["uy"])
+
+    valid = ~(np.isnan(cx_arr) | np.isnan(cy_arr))
+    if valid.sum() < 3:
+        raise RuntimeError(
+            f"Too few valid centroid readings ({valid.sum()}) to fit a model — beam may be off camera for most of the scan range."
+        )
+
+    A = np.column_stack([np.ones(valid.sum()), ux_arr[valid], uy_arr[valid]])
+    cx = np.linalg.lstsq(A, cx_arr[valid], rcond=None)[0]
+    cy = np.linalg.lstsq(A, cy_arr[valid], rcond=None)[0]
 
     print(f"centroid_x = {cx[0]:.2f} + {cx[1]:.4f}*ux + {cx[2]:.4f}*uy")
     print(f"centroid_y = {cy[0]:.2f} + {cy[1]:.4f}*ux + {cy[2]:.4f}*uy")

--- a/mfx/optimize/auto_undpoint.py
+++ b/mfx/optimize/auto_undpoint.py
@@ -44,6 +44,13 @@ def optimize_undulator_pointing(
         else:
             und = devs["und_abs"]
 
+    # UnitConversionDerivedSignal.set() uses exact equality by default.
+    # Unit conversion (um <-> mm) introduces ~1e-13 um floating-point error
+    # for some values (e.g. -350 um), causing the set() completion thread to
+    # spin forever. A sub-nm tolerance switches the comparison to np.allclose.
+    und.xpos.tolerance = 1e-6
+    und.ypos.tolerance = 1e-6
+
     yag = YagWithCentroid(config["pv"], name=f"mfx_{diagnostic}_yag")
     yag.image1.kind = "omitted"
     yag.num_frames = num_frames

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -148,7 +148,7 @@ class Beam:
         self,
         on_diagnostic: Diagnostics = "dg1",
         xopt_obj: Optional[Xopt] = None,
-        threshold_sigma: float = 2.0,
+        threshold_sigma: float = 10.0,
     ) -> bool:
         """
         Predict centroid from current undp_x, undp_y using latest calibration.

--- a/mfx/optimize/beam.py
+++ b/mfx/optimize/beam.py
@@ -492,7 +492,7 @@ class Beam:
                 try:
                     old_path_plot = xopt._cached_path_plot
                 except AttributeError:
-                    ...
+                    path_plot = None
                 else:
                     print("Generating new path plot from cached settings")
                     path_plot = UpdatingDeviceCentroidPathPlot(
@@ -500,8 +500,20 @@ class Beam:
                         goal=old_path_plot.goal,
                         constraints=old_path_plot.constraints,
                     )
+
+                if path_plot is not None:
+                    goal = path_plot.goal
+                else:
+                    goal = select_goal(
+                        device_type=using_device,
+                        location=on_diagnostic,
+                        goal=with_goal,
+                        goal_2d=with_goal_2d,
+                        use_2d_markers=use_2d_markers,
+                    )
             else:
                 print("Loading Xopt object.")
+                dump_file = None
                 if save_run:
                     now = datetime.datetime.now()
                     formatted_string = now.strftime("%y-%m-%d-%H:%M:%S")

--- a/mfx/optimize/beamline_hw.py
+++ b/mfx/optimize/beamline_hw.py
@@ -12,7 +12,7 @@ from pcdsdevices.pv_positioner import OnePVMotor
 from pcdsdevices.ipm import Wave8
 
 from .constraints import constraint_data
-from .devices import FakeLCLSImagePlugin, FakeYagCamera, YagCamera
+from .devices import FakeLCLSImagePlugin, FakeYagCamera, FakeYagWithCentroid, YagCamera
 from .undpoint import UndPointAbs2DMFX, UndPointAbs2DSim
 
 HAPPI_NAMES = (
@@ -168,9 +168,9 @@ def sim_devices() -> dict[str, Device]:
             name="mfx_dg2_wave8_sum",
         ),
     )
-    devices["mfx_dg1_yag"] = FakeYagCamera("", name="mfx_dg1_yag")
-    devices["mfx_dg2_yag"] = FakeYagCamera("", name="mfx_dg2_yag")
-    devices["xcs_yag1"] = FakeYagCamera("", name="xcs_yag1")
+    devices["mfx_dg1_yag"] = FakeYagWithCentroid("", name="mfx_dg1_yag")
+    devices["mfx_dg2_yag"] = FakeYagWithCentroid("", name="mfx_dg2_yag")
+    devices["xcs_yag1"] = FakeYagWithCentroid("", name="xcs_yag1")
     devices["mfx_ip_yag"] = FakeYagCamera("", name="mfx_ip_yag")
 
     def update_fake_dg1_yag(cam: FakeLCLSImagePlugin):

--- a/mfx/optimize/devices.py
+++ b/mfx/optimize/devices.py
@@ -120,9 +120,13 @@ class YagWithCentroid(YagCamera):
             status.wait()
             images.append(self.image1.shaped_image.get())
 
-        centroid = ImageProjectionFit().fit_image(np.mean(images, axis=0)).centroid
-        self.centroid_x.set(centroid[0])
-        self.centroid_y.set(centroid[1])
+        try:
+            centroid = ImageProjectionFit().fit_image(np.mean(images, axis=0)).centroid
+            self.centroid_x.set(centroid[0])
+            self.centroid_y.set(centroid[1])
+        except Exception:
+            self.centroid_x.set(float("nan"))
+            self.centroid_y.set(float("nan"))
 
         done = Status()
         done.set_finished()

--- a/mfx/optimize/devices.py
+++ b/mfx/optimize/devices.py
@@ -227,3 +227,12 @@ class FakeYagCamera(YagCamera):
 
     image1 = Cpt(FakeLCLSImagePlugin, "IMAGE1:")
     coords = Cpt(FakeCoords, "")
+
+
+class FakeYagWithCentroid(YagWithCentroid):
+    """
+    Fake YagWithCentroid for testing — no EPICS connections.
+    """
+
+    image1 = Cpt(FakeLCLSImagePlugin, "IMAGE1:")
+    coords = Cpt(FakeCoords, "")

--- a/mfx/optimize/devices.py
+++ b/mfx/optimize/devices.py
@@ -11,6 +11,8 @@ from ophyd.areadetector.plugins import ImagePlugin
 from ophyd.device import Component as Cpt
 from ophyd.device import Device
 from ophyd.signal import AttributeSignal, EpicsSignalRO, Signal
+from ophyd.status import Status
+from lcls_tools.common.image.fit import ImageProjectionFit
 
 
 class Marker(Device):
@@ -106,6 +108,25 @@ class YagCamera(Device):
     image1 = Cpt(LCLSImagePlugin, "IMAGE1:")
     coords = Cpt(CamViewerCoords, "")
 
+class YagWithCentroid(YagCamera):
+    centroid_x = Cpt(Signal, value=0.0, kind="hinted")
+    centroid_y = Cpt(Signal, value=0.0, kind="hinted")
+    num_frames = 10
+
+    def trigger(self):
+        images = []
+        for _ in range(self.num_frames):
+            status = super().trigger()
+            status.wait()
+            images.append(self.image1.shaped_image.get())
+
+        centroid = ImageProjectionFit().fit_image(np.mean(images, axis=0)).centroid
+        self.centroid_x.set(centroid[0])
+        self.centroid_y.set(centroid[1])
+
+        done = Status()
+        done.set_finished()
+        return done
 
 class FakeMarker(Marker):
     """

--- a/mfx/optimize/mirror_pointing.py
+++ b/mfx/optimize/mirror_pointing.py
@@ -69,8 +69,7 @@ def optimize_mirror_pointing(instrument="mfx", diagnostic="MFX:GIGE:DG1:YAG:", w
 
     start = nominal - window
     stop = nominal + window
-    RE(bp.scan([yag], mirror, start, stop, num_points), [lfp_x, lfp_y])
-
+    RE(bp.scan([yag], mirror, start, stop, num_points, stage=False), [lfp_x, lfp_y])
     solution_x = (goal_x - lf_x.result.params["intercept"].value) / lf_x.result.params["slope"].value
     solution_y = (goal_y - lf_y.result.params["intercept"].value) / lf_y.result.params["slope"].value
 

--- a/mfx/optimize/mirror_pointing.py
+++ b/mfx/optimize/mirror_pointing.py
@@ -49,9 +49,15 @@ def optimize_mirror_pointing(instrument="mfx", diagnostic="MFX:GIGE:DG1:YAG:", w
     yag.image1.kind = "omitted"
     yag.num_frames = num_frames
 
+    # we don't have put permissions to enable callbacks, clearing the signals avoids this error
+    if instrument == "mec":
+        yag.image1.configuration_attrs = []
+        yag.image1.stage_sigs.clear()
+
     pv = "MR1L4:PITCH:MFX:Coating1" if instrument == "mfx" else "MR1L4:PITCH:MEC:Coating1"
     nominal = caget(pv)
 
+    # mec's markers are not global and can't be read from mfx, we're using marker positions from a recent ecperiment
     if instrument == "mec":
         goal = mec_goal
     else:

--- a/mfx/optimize/mirror_pointing.py
+++ b/mfx/optimize/mirror_pointing.py
@@ -4,9 +4,52 @@ from bluesky.callbacks import LiveFit, LiveFitPlot
 from lmfit.models import LinearModel
 import bluesky.plans as bp
 import bluesky.plan_stubs as bps
+from epics import caget
+
+from mfx.optimize.devices import YagWithCentroid
+from mfx.optimize.beamline_hw import init_devices
 
 
-def optimize_mirror_pointing(mirror, yag, nominal, goal, window_size=5.0, num_points=10):
+def optimize_mirror_pointing(instrument="mfx", diagnostic="MFX:GIGE:DG1:YAG:", window=5.0, num_frames=10, num_points=10, sim=False):
+    """
+    Scan the MR1L4 mirror pitch and fit beam centroid to find the optimal position.
+
+    Parameters
+    ----------
+    instrument : str
+        Instrument name, "mfx" or "mec".
+    diagnostic : str
+        PV prefix for the YAG camera.
+        MFX: "MFX:GIGE:DG1:YAG:" or "MFX:GIGE:DG2:YAG:"
+        MEC: "MEC:GIGE:13:" (MEC_YAG3), "MEC:GIGE:14:" (MEC_YAG1), or "MEC:GIGE:44:" (MEC_YAG2)
+    window : float
+        Half-width of the scan range around the nominal position, in urad.
+    num_frames : int
+        Number of frames to average per centroid measurement.
+    num_points : int
+        Number of scan points across the window.
+    sim : bool
+        If True, use a simulated mirror instead of real hardware.
+
+    Returns
+    -------
+    float
+        The mirror pitch position the mirror was moved to.
+    """
+    if sim:
+        from mfx.optimize.beamline_hw import sim_devices
+        mirror = sim_devices()["mr1l4_homs"].pitch
+    else:
+        devices = init_devices(force=True)
+        mirror = devices["mr1l4_homs"].pitch
+
+    yag = YagWithCentroid(diagnostic, num_frames=num_frames, name=f"{instrument}_yag")
+    yag.image1.kind = "omitted"
+
+    pv = "MR1L4:PITCH:MFX:Coating1" if instrument == "mfx" else "MR1L4:PITCH:MEC:Coating1"
+    nominal = caget(pv)
+    goal = yag.coords.standard_two_corners_target()
+
     RE = RunEngine({})
     RE.subscribe(BestEffortCallback())
 
@@ -17,8 +60,8 @@ def optimize_mirror_pointing(mirror, yag, nominal, goal, window_size=5.0, num_po
     lfp_x = LiveFitPlot(lf_x, color="r")
     lfp_y = LiveFitPlot(lf_y, color="b")
 
-    start = nominal - window_size
-    stop = nominal + window_size
+    start = nominal - window
+    stop = nominal + window
     RE(bp.scan([yag], mirror, start, stop, num_points), [lfp_x, lfp_y])
 
     solution_x = (goal_x - lf_x.result.params["intercept"].value) / lf_x.result.params["slope"].value
@@ -34,30 +77,3 @@ def optimize_mirror_pointing(mirror, yag, nominal, goal, window_size=5.0, num_po
     RE(bps.mv(mirror, solution))
     print(f"Moved mirror to {solution:.3f}")
     return solution
-
-
-if __name__ == "__main__":
-    import argparse
-    from epics import caget
-    from mfx.optimize.devices import YagWithCentroid
-    from mfx.optimize.beamline_hw import init_devices
-
-    parser = argparse.ArgumentParser(description="Mirror pointing optimization")
-    parser.add_argument("--instrument", "-i", choices=["mfx", "mec"], default="mfx")
-    parser.add_argument("--diagnostic", "-d", type=str, required=True)
-    parser.add_argument("--window", "-w", type=float, default=5.0)
-    parser.add_argument("--num-frames", "-n", type=int, default=10)
-    parser.add_argument("--num-points", "-p", type=int, default=10)
-    args = parser.parse_args()
-
-    devices = init_devices()
-    mirror = devices["mr1l4_homs"].pitch
-
-    yag = YagWithCentroid(args.diagnostic, num_frames=args.num_frames, name=f"{args.instrument}_yag")
-    yag.image1.kind = "omitted"
-
-    pv = "MR1L4:PITCH:MFX:Coating1" if args.instrument == "mfx" else "MR1L4:PITCH:MEC:Coating1"
-    nominal = caget(pv)
-    goal = yag.coords.standard_two_corners_target()
-
-    optimize_mirror_pointing(mirror, yag, nominal, goal, args.window, args.num_points)

--- a/mfx/optimize/mirror_pointing.py
+++ b/mfx/optimize/mirror_pointing.py
@@ -10,7 +10,7 @@ from mfx.optimize.devices import YagWithCentroid
 from mfx.optimize.beamline_hw import init_devices
 
 
-def optimize_mirror_pointing(instrument="mfx", diagnostic="MFX:GIGE:DG1:YAG:", window=5.0, num_frames=10, num_points=10, sim=False):
+def optimize_mirror_pointing(instrument="mfx", diagnostic="MFX:GIGE:DG1:YAG:", window=5.0, num_frames=10, num_points=10, sim=False, mec_goal=(296, 228)):
     """
     Scan the MR1L4 mirror pitch and fit beam centroid to find the optimal position.
 
@@ -30,6 +30,8 @@ def optimize_mirror_pointing(instrument="mfx", diagnostic="MFX:GIGE:DG1:YAG:", w
         Number of scan points across the window.
     sim : bool
         If True, use a simulated mirror instead of real hardware.
+    mec_goal : tuple[int, int]
+        Hardcoded centroid goal (x, y) to use when instrument == "mec".
 
     Returns
     -------
@@ -49,7 +51,11 @@ def optimize_mirror_pointing(instrument="mfx", diagnostic="MFX:GIGE:DG1:YAG:", w
 
     pv = "MR1L4:PITCH:MFX:Coating1" if instrument == "mfx" else "MR1L4:PITCH:MEC:Coating1"
     nominal = caget(pv)
-    goal = yag.coords.standard_two_corners_target()
+
+    if instrument == "mec":
+        goal = mec_goal
+    else:
+        goal = yag.coords.standard_two_corners_target()
 
     RE = RunEngine({})
     RE.subscribe(BestEffortCallback())

--- a/mfx/optimize/mirror_pointing.py
+++ b/mfx/optimize/mirror_pointing.py
@@ -69,7 +69,7 @@ def optimize_mirror_pointing(instrument="mfx", diagnostic="MFX:GIGE:DG1:YAG:", w
 
     start = nominal - window
     stop = nominal + window
-    RE(bp.scan([yag], mirror, start, stop, num_points, stage=False), [lfp_x, lfp_y])
+    RE(bp.scan([yag], mirror, start, stop, num_points), [lfp_x, lfp_y])
     solution_x = (goal_x - lf_x.result.params["intercept"].value) / lf_x.result.params["slope"].value
     solution_y = (goal_y - lf_y.result.params["intercept"].value) / lf_y.result.params["slope"].value
 

--- a/mfx/optimize/mirror_pointing.py
+++ b/mfx/optimize/mirror_pointing.py
@@ -1,182 +1,61 @@
-from mfx.optimize.devices import YagCamera
-from mfx.optimize.beamline_hw import init_devices
-from lcls_tools.common.image.fit import ImageProjectionFit
-
-import numpy as np, matplotlib.pyplot as plt
-from epics import caget
-import argparse
-import time
-
-def get_yag_centroid(prefix, name, num_frames=10, timeout=10):
-    camera = YagCamera(prefix, name=name)
-    image_dev = camera.image1.shaped_image
-
-    images = []
-    for i in range(num_frames):
-        image_dev.trigger().wait(timeout=timeout)
-        image = image_dev.get()
-        images.append(image)
-    
-    averaged_image = np.mean(images, axis=0)
-
-    fitter = ImageProjectionFit()
-    result = fitter.fit_image(averaged_image)
-
-    return result.centroid
+from bluesky import RunEngine
+from bluesky.callbacks.best_effort import BestEffortCallback
+from bluesky.callbacks import LiveFit
+from lmfit.models import LinearModel
+import bluesky.plans as bp
+import bluesky.plan_stubs as bps
 
 
-def optimize_mirror_pointing(
-    instrument: str,
-    diagnostic_pvname: str,
-    window_size: float = 5.0,
-    num_frames: int = 10,
-    num_points: int = 10,
-):
-    """
-    Simple mirror pointing optimization.
-    
-    Parameters
-    ----------
-    instrument : str
-        "mfx" or "mec"
-    diagnostic_pvname : str
-        PV prefix for YAG camera (e.g., "MFX:GIGE:DG1:YAG:" or "MEC:GIGE:13:")
-    window_size : float
-        Window size around nominal position, default 5.0
-    num_frames : int
-        Number of frames to average, default 10
-    num_points : int
-        Number of points in scan, default 10
-    """
-    # Get nominal position
-    if instrument.lower() == "mfx":
-        pv_name = "MR1L4:PITCH:MFX:Coating1"
-    else:  # MEC
-        pv_name = "MR1L4:PITCH:MEC:Coating1"
-    nominal_position = caget(pv_name)
-    print(f"Nominal position: {nominal_position}")
-    
-    # Create mirror positions
-    mirror_bounds = [nominal_position - window_size, nominal_position + window_size]
-    mirror_positions = np.linspace(mirror_bounds[0], mirror_bounds[1], num_points)
-    
-    # Initialize devices
-    devices = init_devices()
-    mirror_device = devices["mr1l4_homs"]
-    
-    # Get YAG camera and goal
-    yag_camera = YagCamera(diagnostic_pvname, name=f"{instrument}_yag")
-    goal_x, goal_y = yag_camera.coords.standard_two_corners_target()
-    print(f"Goal position: ({goal_x}, {goal_y})")
-    
-    # Scan mirror positions and collect centroids
-    centroids_x = []
-    centroids_y = []
-    
-    for pos in mirror_positions:
-        print(f"Moving mirror to {pos}")
-        mirror_device.pitch.mv(pos)
-        time.sleep(2)  # Wait for motion to settle
-        
-        centroid = get_yag_centroid(
-            prefix=diagnostic_pvname,
-            name=f"{instrument}_yag",
-            num_frames=num_frames,
-        )
-        centroids_x.append(centroid[0])
-        centroids_y.append(centroid[1])
-        print(f"  Centroid: ({centroid[0]:.2f}, {centroid[1]:.2f})")
-    
-    # Fit lines
-    slope_x, intercept_x = np.polyfit(mirror_positions, centroids_x, 1)
-    slope_y, intercept_y = np.polyfit(mirror_positions, centroids_y, 1)
-    
-    # Solve for mirror position
-    mirror_solution_x = (goal_x - intercept_x) / slope_x
-    mirror_solution_y = (goal_y - intercept_y) / slope_y
-    
-    # Use the one with better fit (or average)
-    r2x = 1 - np.sum((centroids_x - (slope_x * mirror_positions + intercept_x))**2) / np.sum((centroids_x - np.mean(centroids_x))**2)
-    r2y = 1 - np.sum((centroids_y - (slope_y * mirror_positions + intercept_y))**2) / np.sum((centroids_y - np.mean(centroids_y))**2)
-    
-    print(f"R^2 x: {r2x:.3f}, R^2 y: {r2y:.3f}")
-    
-    if r2x >= r2y:
-        mirror_solution = mirror_solution_x
-        print(f"Using x fit (better R^2)")
+def optimize_mirror_pointing(mirror, yag, nominal, goal, window_size=5.0, num_points=10):
+    RE = RunEngine({})
+    RE.subscribe(BestEffortCallback())
+
+    goal_x, goal_y = goal
+
+    lf_x = LiveFit(LinearModel(), f"{yag.name}_centroid_x", {"x": mirror.name})
+    lf_y = LiveFit(LinearModel(), f"{yag.name}_centroid_y", {"x": mirror.name})
+
+    start = nominal - window_size
+    stop = nominal + window_size
+    RE(bp.scan([yag], mirror, start, stop, num_points), [lf_x, lf_y])
+
+    solution_x = (goal_x - lf_x.result.params["intercept"].value) / lf_x.result.params["slope"].value
+    solution_y = (goal_y - lf_y.result.params["intercept"].value) / lf_y.result.params["slope"].value
+
+    if abs(lf_x.result.params["slope"].value) >= abs(lf_y.result.params["slope"].value):
+        solution = solution_x
+        print(f"Using x fit, solution={solution:.3f}")
     else:
-        mirror_solution = mirror_solution_y
-        print(f"Using y fit (better R^2)")
-    
-    print(f"Mirror solution: {mirror_solution:.3f}")
-    
-    # Move to solution
-    print(f"Moving mirror to solution: {mirror_solution}")
-    mirror_device.pitch.mv(mirror_solution)
-    
-    # Plot results
-    plt.figure()
-    plt.plot(mirror_positions, centroids_x, 'o-', label='centroid_x')
-    plt.axvline(mirror_solution, color='r', linestyle='--', label='solution')
-    plt.axhline(goal_x, color='g', linestyle='--', label='goal_x')
-    plt.xlabel("mirror_position")
-    plt.ylabel("centroid_x")
-    plt.legend()
-    plt.show(block=False)
-    
-    plt.figure()
-    plt.plot(mirror_positions, centroids_y, 'o-', label='centroid_y')
-    plt.axvline(mirror_solution, color='r', linestyle='--', label='solution')
-    plt.axhline(goal_y, color='g', linestyle='--', label='goal_y')
-    plt.xlabel("mirror_position")
-    plt.ylabel("centroid_y")
-    plt.legend()
-    plt.show(block=False)
-    
-    return mirror_solution
+        solution = solution_y
+        print(f"Using y fit, solution={solution:.3f}")
 
+    RE(bps.mv(mirror, solution))
+    print(f"Moved mirror to {solution:.3f}")
+    return solution
 
-def main():
-    parser = argparse.ArgumentParser(description="Mirror pointing optimization script")
-    parser.add_argument(
-        "--instrument", "-i",
-        choices=["mfx", "mec"],
-        default="mfx",
-        help="Instrument name (default: mfx)"
-    )
-    parser.add_argument(
-        "--diagnostic", "-d",
-        type=str,
-        required=True,
-        help="Diagnostic PV prefix (e.g., MFX:GIGE:DG1:YAG: or MEC:GIGE:13:)"
-    )
-    parser.add_argument(
-        "--window", "-w",
-        type=float,
-        default=5.0,
-        help="Window size around nominal position (default: 5.0)"
-    )
-    parser.add_argument(
-        "--num-frames", "-n",
-        type=int,
-        default=10,
-        help="Number of frames to average (default: 10)"
-    )
-    parser.add_argument(
-        "--num-points", "-p",
-        type=int,
-        default=10,
-        help="Number of points in scan (default: 10)"
-    )
-    args = parser.parse_args()
-    
-    optimize_mirror_pointing(
-        instrument=args.instrument,
-        diagnostic_pvname=args.diagnostic,
-        window_size=args.window,
-        num_frames=args.num_frames,
-        num_points=args.num_points,
-    ) 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+    from epics import caget
+    from mfx.optimize.devices import YagWithCentroid
+    from mfx.optimize.beamline_hw import init_devices
+
+    parser = argparse.ArgumentParser(description="Mirror pointing optimization")
+    parser.add_argument("--instrument", "-i", choices=["mfx", "mec"], default="mfx")
+    parser.add_argument("--diagnostic", "-d", type=str, required=True)
+    parser.add_argument("--window", "-w", type=float, default=5.0)
+    parser.add_argument("--num-frames", "-n", type=int, default=10)
+    parser.add_argument("--num-points", "-p", type=int, default=10)
+    args = parser.parse_args()
+
+    devices = init_devices()
+    mirror = devices["mr1l4_homs"].pitch
+
+    yag = YagWithCentroid(args.diagnostic, num_frames=args.num_frames, name=f"{args.instrument}_yag")
+    yag.image1.kind = "omitted"
+
+    pv = "MR1L4:PITCH:MFX:Coating1" if args.instrument == "mfx" else "MR1L4:PITCH:MEC:Coating1"
+    nominal = caget(pv)
+    goal = yag.coords.standard_two_corners_target()
+
+    optimize_mirror_pointing(mirror, yag, nominal, goal, args.window, args.num_points)

--- a/mfx/optimize/mirror_pointing.py
+++ b/mfx/optimize/mirror_pointing.py
@@ -43,8 +43,9 @@ def optimize_mirror_pointing(instrument="mfx", diagnostic="MFX:GIGE:DG1:YAG:", w
         devices = init_devices(force=True)
         mirror = devices["mr1l4_homs"].pitch
 
-    yag = YagWithCentroid(diagnostic, num_frames=num_frames, name=f"{instrument}_yag")
+    yag = YagWithCentroid(diagnostic, name=f"{instrument}_yag")
     yag.image1.kind = "omitted"
+    yag.num_frames = num_frames
 
     pv = "MR1L4:PITCH:MFX:Coating1" if instrument == "mfx" else "MR1L4:PITCH:MEC:Coating1"
     nominal = caget(pv)

--- a/mfx/optimize/mirror_pointing.py
+++ b/mfx/optimize/mirror_pointing.py
@@ -1,6 +1,6 @@
 from bluesky import RunEngine
 from bluesky.callbacks.best_effort import BestEffortCallback
-from bluesky.callbacks import LiveFit
+from bluesky.callbacks import LiveFit, LiveFitPlot
 from lmfit.models import LinearModel
 import bluesky.plans as bp
 import bluesky.plan_stubs as bps
@@ -14,10 +14,12 @@ def optimize_mirror_pointing(mirror, yag, nominal, goal, window_size=5.0, num_po
 
     lf_x = LiveFit(LinearModel(), f"{yag.name}_centroid_x", {"x": mirror.name})
     lf_y = LiveFit(LinearModel(), f"{yag.name}_centroid_y", {"x": mirror.name})
+    lfp_x = LiveFitPlot(lf_x, color="r")
+    lfp_y = LiveFitPlot(lf_y, color="b")
 
     start = nominal - window_size
     stop = nominal + window_size
-    RE(bp.scan([yag], mirror, start, stop, num_points), [lf_x, lf_y])
+    RE(bp.scan([yag], mirror, start, stop, num_points), [lfp_x, lfp_y])
 
     solution_x = (goal_x - lf_x.result.params["intercept"].value) / lf_x.result.params["slope"].value
     solution_y = (goal_y - lf_y.result.params["intercept"].value) / lf_y.result.params["slope"].value

--- a/mfx/optimize/mirror_pointing.py
+++ b/mfx/optimize/mirror_pointing.py
@@ -54,7 +54,7 @@ def optimize_mirror_pointing(instrument="mfx", diagnostic="MFX:GIGE:DG1:YAG:", w
         yag.image1.configuration_attrs = []
         yag.image1.stage_sigs.clear()
 
-    pv = "MR1L4:PITCH:MFX:Coating1" if instrument == "mfx" else "MR1L4:PITCH:MEC:Coating1"
+    pv = "MR1L4:PITCH:MFX:Coating1" if instrument == "mfx" else "MR1L4:PITCH:MEC:Coating2"
     nominal = caget(pv)
 
     # mec's markers are not global and can't be read from mfx, we're using marker positions from a recent ecperiment


### PR DESCRIPTION
We reimplemented the multiplexing workflow using Bluesky and validated it in simulation. The original implementation is described in #276.

```python

In [1]: from mfx.optimize.mirror_pointing import optimize_mirror_pointing

In [2]: optimize_mirror_pointing(instrument="mfx", diagnostic="MFX:GIGE:DG1:YAG:
   ...: ", window=5.0, num_frames=10, num_points=10, sim=True)
[INTENSITY] vernier=7000.0, dccm=6999.7, offset=0.3, intensity_calc=998.5
Generated fake dg1 and dg2 signals and images
Expected: 1:1 linear relationship between x and pitch


Transient Scan ID: 1     Time: 2026-02-16 18:13:32
Persistent Unique Scan ID: 'f2377acb-41d4-4d7e-8bcd-68c116a4a25d'
New stream: 'primary'
+-----------+------------+------------------+--------------------+--------------------+
|   seq_num |       time | mr1l4_homs_pitch | mfx_yag_centroid_x | mfx_yag_centroid_y |
+-----------+------------+------------------+--------------------+--------------------+
|         1 | 18:13:34.3 |             -563 |                280 |                254 |
|         2 | 18:13:34.7 |             -562 |                298 |                272 |
|         3 | 18:13:35.7 |             -561 |                278 |                242 |
|         4 | 18:13:36.3 |             -560 |                285 |                311 |
|         5 | 18:13:37.1 |             -559 |                296 |                283 |
|         6 | 18:13:38.4 |             -558 |                316 |                298 |
|         7 | 18:13:39.2 |             -557 |                293 |                253 |
|         8 | 18:13:40.1 |             -555 |                312 |                213 |
|         9 | 18:13:40.6 |             -554 |                307 |                317 |
|        10 | 18:13:41.7 |             -553 |                291 |                234 |
+-----------+------------+------------------+--------------------+--------------------+
generator scan ['f2377acb'] (scan num: 1)



Using x fit, solution=-595.173
Moved mirror to -595.173
Out[2]: -595.1731920104847

```

<img width="1013" height="881" alt="Screenshot 2026-02-16 at 18 19 25" src="https://github.com/user-attachments/assets/7964e545-167b-49fc-97c9-71adec20e46a" />


 