### PR TITLE
281 dev timing code

### DIFF
--- a/mfx/beamline.py
+++ b/mfx/beamline.py
@@ -332,6 +332,10 @@ def mfx_reload(module_name):
         from mfx.xrt_spec import XRTspec
         xrtspec = XRTspec()
 
+    if module_name == 'mfx.timing':
+        from mfx.timing import Timing
+        timing = Timing()
+
 #aliases added by Leland 071523
 with safe_load('Make Aliases'):
     from mfx.db import mfx_attenuator as att

--- a/mfx/beamline.py
+++ b/mfx/beamline.py
@@ -183,6 +183,10 @@ with safe_load('EXAFS_Builder'):
 with safe_load('energy_control'):
     from mfx.energy_control import *
 
+with safe_load('Timing'):
+    from mfx.timing import *
+    timing = Timing()
+
 with safe_load("laser wp power"):
     from pcdsdevices.lxe import LaserEnergyPositioner
     from hutch_python.utils import get_current_experiment
@@ -262,8 +266,10 @@ with safe_load('add laser motor groups'):
             focus_track = Newport('MFX:HRA:MMN:31', name='focus_track')
 
         with safe_load('Fast delay encoders'):
-            lxt_fast1_enc = UsDigitalUsbEncoder('MFX:USDUSB4:01:CH2', name='lxt_fast_enc1', linked_axis=mfx_lxt_fast1)
-            lxt_fast2_enc = UsDigitalUsbEncoder('MFX:USDUSB4:01:CH1', name='lxt_fast_enc2', linked_axis=mfx_lxt_fast2)
+            lxt_fast1_enc = UsDigitalUsbEncoder(
+                'MFX:USDUSB4:01:CH2', name='lxt_fast_enc1', linked_axis=mfx_lxt_fast1)
+            lxt_fast2_enc = UsDigitalUsbEncoder(
+                'MFX:USDUSB4:01:CH1', name='lxt_fast_enc2', linked_axis=mfx_lxt_fast2)
 
     # timing virtual motors for x-ray laser delay adjustment
     lxt = lxt # virtual motor that moves the laser timing system phase shifter

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -188,13 +188,14 @@ class Timing:
 
         pp.close()
         post(
-            sample=sample,
+            sample=pv,
             tag=tag,
             run_number=run_number,
             post=record,
             inspire=inspire,
             daq_num=daq_num,
             add_note=(
+                f'Scaning {pv}, '
                 f'Time range:{start}-{end}s, '
                 f'steps:{steps} @ {events_per_step} events per step'
                 ))

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -62,7 +62,7 @@ class Timing:
 
         self.lxt_ttc = LXTTTC('', name='lxt_ttc')
 
-    def clustered_points(self,y, z, n, power=2.0, center=None, plot=False):
+    def clustered_points(self, y, z, n, power=2.0, center=None, plot=False):
         """
         n points in [y, z], spaced denser near `center`.
         power > 1 increases clustering strength.
@@ -77,20 +77,16 @@ class Timing:
         if not (y <= c <= z):
             raise ValueError("center must be within [y, z]")
 
-        # map [y,z] -> [-1,1] with 0 at the desired center
+        # Create symmetric parameter space around center
         left = c - y
         right = z - c
-        scale = max(left, right) if max(left, right) > 0 else 1.0
 
-        a = -left / scale
-        b =  right / scale
+        # Generate points in [-1, 1] parameter space
+        t = np.linspace(-1.0, 1.0, n)
+        u = np.sign(t) * (np.abs(t) ** power)
 
-        t = np.linspace(a, b, n)                 # uniform in parameter space
-        u = np.sign(t) * (np.abs(t) ** power)    # compress toward 0 => denser near center
-        x = c + scale * u
-
-        # keep within bounds (handles asymmetric ranges cleanly)
-        x = np.clip(x, y, z)
+        # Map to [y, z] with asymmetric scaling
+        x = np.where(u < 0, c + left * u, c + right * u)
 
         if plot:
             xs = np.sort(x)

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -1,0 +1,320 @@
+"""Vernier energy control and calibration utilities for MFX beamline."""
+import os
+import sys
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Timing:
+    """
+
+    Attributes
+    ----------
+
+    Methods
+    -------
+
+    Notes
+    -----
+
+    Examples
+    --------
+
+    See Also
+    --------
+
+    """
+
+    def __init__(self):
+        """
+        Initialize Timing control system.
+        """
+        from pcdsdevices.device import ObjectComponent as OCpt
+        from pcdsdevices.pseudopos import SyncAxis
+        from pcdsdevices.usb_encoder import UsDigitalUsbEncoder
+        from mfx.db import mfx_txt
+        from mfx.db import mfx_lxt_fast1, mfx_lxt_fast2
+
+        self.lxt = LaserTiming('LAS:FS45', name='lxt')
+        self.txt = mfx_txt
+        self.lxt_fast1 = mfx_lxt_fast1
+        self.lxt_fast2 = mfx_lxt_fast2
+
+        self.lxt_fast1_enc = UsDigitalUsbEncoder(
+            'MFX:USDUSB4:01:CH2', name='lxt_fast_enc1', linked_axis=self.mfx_lxt_fast1)
+        self.lxt_fast2_enc = UsDigitalUsbEncoder(
+            'MFX:USDUSB4:01:CH1', name='lxt_fast_enc2', linked_axis=self.mfx_lxt_fast2)
+
+        class LXTTTC(SyncAxis):
+            lxt = OCpt(self.lxt)
+            txt = OCpt(self.txt)
+
+            tab_component_names = True
+            scales = {'txt': -1}
+            warn_deadband = 5e-14
+            fix_sync_keep_still = 'lxt'
+            sync_limits = (-10e-6, 10e-6)
+
+        self.lxt_ttc = LXTTTC('', name='lxt_ttc')
+
+    def scan(
+            self,
+            start: float,
+            end: float,
+            steps: int,
+            events_per_step: int = 240,
+            sample: str = '?',
+            tag: str = 'timing',
+            picker: str = None,
+            inspire: bool = False,
+            record: bool = True,
+            daq_num: int = 2,
+            pv: str = None):
+        """Perform Timing scan.
+
+        Parameters:
+            start (float):
+                Time Point (in s) to start the scan at.
+
+            end (float):
+                Time Point (in s) to end the scan at.
+
+            steps (int):
+                Number of steps in scan.
+
+            events_per_step (int):
+                Number of events per step. Optional. Default: 240.
+
+            sample: str, optional
+                Sample Name
+
+            tag: str, optional
+                Run group tag
+
+            picker: str, optional
+                If 'open' it opens pp before run starts. If 'flip' it flipflops before run starts
+
+            inspire: bool, optional
+                Set false by default because it makes Sandra sad. Set True to inspire
+
+            record (bool):
+                whether to record the scan or not. Optional. Default: False.
+
+            daq_num: int, optional
+                Switch between daq 1 and 2. Default 2
+
+            pv (str):
+                PV type Please enter lxt, txt, lxt_ttc, lxt_fast1, or lxt_fast2
+
+        """
+        from ophyd import EpicsSignal
+        from pcdsdevices.pv_positioner import OnePVMotor
+        try:
+            from mfx.db import RE, pp, daq
+            from mfx.autorun import quote, post
+            from mfx.macros import get_exp, get_run
+            import bluesky.plans as bp
+        except ImportError:
+            from bluesky import RunEngine
+            RE = RunEngine({})
+        from nabs.plans import daq_scan
+
+        if pv.lower() == 'lxt':
+            pv = self.lxt
+        elif pv.lower() == 'txt':
+            pv = self.txt
+        elif pv.lower() == 'lxt_ttc':
+            pv = self.lxt_ttc
+        elif pv.lower() == 'lxt_fast1':
+            pv = self.lxt_fast1
+        elif pv.lower() == 'lxt_fast2':
+            pv = self.lxt_fast2
+        else:
+            logger.error('Please enter lxt, txt, lxt_ttc, lxt_fast1, or lxt_fast2')
+            sys.exit()
+
+        if picker=='open':
+            pp.open()
+        if picker=='flip':
+            pp.flipflop()
+
+        if tag is None:
+            tag = sample
+
+        if daq_num == 1:
+            station = 1
+        elif daq_num == 2:
+            station = 0
+        else:
+            logger.error('Please enter daq 1 or 2.')
+
+        if pv == self.lxt_ttc or pv == self.lxt_fast1 or pv == self.lxt_fast2:
+            original_time = pv.get()[0][0]
+        else:
+            original_time = pv.get()[0]
+
+        run_number = get_run(station=station) + 1
+        logger.info(f"Run Number {run_number} Running {sample}......{quote()['quote']}")
+
+        if daq_num == 1:
+            pv_motor = EpicsSignal(pv, name='pv')
+            RE(
+                daq_scan(
+                    [],
+                    pv_motor,
+                    start,
+                    end,
+                    steps,
+                    events=events_per_step,
+                    record=record))
+            daq.disconnect()
+
+        elif daq_num == 2:
+            pv_motor = OnePVMotor(pv, name="pv")
+            pv_motor.setpoint.kind = "hinted"
+            daq.configure(
+                motors=[pv_motor],
+                group_mask=0x1,
+                events=events_per_step,
+                record=record)
+
+            RE(bp.scan(
+                [daq],
+                pv_motor,
+                start,
+                end,
+                steps))
+
+        else:
+            logger.error('Please enter daq 1 or 2.')
+
+        pp.close()
+        post(
+            sample=sample,
+            tag=tag,
+            run_number=run_number,
+            post=record,
+            inspire=inspire,
+            daq_num=daq_num,
+            add_note=(
+                f'Time range:{start}-{end}s, '
+                f'steps:{steps} @ {events_per_step} events per step'
+                ))
+
+        logger.warning('Finished with all runs thank you for choosing the MFX beamline!\n')
+
+        exp = str(get_exp())
+        logger.warning(
+                f"timing.output(user='user', facility='s3df', run_type='scan', "
+                f"exp='{exp}', run={run_number}")
+
+        logger.info(f'Setting {pv} back to original time: {original_time}')
+        pv(original_time)
+
+        logger.warning(f"Scan completed. Would you like to analyze the output?")
+        answer = input("(y/n)? ")
+
+        if answer.lower() == "y":
+            facility = input("Enter facility (s3df or nersc) to continue: ")
+            user = input("Enter username to continue: ")
+            self.output(
+                user=user,
+                facility=facility,
+                exp=exp,
+                run=run_number)
+
+
+    def output(
+        self,
+        user: str,
+        facility: str = 'S3DF',
+        exp: str = None,
+        run: str = None,
+        energy: float = None,
+        step: float = None,
+        num: int = None,
+        daq_num: int = 2):
+        """
+        Analysis and output for notch scan data.
+
+        Provides methods to analyze energy calibration data and
+        generate plots on computing facilities.
+
+        Methods
+        -------
+        series(user, facility, exp, run, energy, step, num)
+            Analyze energy scan series data
+
+        Notes
+        -----
+        Analysis Process:
+        1. Retrieve data from DAQ files
+        2. Extract detector intensities vs. energy
+        3. Identify absorption edge
+        4. Compare to reference energy
+        5. Calculate energy offset
+        6. Generate calibration plots
+
+        Output Products:
+        - Energy vs. intensity plots
+        - Edge position determination
+        - Calibration offset value
+        - Statistical uncertainties
+
+        Computing Facilities:
+        - S3DF: Interactive analysis
+        - NERSC: Batch processing
+
+        Examples
+        --------
+        >>> output = NotchOutput()
+        >>> output.series(
+        ...     user='myuser',
+        ...     facility='S3DF',
+        ...     exp='mfxls1234',
+        ...     run=100,
+        ...     energy=7112,
+        ...     step=5,
+        ...     num=20
+        ... )
+
+        See Also
+        --------
+        NotchScan.series : Data collection
+        """
+        from mfx.macros import get_exp, get_run
+        from mfx.cctbx import cctbx
+        cctbx = cctbx()
+
+        if daq_num == 2:
+            station=0
+        elif daq_num == 1:
+            station=1
+        else:
+            logger.error('Please enter daq 1 or 2.')
+
+        logger.info("Plotting XRT-Spec Output")
+        if exp is None:
+            exp = str(get_exp(station=station))
+
+        if run is None:
+            run = int(get_run(station=station))
+
+        facility = facility.upper()
+        if facility == 'NERSC':
+            logger.warning(f"Have you renewed your token with sshproxy today?")
+            token = input("(y/n)? ")
+
+            if token.lower() == "n":
+                cctbx.sshproxy(user)
+
+        proc = [
+            f"ssh -Yt {user}@s3dflogin '"
+            f"source /sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh && "
+            f"python /sdf/group/lcls/ds/tools/mfx/scripts/cctbx/energy_calib_output.py "
+            f"-f {facility} -t series -e {exp} -r {run} -z {energy} -s {step} -n {num}'"
+            ]
+
+        logger.info(proc)
+        os.system(proc[0])

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -85,23 +85,11 @@ class Timing:
             name='shutter5'
         )
 
-    def shutter_status(self):
-        """
-        Return the status of all laser shutters.
-        """
-        status = []
-        for shutter in (self.shutter1, self.shutter2, self.shutter3, self.shutter4, self.shutter5):
-            status.append(shutter.state.get())
-            if laser is not None:
-                shutter('IN')
-
-        return status
-
     def check(self):
         """
         Check that all timing devices are responsive.
         """
-        print(f"Device {self.lxt}: {self.lxt.position}")
+        print(f"Device {self.lxt}: {self.lxt.position} s")
 
         for device in (self.txt, self.lxt_fast1, self.lxt_fast2):
             print(f"Device {device}: {device.position[0]} s")
@@ -355,28 +343,46 @@ class Timing:
             logger.error('Please enter daq 1 or 2.')
 
         pp.close()
-        status = self.shutter_status()
+        # Stop acquisition
+        logger.info("Stopping acquisition...")
+        daq.control.setState("configured")
+        while daq.control.getState() != "configured":
+            sleep(0.01)
 
-        post(
-            sample=sample,
-            tag=tag,
-            run_number=run_number,
-            post=record,
-            inspire=inspire,
-            daq_num=daq_num,
-            add_note=(
-                f'Scaning {pv}, '
-                f'Time range:{start} to {end}s, '
-                f'steps:{steps} @ {events_per_step} events per step'
-                f'shutter 1 state: {status[0]}, '
-                f'shutter 2 state: {status[1]}, '
-                f'shutter 3 state: {status[2]}, '
-                f'shutter 4 state: {status[3]}, '
-                f'shutter 5 state: {status[4]}, '
-                f'{" with clustering at center " + str(center) if cluster else ""}'
-                f'{" with randomization" if randomize else ""}'
-                f'{" with delay scan" if delay else ""}'
-                ))
+        try:
+            daq.control.setRecord(False)
+            daq.control.setState("running")
+            logger.debug("DAQ returned to running/non-recording state")
+        except Exception as e:
+            logger.warning(f"DAQ cleanup warning: {e}")
+
+        status = []
+        for shutter in (self.shutter1, self.shutter2, self.shutter3, self.shutter4, self.shutter5):
+            status.append(shutter.state.get())
+            if laser is not None:
+                shutter('IN')
+
+        if record:
+            post(
+                sample=sample,
+                tag=tag,
+                run_number=run_number,
+                post=record,
+                inspire=inspire,
+                daq_num=daq_num,
+                add_note=(
+                    f'Scaning {pv}, '
+                    f'Time range:{start} to {end}s, '
+                    f'steps:{steps} @ {events_per_step} events per step'
+                    f'shutter 1 state: {status[0]}, '
+                    f'shutter 2 state: {status[1]}, '
+                    f'shutter 3 state: {status[2]}, '
+                    f'shutter 4 state: {status[3]}, '
+                    f'shutter 5 state: {status[4]}, '
+                    f'{" with clustering at center " + str(center) if cluster else ""}'
+                    f'{" with randomization" if randomize else ""}'
+                    f'{" with delay scan" if delay else ""}'
+                    ))
 
         logger.warning('Finished with all runs thank you for choosing the MFX beamline!\n')
 

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -170,8 +170,6 @@ class Timing:
             daq.disconnect()
 
         elif daq_num == 2:
-            # pv_motor = OnePVMotor(pv, name="pv")
-            # pv_motor.setpoint.kind = "hinted"
             daq.configure(
                 motors=[pv],
                 group_mask=0x1,
@@ -205,8 +203,8 @@ class Timing:
 
         exp = str(get_exp())
         logger.warning(
-                f"timing.output(user='user', facility='s3df', run_type='scan', "
-                f"exp='{exp}', run={run_number}")
+                f"timing.output(user='user', facility='s3df', "
+                f"exp='{exp}', run={run_number}, daq_num={daq_num})")
 
         logger.info(f'Setting {pv} back to original time: {original_time}')
         pv(original_time)

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -235,9 +235,9 @@ class Timing:
         num: int = None,
         daq_num: int = 2):
         """
-        Analysis and output for notch scan data.
+        Analysis and output for timing scan data.
 
-        Provides methods to analyze energy calibration data and
+        Provides methods to analyze timing calibration data and
         generate plots on computing facilities.
 
         Methods
@@ -283,8 +283,6 @@ class Timing:
         NotchScan.series : Data collection
         """
         from mfx.macros import get_exp, get_run
-        from mfx.cctbx import cctbx
-        cctbx = cctbx()
 
         if daq_num == 2:
             station=0
@@ -310,9 +308,9 @@ class Timing:
 
         proc = [
             f"ssh -Yt {user}@s3dflogin '"
-            f"source /sdf/group/lcls/ds/ana/sw/conda1/manage/bin/psconda.sh && "
-            f"python /sdf/group/lcls/ds/tools/mfx/scripts/cctbx/energy_calib_output.py "
-            f"-f {facility} -t series -e {exp} -r {run} -z {energy} -s {step} -n {num}'"
+            f"source /sdf/group/lcls/ds/ana/sw/conda2/manage/bin/psconda.sh && "
+            f"python /sdf/group/lcls/ds/tools/mfx/scripts/analyze_timing.py "
+            f"-f {facility} -t proxy -e {exp} -r {run}'"
             ]
 
         logger.info(proc)

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -257,7 +257,7 @@ class Timing:
             if cluster:
                 points = self.clustered_toward_center(start, end, steps, power=2.0, plot=True)
             else:
-                points = list(range(start, end + 1))
+                points = list(np.linspace(start, end, steps))
 
             if randomize:
                 random.shuffle(points)

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -170,17 +170,17 @@ class Timing:
             daq.disconnect()
 
         elif daq_num == 2:
-            pv_motor = OnePVMotor(pv, name="pv")
-            pv_motor.setpoint.kind = "hinted"
+            # pv_motor = OnePVMotor(pv, name="pv")
+            # pv_motor.setpoint.kind = "hinted"
             daq.configure(
-                motors=[pv_motor],
+                motors=[pv],
                 group_mask=0x1,
                 events=events_per_step,
                 record=record)
 
             RE(bp.scan(
                 [daq],
-                pv_motor,
+                pv,
                 start,
                 end,
                 steps))
@@ -221,8 +221,8 @@ class Timing:
                 user=user,
                 facility=facility,
                 exp=exp,
-                run=run_number)
-
+                run=run_number,
+                daq_num=daq_num)
 
     def output(
         self,
@@ -230,9 +230,6 @@ class Timing:
         facility: str = 'S3DF',
         exp: str = None,
         run: str = None,
-        energy: float = None,
-        step: float = None,
-        num: int = None,
         daq_num: int = 2):
         """
         Analysis and output for timing scan data.

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -62,44 +62,56 @@ class Timing:
 
         self.lxt_ttc = LXTTTC('', name='lxt_ttc')
 
-    def clustered_toward_center(
-            self,
-            start: float,
-            end: float,
-            steps: int,
-            power: float = 2.0,
-            plot : bool = False
-            ) -> list:
+    def clustered_points(y, z, n, power=2.0, center=None, plot=False):
         """
-        n points in [y, z], spaced denser near the center.
-        power > 1 increases clustering toward center.
+        n points in [y, z], spaced denser near `center`.
+        power > 1 increases clustering strength.
+
+        center: float in [y, z]. If None, uses midpoint.
         """
-        c = (start + end) / 2.0
-        r = (end - start) / 2.0
+        y, z = float(y), float(z)
+        if y > z:
+            y, z = z, y
 
-        t = np.linspace(-1.0, 1.0, steps)          # uniform in parameter space
-        u = np.sign(t) * (np.abs(t) ** power)  # compress near 0 -> denser near center
+        c = (y + z) / 2.0 if center is None else float(center)
+        if not (y <= c <= z):
+            raise ValueError("center must be within [y, z]")
 
-        x = c + r * u
+        # map [y,z] -> [-1,1] with 0 at the desired center
+        left = c - y
+        right = z - c
+        scale = max(left, right) if max(left, right) > 0 else 1.0
+
+        a = -left / scale
+        b =  right / scale
+
+        t = np.linspace(a, b, n)                 # uniform in parameter space
+        u = np.sign(t) * (np.abs(t) ** power)    # compress toward 0 => denser near center
+        x = c + scale * u
+
+        # keep within bounds (handles asymmetric ranges cleanly)
+        x = np.clip(x, y, z)
+
         if plot:
             xs = np.sort(x)
             dx = np.diff(xs)
 
             fig, ax = plt.subplots(2, 1, figsize=(7, 4), constrained_layout=True)
 
-            # points on a line
             ax[0].plot(xs, np.zeros_like(xs), "o")
+            ax[0].axvline(c, color="r", linestyle="--", label="center")
             ax[0].set_yticks([])
-            ax[0].set_xlim(start, end)
-            ax[0].set_title("Points (denser near center)")
+            ax[0].set_xlim(y, z)
+            ax[0].set_title("Points (denser near chosen center)")
+            ax[0].legend()
 
-            # spacing between adjacent points
             ax[1].plot(dx, "-o")
             ax[1].set_title("Adjacent spacing (sorted)")
             ax[1].set_xlabel("Interval index")
             ax[1].set_ylabel("Δx")
 
             plt.show()
+
         return x.tolist()
 
     def scan(

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -127,6 +127,7 @@ class Timing:
             record: bool = True,
             daq_num: int = 2,
             pv: str = None,
+            analysis: bool = True,
             randomize: bool = False,
             cluster: bool = False,
             center: float = None,
@@ -169,6 +170,9 @@ class Timing:
 
             pv (str):
                 PV type Please enter lxt, txt, lxt_ttc, lxt_fast1, or lxt_fast2
+
+            analysis (bool):
+                Whether to perform analysis and output after the scan. Default: True.
 
             randomize (bool):
                 Whether to randomize the order of the scan points. Default: False.
@@ -259,7 +263,8 @@ class Timing:
                 record=record)
 
             if cluster:
-                points = self.clustered_points(start, end, steps, power=2.0, plot=True)
+                points = self.clustered_points(
+                    start, end, steps, power=2.0, center=center,plot=True)
             else:
                 points = list(np.linspace(start, end, steps))
 
@@ -296,6 +301,9 @@ class Timing:
                 f'Scaning {pv}, '
                 f'Time range:{start}-{end}s, '
                 f'steps:{steps} @ {events_per_step} events per step'
+                f'{" with clustering at center " + str(center) if cluster else ""}'
+                f'{" with randomization" if randomize else ""}'
+                f'{" with delay scan" if delay else ""}'
                 ))
 
         logger.warning('Finished with all runs thank you for choosing the MFX beamline!\n')
@@ -308,18 +316,19 @@ class Timing:
         logger.info(f'Setting {pv} back to original time: {original_time}')
         pv(original_time)
 
-        logger.warning(f"Scan completed. Would you like to analyze the output?")
-        answer = input("(y/n)? ")
+        if analysis:
+            logger.warning(f"Scan completed. Would you like to analyze the output?")
+            answer = input("(y/n)? ")
 
-        if answer.lower() == "y":
-            facility = input("Enter facility (s3df or nersc) to continue: ")
-            user = input("Enter username to continue: ")
-            self.output(
-                user=user,
-                facility=facility,
-                exp=exp,
-                run=run_number,
-                daq_num=daq_num)
+            if answer.lower() == "y":
+                facility = input("Enter facility (s3df or nersc) to continue: ")
+                user = input("Enter username to continue: ")
+                self.output(
+                    user=user,
+                    facility=facility,
+                    exp=exp,
+                    run=run_number,
+                    daq_num=daq_num)
 
     def output(
         self,

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -85,6 +85,34 @@ class Timing:
             name='shutter5'
         )
 
+    def shutter_status(self):
+        """
+        Return the status of all laser shutters.
+        """
+        status = []
+        for shutter in (self.shutter1, self.shutter2, self.shutter3, self.shutter4, self.shutter5):
+            status.append(shutter.state.get())
+            if laser is not None:
+                shutter('IN')
+
+        return status
+
+    def check(self):
+        """
+        Check that all timing devices are responsive.
+        """
+        print(f"Device {self.lxt}: {self.lxt.position}")
+
+        for device in (self.txt, self.lxt_fast1, self.lxt_fast2):
+            print(f"Device {device}: {device.position[0]} s")
+
+        print('shutter1:', self.shutter1.state.get())
+        print('shutter2:', self.shutter2.state.get())
+        print('shutter3:', self.shutter3.state.get())
+        print('shutter4:', self.shutter4.state.get())
+        print('shutter5:', self.shutter5.state.get())
+
+
     def clustered_points(self, y, z, n, power=2.0, center=None, plot=False):
         """
         n points in [y, z], spaced denser near `center`.
@@ -327,11 +355,7 @@ class Timing:
             logger.error('Please enter daq 1 or 2.')
 
         pp.close()
-        status = []
-        for shutter in (self.shutter1, self.shutter2, self.shutter3, self.shutter4, self.shutter5):
-            status.append(shutter.state.get())
-            if laser is not None:
-                shutter('IN')
+        status = self.shutter_status()
 
         post(
             sample=sample,
@@ -342,7 +366,7 @@ class Timing:
             daq_num=daq_num,
             add_note=(
                 f'Scaning {pv}, '
-                f'Time range:{start}-{end}s, '
+                f'Time range:{start} to {end}s, '
                 f'steps:{steps} @ {events_per_step} events per step'
                 f'shutter 1 state: {status[0]}, '
                 f'shutter 2 state: {status[1]}, '

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -2,6 +2,9 @@
 import os
 import sys
 import logging
+import random
+import numpy as np
+import matplotlib.pyplot as plt
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +62,46 @@ class Timing:
 
         self.lxt_ttc = LXTTTC('', name='lxt_ttc')
 
+    def clustered_toward_center(
+            self,
+            start: float,
+            end: float,
+            steps: int,
+            power: float = 2.0,
+            plot : bool = False
+            ) -> list:
+        """
+        n points in [y, z], spaced denser near the center.
+        power > 1 increases clustering toward center.
+        """
+        c = (start + end) / 2.0
+        r = (end - start) / 2.0
+
+        t = np.linspace(-1.0, 1.0, steps)          # uniform in parameter space
+        u = np.sign(t) * (np.abs(t) ** power)  # compress near 0 -> denser near center
+
+        x = c + r * u
+        if plot:
+            xs = np.sort(x)
+            dx = np.diff(xs)
+
+            fig, ax = plt.subplots(2, 1, figsize=(7, 4), constrained_layout=True)
+
+            # points on a line
+            ax[0].plot(xs, np.zeros_like(xs), "o")
+            ax[0].set_yticks([])
+            ax[0].set_xlim(start, end)
+            ax[0].set_title("Points (denser near center)")
+
+            # spacing between adjacent points
+            ax[1].plot(dx, "-o")
+            ax[1].set_title("Adjacent spacing (sorted)")
+            ax[1].set_xlabel("Interval index")
+            ax[1].set_ylabel("Δx")
+
+            plt.show()
+        return x.tolist()
+
     def scan(
             self,
             start: float,
@@ -71,7 +114,13 @@ class Timing:
             inspire: bool = False,
             record: bool = True,
             daq_num: int = 2,
-            pv: str = None):
+            pv: str = None,
+            randomize: bool = False,
+            cluster: bool = False,
+            delay: bool = False,
+            duration: float = 300.0,
+            sweep_time: float = 5.0
+            ):
         """Perform Timing scan.
 
         Parameters:
@@ -107,6 +156,24 @@ class Timing:
 
             pv (str):
                 PV type Please enter lxt, txt, lxt_ttc, lxt_fast1, or lxt_fast2
+
+            randomize (bool):
+                Whether to randomize the order of the scan points. Default: False.
+
+            cluster (bool):
+                Cluster points toward center and mark them on the plot. Default: False.
+
+            delay (bool):
+                Whether to perform a delay scan with the specified
+                duration and sweep time instead of a step scan. Default: False.
+
+            duration (float):
+                Total duration of the delay scan in seconds.
+                Required if delay is True.
+
+            sweep_time (float):
+                Time to spend at each delay point during the delay scan in seconds.
+                Required if delay is True.
 
         """
         from ophyd import EpicsSignal
@@ -150,7 +217,6 @@ class Timing:
         else:
             logger.error('Please enter daq 1 or 2.')
 
-        # original_time = pv.get()[0] if pv in [self.lxt, self.txt] else pv.get()[0][0]
         original_time = pv()
 
         run_number = get_run(station=station) + 1
@@ -176,19 +242,35 @@ class Timing:
                 events=events_per_step,
                 record=record)
 
-            RE(bp.scan(
-                [daq],
-                pv,
-                start,
-                end,
-                steps))
+            if cluster:
+                points = self.clustered_toward_center(start, end, steps, power=2.0, plot=True)
+            else:
+                points = list(range(start, end + 1))
+
+            if randomize:
+                random.shuffle(points)
+
+            if cluster or randomize:
+                logger.info(f"Scan points: clustered {cluster} randomize {randomize}")
+                RE(bp.list_scan([daq], pv, points))
+
+            elif delay:
+                logger.info(
+                    f"Scan points: delay {delay} for duration "
+                    f"{duration} with sweep time {sweep_time}")
+                RE(
+                    bp.delay_scan(
+                        [daq], pv, [start, end], sweep_time=sweep_time, duration=duration))
+
+            else:
+                RE(bp.scan([daq], pv, start, end, steps))
 
         else:
             logger.error('Please enter daq 1 or 2.')
 
         pp.close()
         post(
-            sample=pv,
+            sample=sample,
             tag=tag,
             run_number=run_number,
             post=record,

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -171,69 +171,112 @@ class Timing:
             duration: float = 300.0,
             sweep_time: float = 5.0
             ):
-        """Perform Timing scan.
+        """
+        Execute timing calibration scan series.
 
-        Parameters:
-            start (float):
-                Time Point (in s) to start the scan at.
+        Performs a systematic scan of timing delays to calibrate laser-X-ray
+        synchronization by stepping through time delays and collecting events
+        at each position.
 
-            end (float):
-                Time Point (in s) to end the scan at.
+        Parameters
+        ----------
+        pv : object
+            Process variable (timing motor) to scan. Should have callable
+            interface for setting position.
+        start : float
+            Starting time delay value in seconds.
+        end : float
+            Ending time delay value in seconds.
+        steps : int
+            Number of delay steps in the scan.
+        events_per_step : int
+            Number of DAQ events to collect at each step.
+        sample : str, optional
+            Sample name for data logging, by default None.
+        tag : str, optional
+            Additional tag for run identification, by default None.
+        run_number : int, optional
+            Specific run number to assign. If None, auto-increments,
+            by default None.
+        record : bool, optional
+            Whether to record data to eLog and database, by default True.
+        inspire : bool, optional
+            Enable inspire mode for data collection, by default False.
+        daq_num : int, optional
+            DAQ station number (1 or 2), by default 2.
+        cluster : bool, optional
+            Whether to cluster scan points around center position,
+            by default False.
+        center : float, optional
+            Center position for clustered scanning. Required if cluster=True,
+            by default None.
+        randomize : bool, optional
+            Randomize order of scan positions, by default False.
+        delay : bool, optional
+            Include additional delay scan, by default False.
+        analysis : bool, optional
+            Prompt for automatic analysis after scan completion,
+            by default True.
 
-            steps (int):
-                Number of steps in scan.
+        Returns
+        -------
+        None
+            Executes scan and optionally triggers analysis.
 
-            events_per_step (int):
-                Number of events per step. Optional. Default: 240.
+        Raises
+        ------
+        ValueError
+            If cluster=True but center is None.
+            If daq_num is not 1 or 2.
 
-            sample: str, optional
-                Sample Name
+        Notes
+        -----
+        Scan Procedure:
+        1. Records initial laser shutter states (shutters 1-5)
+        2. Generates scan positions (linear, clustered, or randomized)
+        3. For each position:
+            - Moves timing motor to target delay
+            - Collects specified number of events
+            - Records shutter states
+        4. Returns motor to original position
+        5. Posts scan metadata to eLog if record=True
+        6. Optionally launches analysis pipeline
 
-            tag: str, optional
-                Run group tag
+        The scan records all shutter states and motor positions for each
+        step to enable post-processing and correlation analysis.
 
-            picker: str, optional
-                If 'open' it opens pp before run starts. If 'flip' it flipflops before run starts
+        Clustering mode concentrates scan points around a center position
+        for higher resolution characterization of timing features.
 
-            inspire: bool, optional
-                Set false by default because it makes Sandra sad. Set True to inspire
+        Examples
+        --------
+        >>> timing = Timing()
+        >>> # Linear scan
+        >>> timing.series(
+        ...     pv=timing.lxt_fast1,
+        ...     start=-1e-12,
+        ...     end=1e-12,
+        ...     steps=20,
+        ...     events_per_step=1000,
+        ...     sample='water',
+        ...     daq_num=2
+        ... )
 
-            record (bool):
-                whether to record the scan or not. Optional. Default: False.
+        >>> # Clustered scan around zero delay
+        >>> timing.series(
+        ...     pv=timing.lxt_fast1,
+        ...     start=-2e-12,
+        ...     end=2e-12,
+        ...     steps=30,
+        ...     events_per_step=500,
+        ...     cluster=True,
+        ...     center=0.0,
+        ...     randomize=True
+        ... )
 
-            daq_num: int, optional
-                Switch between daq 1 and 2. Default 2
-
-            pv (str):
-                PV type Please enter lxt, txt, lxt_ttc, lxt_fast1, or lxt_fast2
-
-            laser (int):
-                Specify which laser shutter to open (1 - 5). Default None
-
-            analysis (bool):
-                Whether to perform analysis and output after the scan. Default: True.
-
-            randomize (bool):
-                Whether to randomize the order of the scan points. Default: False.
-
-            cluster (bool):
-                Cluster points toward center and mark them on the plot. Default: False.
-
-            center (float):
-                Center point for clustering. If None, uses midpoint of start and end. Default: None.
-
-            delay (bool):
-                Whether to perform a delay scan with the specified
-                duration and sweep time instead of a step scan. Default: False.
-
-            duration (float):
-                Total duration of the delay scan in seconds.
-                Required if delay is True.
-
-            sweep_time (float):
-                Time to spend at each delay point during the delay scan in seconds.
-                Required if delay is True.
-
+        See Also
+        --------
+        output : Analyze timing scan data
         """
         from ophyd import EpicsSignal
         from pcdsdevices.pv_positioner import OnePVMotor
@@ -418,50 +461,66 @@ class Timing:
         """
         Analysis and output for timing scan data.
 
-        Provides methods to analyze timing calibration data and
-        generate plots on computing facilities.
+        Provides methods to analyze timing calibration data and generate plots
+        on computing facilities (S3DF or NERSC).
 
-        Methods
+        Parameters
+        ----------
+        user : str
+            Username for remote computing facility authentication.
+        facility : str, optional
+            Computing facility to use for analysis, by default 'S3DF'.
+            Options: 'S3DF' or 'NERSC'.
+        exp : str, optional
+            Experiment name/ID. If None, retrieves from current DAQ station,
+            by default None.
+        run : str, optional
+            Run number to analyze. If None, retrieves from current DAQ station,
+            by default None.
+        daq_num : int, optional
+            DAQ station number (1 or 2), by default 2.
+            Station 0 corresponds to daq_num=2, station 1 to daq_num=1.
+
+        Returns
         -------
-        series(user, facility, exp, run, energy, step, num)
-            Analyze energy scan series data
+        None
+            Executes remote analysis script and displays results.
+
+        Raises
+        ------
+        ValueError
+            If daq_num is not 1 or 2.
 
         Notes
         -----
         Analysis Process:
-        1. Retrieve data from DAQ files
-        2. Extract detector intensities vs. energy
-        3. Identify absorption edge
-        4. Compare to reference energy
-        5. Calculate energy offset
+        1. Retrieve data from DAQ files on remote facility
+        2. Extract detector intensities vs. time
+        3. Identify timing correlation peaks
+        4. Compare to reference timing
+        5. Calculate timing offset
         6. Generate calibration plots
 
-        Output Products:
-        - Energy vs. intensity plots
-        - Edge position determination
-        - Calibration offset value
-        - Statistical uncertainties
+        For NERSC facility, requires valid sshproxy token. The method will
+        prompt for token renewal if needed.
 
-        Computing Facilities:
-        - S3DF: Interactive analysis
-        - NERSC: Batch processing
+        The analysis script path is:
+        /sdf/group/lcls/ds/tools/mfx/scripts/analyze_timing.py
 
         Examples
         --------
-        >>> output = NotchOutput()
-        >>> output.series(
+        >>> timing = Timing()
+        >>> timing.output(
         ...     user='myuser',
         ...     facility='S3DF',
         ...     exp='mfxls1234',
-        ...     run=100,
-        ...     energy=7112,
-        ...     step=5,
-        ...     num=20
+        ...     run='100',
+        ...     daq_num=2
         ... )
 
         See Also
         --------
-        NotchScan.series : Data collection
+        series : Perform timing scan series data collection
         """
         from mfx.macros import get_exp, get_run
 

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -31,6 +31,7 @@ class Timing:
         Initialize Timing control system.
         """
         from pcdsdevices.device import ObjectComponent as OCpt
+        from pcdsdevices.lxe import LaserTiming
         from pcdsdevices.pseudopos import SyncAxis
         from pcdsdevices.usb_encoder import UsDigitalUsbEncoder
         from mfx.db import mfx_txt
@@ -42,9 +43,9 @@ class Timing:
         self.lxt_fast2 = mfx_lxt_fast2
 
         self.lxt_fast1_enc = UsDigitalUsbEncoder(
-            'MFX:USDUSB4:01:CH2', name='lxt_fast_enc1', linked_axis=self.mfx_lxt_fast1)
+            'MFX:USDUSB4:01:CH2', name='lxt_fast_enc1', linked_axis=mfx_lxt_fast1)
         self.lxt_fast2_enc = UsDigitalUsbEncoder(
-            'MFX:USDUSB4:01:CH1', name='lxt_fast_enc2', linked_axis=self.mfx_lxt_fast2)
+            'MFX:USDUSB4:01:CH1', name='lxt_fast_enc2', linked_axis=mfx_lxt_fast2)
 
         class LXTTTC(SyncAxis):
             lxt = OCpt(self.lxt)
@@ -149,10 +150,8 @@ class Timing:
         else:
             logger.error('Please enter daq 1 or 2.')
 
-        if pv == self.lxt_ttc or pv == self.lxt_fast1 or pv == self.lxt_fast2:
-            original_time = pv.get()[0][0]
-        else:
-            original_time = pv.get()[0]
+        # original_time = pv.get()[0] if pv in [self.lxt, self.txt] else pv.get()[0][0]
+        original_time = pv()
 
         run_number = get_run(station=station) + 1
         logger.info(f"Run Number {run_number} Running {sample}......{quote()['quote']}")

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -11,22 +11,121 @@ logger = logging.getLogger(__name__)
 
 class Timing:
     """
+    Timing calibration and control system for MFX beamline laser synchronization.
+
+    The Timing class provides comprehensive control of laser timing motors and
+    performs timing calibration scans to synchronize laser pulses with X-ray
+    pulses at the MFX (Macromolecular Femtosecond Crystallography) beamline.
+    It manages multiple timing systems including fast delay stages and
+    time-tool correlation.
 
     Attributes
     ----------
+    lxt : LaserTiming
+        Main laser timing motor control (LAS:FS45).
+    txt : object
+        MFX text-based timing control from device database.
+    lxt_fast1 : object
+        Fast laser timing stage 1 from device database.
+    lxt_fast2 : object
+        Fast laser timing stage 2 from device database.
+    lxt_fast1_enc : UsDigitalUsbEncoder
+        USB encoder for fast timing stage 1 (MFX:USDUSB4:01:CH2).
+        Provides position feedback linked to lxt_fast1 axis.
+    lxt_fast2_enc : UsDigitalUsbEncoder
+        USB encoder for fast timing stage 2 (MFX:USDUSB4:01:CH1).
+        Provides position feedback linked to lxt_fast2 axis.
+    LXTTTC : SyncAxis
+        Synchronized axis combining laser timing (lxt) and time-tool
+        correlation (txt) for coordinated motion.
 
     Methods
     -------
+    series(pv, start, end, steps, events_per_step, **kwargs)
+        Execute timing calibration scan series across delay range.
+    output(user, facility, exp, run, daq_num)
+        Analyze and visualize timing scan data from computing facility.
 
     Notes
     -----
+    Timing System Overview:
+    - **LXT (Laser Timing)**: Controls laser arrival time relative to X-ray pulses
+    - **TXT (Time Tool)**: Provides real-time timing diagnostics
+    - **Fast Stages**: High-resolution delay stages for sub-picosecond control
+    - **USB Encoders**: Provide accurate position feedback for fast stages
+
+    The timing calibration process involves:
+    1. Scanning laser delay over specified range
+    2. Collecting detector events at each delay point
+    3. Analyzing correlation between laser and X-ray signals
+    4. Determining optimal timing offset for synchronization
+
+    Typical timing precision: ~10 femtoseconds (1e-14 seconds)
+    Typical scan range: -1 to +1 picoseconds around zero delay
+
+    The class integrates with:
+    - LCLS DAQ system for data acquisition
+    - eLog for run documentation
+    - S3DF/NERSC computing facilities for analysis
+    - Laser shutter control system (5 independent shutters)
 
     Examples
     --------
+    Initialize timing system and perform calibration scan:
+
+    >>> from mfx.macros import Timing
+    >>> timing = Timing()
+
+    >>> # Check current positions
+    >>> print(f"LXT position: {timing.lxt.position}")
+    >>> print(f"Fast stage 1: {timing.lxt_fast1.position}")
+
+    >>> # Perform timing scan on fast stage 1
+    >>> timing.series(
+    ...     pv=timing.lxt_fast1,
+    ...     start=-500e-15,  # -500 femtoseconds
+    ...     end=500e-15,     # +500 femtoseconds
+    ...     steps=25,
+    ...     events_per_step=1000,
+    ...     sample='lysozyme',
+    ...     tag='timing_cal',
+    ...     record=True,
+    ...     daq_num=2
+    ... )
+
+    >>> # Analyze the results
+    >>> timing.output(
+    ...     user='myuser',
+    ...     facility='S3DF',
+    ...     exp='mfxls1234',
+    ...     run='150'
+    ... )
+
+    >>> # Perform clustered scan for fine calibration
+    >>> timing.series(
+    ...     pv=timing.lxt_fast1,
+    ...     start=-200e-15,
+    ...     end=200e-15,
+    ...     steps=40,
+    ...     events_per_step=500,
+    ...     cluster=True,
+    ...     center=0.0,
+    ...     randomize=True,
+    ...     sample='lysozyme',
+    ...     daq_num=2
+    ... )
 
     See Also
     --------
+    pcdsdevices.lxe.LaserTiming : Laser timing motor control
+    pcdsdevices.pseudopos.SyncAxis : Synchronized multi-axis control
+    pcdsdevices.usb_encoder.UsDigitalUsbEncoder : Position encoder interface
+    mfx.devices.LaserShutter : Laser shutter control
 
+    References
+    ----------
+    .. [1] LCLS MFX Beamline Documentation
+       https://confluence.slac.stanford.edu/display/PCDS/MFX
     """
 
     def __init__(self):

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -62,7 +62,7 @@ class Timing:
 
         self.lxt_ttc = LXTTTC('', name='lxt_ttc')
 
-    def clustered_points(y, z, n, power=2.0, center=None, plot=False):
+    def clustered_points(self,y, z, n, power=2.0, center=None, plot=False):
         """
         n points in [y, z], spaced denser near `center`.
         power > 1 increases clustering strength.
@@ -129,6 +129,7 @@ class Timing:
             pv: str = None,
             randomize: bool = False,
             cluster: bool = False,
+            center: float = None,
             delay: bool = False,
             duration: float = 300.0,
             sweep_time: float = 5.0
@@ -174,6 +175,9 @@ class Timing:
 
             cluster (bool):
                 Cluster points toward center and mark them on the plot. Default: False.
+
+            center (float):
+                Center point for clustering. If None, uses midpoint of start and end. Default: None.
 
             delay (bool):
                 Whether to perform a delay scan with the specified
@@ -255,7 +259,7 @@ class Timing:
                 record=record)
 
             if cluster:
-                points = self.clustered_toward_center(start, end, steps, power=2.0, plot=True)
+                points = self.clustered_points(start, end, steps, power=2.0, plot=True)
             else:
                 points = list(np.linspace(start, end, steps))
 

--- a/mfx/timing.py
+++ b/mfx/timing.py
@@ -37,6 +37,7 @@ class Timing:
         from pcdsdevices.lxe import LaserTiming
         from pcdsdevices.pseudopos import SyncAxis
         from pcdsdevices.usb_encoder import UsDigitalUsbEncoder
+        from mfx.devices import LaserShutter
         from mfx.db import mfx_txt
         from mfx.db import mfx_lxt_fast1, mfx_lxt_fast2
 
@@ -61,6 +62,28 @@ class Timing:
             sync_limits = (-10e-6, 10e-6)
 
         self.lxt_ttc = LXTTTC('', name='lxt_ttc')
+
+        # Initialize shutter objects with hardware PVs
+        self.shutter1 = LaserShutter(
+            'MFX:USR:ao1:6',
+            name='shutter1'
+        )
+        self.shutter2 = LaserShutter(
+            'MFX:USR:ao1:8',
+            name='shutter2'
+        )
+        self.shutter3 = LaserShutter(
+            'MFX:USR:ao1:2',
+            name='shutter3'
+        )
+        self.shutter4 = LaserShutter(
+            'MFX:USR:ao1:3',
+            name='shutter4'
+        )
+        self.shutter5 = LaserShutter(
+            'MFX:USR:ao1:4',
+            name='shutter5'
+        )
 
     def clustered_points(self, y, z, n, power=2.0, center=None, plot=False):
         """
@@ -123,6 +146,7 @@ class Timing:
             record: bool = True,
             daq_num: int = 2,
             pv: str = None,
+            laser: int = None,
             analysis: bool = True,
             randomize: bool = False,
             cluster: bool = False,
@@ -166,6 +190,9 @@ class Timing:
 
             pv (str):
                 PV type Please enter lxt, txt, lxt_ttc, lxt_fast1, or lxt_fast2
+
+            laser (int):
+                Specify which laser shutter to open (1 - 5). Default None
 
             analysis (bool):
                 Whether to perform analysis and output after the scan. Default: True.
@@ -222,6 +249,20 @@ class Timing:
             pp.open()
         if picker=='flip':
             pp.flipflop()
+
+        if laser is not None:
+            if laser == 1:
+                self.shutter1('OUT')
+            elif laser == 2:
+                self.shutter2('OUT')
+            elif laser == 3:
+                self.shutter3('OUT')
+            elif laser == 4:
+                self.shutter4('OUT')
+            elif laser == 5:
+                self.shutter5('OUT')
+            else:
+                logger.error('Please enter a valid laser shutter number (1-5).')
 
         if tag is None:
             tag = sample
@@ -286,6 +327,12 @@ class Timing:
             logger.error('Please enter daq 1 or 2.')
 
         pp.close()
+        status = []
+        for shutter in (self.shutter1, self.shutter2, self.shutter3, self.shutter4, self.shutter5):
+            status.append(shutter.state.get())
+            if laser is not None:
+                shutter('IN')
+
         post(
             sample=sample,
             tag=tag,
@@ -297,6 +344,11 @@ class Timing:
                 f'Scaning {pv}, '
                 f'Time range:{start}-{end}s, '
                 f'steps:{steps} @ {events_per_step} events per step'
+                f'shutter 1 state: {status[0]}, '
+                f'shutter 2 state: {status[1]}, '
+                f'shutter 3 state: {status[2]}, '
+                f'shutter 4 state: {status[3]}, '
+                f'shutter 5 state: {status[4]}, '
                 f'{" with clustering at center " + str(center) if cluster else ""}'
                 f'{" with randomization" if randomize else ""}'
                 f'{" with delay scan" if delay else ""}'

--- a/scripts/analyze_timing.py
+++ b/scripts/analyze_timing.py
@@ -7,13 +7,15 @@ import os
 import sys
 import argparse
 import pickle
-from pathlib import Path
 import h5py
 import pandas as pd
 import numpy as np
-from tqdm import tqdm
 import matplotlib.pyplot as plt
 from psana import DataSource
+from scipy.optimize import curve_fit
+from scipy import special
+from pathlib import Path
+from tqdm import tqdm
 
 
 logging.basicConfig()
@@ -46,7 +48,7 @@ def proxy_jump(
             f"ssh -Yt psana '"
             f"source /sdf/group/lcls/ds/ana/sw/conda2/manage/bin/psconda.sh && "
             f"python /sdf/group/lcls/ds/tools/mfx/scripts/analyze_timing.py "
-            f"-f {facility} -t proxy -e {exp} -r {run}'"
+            f"-f {facility} -t output -e {exp} -r {run}'"
             ]
     else:
         logging.error(f"Facility not found: {facility}. Program Exit.")
@@ -68,7 +70,7 @@ def get_scan_motor(run):
 def custom_erf(x, a, sigma, mu, b):
             return a * special.erf((x - mu) / (np.sqrt(2) * sigma)) + b
 
-def fit_irfs1(x_data, y_data):
+def fit_irfs1(x_data, y_data, run_number, t_stage):
     # Convert to numpy arrays
     x_data = np.asarray(x_data, dtype=float)
     y_data = np.asarray(y_data, dtype=float)
@@ -267,8 +269,8 @@ def output(
     plt.grid(True)
     plt.show()
 
-    fit_irfs1(binned['t_position'], binned['normalized_laser_x_ray'])
-
+    # fit_irfs1(binned['t_position'], binned['normalized_laser_x_ray'])
+    fit_irfs1(binned['t_position'], binned['normalized_laser'], run_number, t_stage)
 
 def parse_args(args):
     """Parse command line parameters

--- a/scripts/analyze_timing.py
+++ b/scripts/analyze_timing.py
@@ -170,6 +170,7 @@ def output(
     x_ray_diode_sum = []
     x = []
 
+    # Load QADC and timing info from XTC file and plot as funciton of time
     for run_number in run_numbers:
         logger.info(f'Processing run {run_number} for experiment {experiment}...')
         ds = DataSource(exp=experiment, run=int(run_number), xdetectors=['jungfrau'])
@@ -220,7 +221,6 @@ def output(
         #'tt': tt
     }
 
-
     df = pd.DataFrame(data)
 
     df['normalized_laser'] = df['qadc1_sum'] # / df['qadc0_sum']
@@ -255,7 +255,10 @@ def output(
 
     # --- Bin and plot ---
     n_bins = 100
-    df_clean['t_bin'] = pd.cut(df_clean['t_position'], bins=n_bins)
+    if t_stage == 'lxt_ttc' or t_stage == 'mfx_lxt_fast1' or t_stage == 'mfx_lxt_fast2':
+        df_clean['t_bin'] = pd.cut(df_clean['t_position'].astype(float), bins=n_bins)
+    else:
+        df_clean['t_bin'] = pd.cut(df_clean['t_position'], bins=n_bins)
 
     binned = df_clean.groupby('t_bin').agg({
         't_position': 'mean',
@@ -269,7 +272,7 @@ def output(
     plt.grid(True)
     plt.show()
 
-    # fit_irfs1(binned['t_position'], binned['normalized_laser_x_ray'])
+    # Now fit
     fit_irfs1(binned['t_position'], binned['normalized_laser'], run_number, t_stage)
 
 def parse_args(args):

--- a/scripts/analyze_timing.py
+++ b/scripts/analyze_timing.py
@@ -186,8 +186,8 @@ def output(
                 diode_val_0 = diode_0.raw.value(evt)
                 diode_val_1 = diode_1.raw.value(evt)
                 if diode_val_0 is not None and diode_val_1 is not None:
-                    tmp0 = np.sum(diode_val_0[qadc0_low:qadc0_high])
-                    tmp1 = np.sum(diode_val_1[qadc1_low:qadc1_high])
+                    tmp0 = np.sum(np.abs(diode_val_0[qadc0_low:qadc0_high]))
+                    tmp1 = np.sum(np.abs(diode_val_1[qadc1_low:qadc1_high]))
 
                     qadc0_cropped.append(tmp0)
                     qadc1_cropped.append(tmp1)

--- a/scripts/analyze_timing.py
+++ b/scripts/analyze_timing.py
@@ -1,0 +1,333 @@
+# -*- coding: utf-8 -*-
+"""
+analyze_timing
+"""
+import logging
+import os
+import sys
+import argparse
+import pickle
+from pathlib import Path
+import h5py
+import pandas as pd
+import numpy as np
+from tqdm import tqdm
+import matplotlib.pyplot as plt
+from psana import DataSource
+
+
+logging.basicConfig()
+logging.getLogger().setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+
+def proxy_jump(
+        facility: str = "S3DF",
+        exp: str = None,
+        run: str = None):
+    """ Generates the output of the energy scan or series.
+
+    Parameters:
+        facility (str):
+            Default: "S3DF". Options: "S3DF, NERSC
+        exp (str):
+            experiment number. Current experiment by default
+        run (str):
+            The run you'd like to process
+    """
+    if facility.upper() == "NERSC": #need paths to work on nersc
+        exp = exp[3:-2]
+        proc = [
+                f"ssh -i ~/.ssh/cctbx -YAC cctbx@perlmutter-p1.nersc.gov "
+                f"/global/common/software/lcls/mfx/scripts/cctbx/energy_calib_output.sh "
+                f"{facility} {exp} {run}"
+            ]
+    elif facility.upper() == "S3DF":
+        proc = [
+            f"ssh -Yt psana '"
+            f"source /sdf/group/lcls/ds/ana/sw/conda2/manage/bin/psconda.sh && "
+            f"python /sdf/group/lcls/ds/tools/mfx/scripts/analyze_timing.py "
+            f"-f {facility} -t proxy -e {exp} -r {run}'"
+            ]
+    else:
+        logging.error(f"Facility not found: {facility}. Program Exit.")
+        sys.exit()
+
+    logging.info(proc)
+    os.system(proc[0])
+
+def get_scan_motor(run):
+    # want to pick up the scanned motor automatically
+    # wants the psana run object
+    tmp = run.scaninfo
+    ignore = {'step_value', 'step_docstring'}
+
+    mot_name = next( k[0] for k in tmp if k[1] == 'raw' and k[0] not in ignore)
+    logger.info(f'Scanning motor found as: {mot_name}')
+    return mot_name
+
+def custom_erf(x, a, sigma, mu, b):
+            return a * special.erf((x - mu) / (np.sqrt(2) * sigma)) + b
+
+def fit_irfs1(x_data, y_data):
+    # Convert to numpy arrays
+    x_data = np.asarray(x_data, dtype=float)
+    y_data = np.asarray(y_data, dtype=float)
+
+    # Remove NaNs and infs
+    mask = np.isfinite(x_data) & np.isfinite(y_data)
+    x_data = x_data[mask]
+    y_data = y_data[mask]
+
+    # Safety check
+    if len(x_data) < 5:
+        raise ValueError("Not enough valid points after removing NaNs/Infs")
+
+    # Normalize safely
+    ymax = np.max(y_data)
+    if ymax != 0:
+        y_data = y_data / ymax
+    else:
+        raise ValueError("y_data max is zero — cannot normalize")
+
+    # Initial guesses
+    a_initial = np.max(y_data) - np.min(y_data)
+    mu_initial = -1e-12
+    sigma_initial = (x_data.max() - x_data.min()) / 100
+    b_initial = np.min(y_data)
+
+    p0 = (a_initial, sigma_initial, mu_initial, b_initial)
+
+    # Fit
+    popt, pcov = curve_fit(custom_erf, x_data, y_data, p0=p0)
+
+    # Generate fit
+    y_fit = custom_erf(x_data, *popt)
+
+    # Sort for plotting
+    order = np.argsort(x_data)
+    x_sorted = x_data[order]
+    y_fit_sorted = y_fit[order]
+
+    # Plot
+    plt.figure(figsize=(5, 3))
+    plt.scatter(x_data, y_data, s=15, label='Data')
+    plt.plot(
+        x_sorted,
+        y_fit_sorted,
+        label=f'Fitted irf, width = {popt[1] * 2.355 * 1e15:.2f} fs'
+    )
+    plt.xlabel('X')
+    plt.ylabel('Y')
+    plt.title(f'Sigmoid Fit for run {run_number} scanning {t_stage}')
+    plt.legend()
+    plt.grid()
+    plt.show()
+
+    # Print results
+    logger.info("Fitted Parameters:")
+    logger.info(f'width = {popt[1] * 2.355}')
+    logger.info(f'offset [ps] = {popt[2] * 1e12}')
+
+    return popt, x_data, y_data, y_fit
+
+def output(
+        facility: str = "S3DF",
+        exp: str = None,
+        run: str = None):
+    """ Generates the output of the timing scan.
+
+    Parameters:
+        facility (str):
+            Default: "S3DF". Options: "S3DF, NERSC
+        exp (str):
+            experiment number. Current experiment by default
+        run (str):
+            The run you'd like to process
+    """
+    qadc0_low = 10
+    qadc0_high = 50
+    qadc1_low = 75
+    qadc1_high = 100
+
+    # diode_0 = run.Detector('qadc_ch0')
+    # diode_1 = run.Detector('qadc_ch1')
+
+    # plt.plot(diode_0[qadc0_low:qadc0_high],label='qadc0')
+    # plt.plot(diode_1[qadc1_low:qadc1_high],label='qadc1')
+    # plt.legend()
+
+    # Load all QADC data from XTC and save in a df
+    experiment = exp
+    run_numbers = [run]
+
+    all_counts=[]
+    evts=0
+    qadc0_cropped = []
+    qadc1_cropped = []
+    time_mot = []
+    x_ray_diode_sum = []
+    x = []
+
+    for run_number in run_numbers:
+        logger.info(f'Processing run {run_number} for experiment {experiment}...')
+        ds = DataSource(exp=experiment, run=int(run_number), xdetectors=['jungfrau'])
+        for run in ds.runs():
+            diode_0 = run.Detector('qadc_ch0')
+            diode_1 = run.Detector('qadc_ch1')
+
+            t_stage = get_scan_motor(run) #'lxt', 'lxt_ttc", 'mfx_lxt_fast1' ect..
+
+            evts=0
+            for i_evt, evt in enumerate(run.events()):
+                evts+=1
+                diode_val_0 = diode_0.raw.value(evt)
+                diode_val_1 = diode_1.raw.value(evt)
+                if diode_val_0 is not None and diode_val_1 is not None:
+                    tmp0 = np.sum(diode_val_0[qadc0_low:qadc0_high])
+                    tmp1 = np.sum(diode_val_1[qadc1_low:qadc1_high])
+
+                    qadc0_cropped.append(tmp0)
+                    qadc1_cropped.append(tmp1)
+
+                    # tmptmp = run.Detector('mfx_lxt_fast1')
+                    # tmptmp = run.Detector('lxt')
+                    # tmptmp = run.Detector('lxt_fast')
+                    # tmptmp = run.Detector('lxt_ttc_set')
+
+                    tmptmp = run.Detector(t_stage)
+                    time_mot.append(tmptmp(evt))
+                    # x.append(time_mot)
+                    ipm= run.Detector('MfxDg2BmMon')
+                    x_ray_diode_sum.append(ipm.raw.totalIntensityJoules(evt))
+                    # timing = run.Detector('timing')
+
+    qadc0_cropped = np.array(qadc0_cropped)
+    qadc1_cropped = np.array(qadc1_cropped)
+
+    # Calculate the sums for each event
+    qadc0_sum_per_event = qadc0_cropped
+    qadc1_sum_per_event = qadc1_cropped
+
+
+    data = {
+        # 't_position': t_position.squeeze(),
+        't_position': time_mot,
+        'qadc0_sum': qadc0_sum_per_event,
+        'qadc1_sum': qadc1_sum_per_event,
+        'x_ray_diode_sum': x_ray_diode_sum
+        #'tt': tt
+    }
+
+
+    df = pd.DataFrame(data)
+
+    df['normalized_laser'] = df['qadc1_sum'] # / df['qadc0_sum']
+    df['normalized_laser_x_ray'] = df['normalized_laser']/df['x_ray_diode_sum']
+
+    fig, axes = plt.subplots(1, 2, figsize=(10, 4), sharex=True)
+
+    # Left plot
+    axes[0].scatter(df['t_position'], df['normalized_laser'], s=0.1)
+    axes[0].set_title(f'Run: {run_number}, scanning: {t_stage}')
+    axes[0].set_xlabel('time (ps?)')
+    axes[0].set_ylabel('normalized laser')
+
+    # Right plot
+    axes[1].scatter(df['t_position'], df['normalized_laser_x_ray'], s=0.1)
+    axes[1].set_title('Normalized laser × X-ray')
+    axes[1].set_xlabel('time (ps?)')
+
+    plt.tight_layout()
+    plt.show()
+
+    # Remove outliers and bin data
+    diode_repsonse = 'normalized_laser' # could use normalized_laser_x_ray if X-ray normalization look sensible
+    # --- Remove outliers using IQR on normalized_laser ---
+    Q1 = df['normalized_laser'].quantile(0.25)
+    Q3 = df['normalized_laser'].quantile(0.75)
+    IQR = Q3 - Q1
+
+    # Keep only points within 1.5 * IQR
+    df_clean = df[(df['normalized_laser'] >= Q1 - 1.5 * IQR) &
+                (df['normalized_laser'] <= Q3 + 1.5 * IQR)]
+
+    # --- Bin and plot ---
+    n_bins = 100
+    df_clean['t_bin'] = pd.cut(df_clean['t_position'], bins=n_bins)
+
+    binned = df_clean.groupby('t_bin').agg({
+        't_position': 'mean',
+        'normalized_laser': 'mean'
+    })
+
+    plt.scatter(binned['t_position'], binned['normalized_laser'], color='royalblue', s=40)
+    plt.xlabel('t_position')
+    plt.ylabel('normalized_laser')
+    plt.title('Binned Scatter (Outliers Removed)')
+    plt.grid(True)
+    plt.show()
+
+    fit_irfs1(binned['t_position'], binned['normalized_laser_x_ray'])
+
+
+def parse_args(args):
+    """Parse command line parameters
+
+    Args:
+      args ([str]): command line parameters as list of strings
+
+    Returns:
+      :obj:`argparse.Namespace`: command line parameters namespace
+    """
+    parser = argparse.ArgumentParser(
+        description="startup script for cctbx on iana."
+    )
+    parser.add_argument(
+        "--facility",
+        "-f",
+        dest="facility",
+        default=None,
+        help="Enter -f to specify facility",
+    )
+    parser.add_argument(
+        "--type",
+        "-t",
+        dest="run_type",
+        default=None,
+        help="Enter -t to specify which step proxy or output",
+    )
+    parser.add_argument(
+        "--experiment",
+        "-e",
+        dest="experiment",
+        default=None,
+        help="Enter -e to specify experiment number",
+    )
+    parser.add_argument(
+        "--run",
+        "-r",
+        dest="run",
+        default=None,
+        help="Enter -r for the run you'd like to process."
+    )
+    return parser.parse_args(args)
+
+def main(args):
+    """
+    Main entry point allowing external calls
+    Entry point for console_scripts
+    Args:
+      args ([str]): command line parameter list
+    """
+    args = parse_args(args)
+    if args.run_type == "proxy":
+        proxy_jump(args.facility, args.experiment, args.run)
+    elif args.run_type == "output":
+        output(args.facility, args.experiment, args.run)
+
+def run():
+    """Entry point for console_scripts"""
+    main(sys.argv[1:])
+
+if __name__ == "__main__":
+    run()

--- a/scripts/analyze_timing.py
+++ b/scripts/analyze_timing.py
@@ -148,8 +148,8 @@ def output(
     """
     qadc0_low = 10
     qadc0_high = 50
-    qadc1_low = 75
-    qadc1_high = 100
+    qadc1_low = 93
+    qadc1_high = 104
 
     # diode_0 = run.Detector('qadc_ch0')
     # diode_1 = run.Detector('qadc_ch1')

--- a/scripts/cctbx/energy_calib_output.sh
+++ b/scripts/cctbx/energy_calib_output.sh
@@ -15,7 +15,8 @@ case $facility in
     mfx3="/sdf/group/lcls/ds/tools/mfx"
     # source /sdf/group/lcls/ds/tools/cctbx/setup.sh #psana1
     #source /sdf/group/lcls/ds/tools/cctbx-psana2/build/conda_setpaths.sh #psana2
-    source /sdf/home/f/fpoitevi/lcls2/setup_env.sh #temporary dev
+    # source /sdf/home/f/fpoitevi/lcls2/setup_env.sh #temporary dev
+    source /sdf/group/lcls/ds/tools/cctbx/setup.sh #psana2
     ;;
 
   NERSC)

--- a/tfs/transfocator.py
+++ b/tfs/transfocator.py
@@ -190,7 +190,17 @@ class MFXTransfocator(TransfocatorBase):
         self.tfs_09.remove()
         self.tfs_10.remove()
 
-    def find_best_combo(self, target=None, energy_eV=None, n=4, z_obj=0, show=True, exclusions=[], avoid_forbidden=False, enable_prefocus=True, **kwargs):
+    def find_best_combo(
+            self,
+            target=None,
+            energy_eV=None,
+            n=4,
+            z_obj=0,
+            show=True,
+            exclusions=[],
+            avoid_forbidden=False,
+            enable_prefocus=True,
+            **kwargs):
         """
         Calculate the best lens array to hit the nominal sample point
 
@@ -220,6 +230,12 @@ class MFXTransfocator(TransfocatorBase):
 
         avoid_forbidden : bool, optional
             Avoids forbidden TFS configurations. True by default
+
+        enable_prefocus : bool, optional
+            Allows the solver to use the prefocusing lenses in the XRT. Default is True since
+            the prefocusing lenses are usually required to hit the target plane at MFX.
+            Setting this to False will force the solver to find a solution using only
+            the TFS lenses.
 
         kwargs:
             Passed to :meth:`.Calculator.find_solution`
@@ -258,7 +274,14 @@ class MFXTransfocator(TransfocatorBase):
         return combo
 
 
-    def try_combo(self, target=400.37, energy=None, show=True, prefocus = None, tfs = [], **kwargs):
+    def try_combo(
+            self,
+            target=400.37,
+            energy=None,
+            show=True,
+            prefocus = None,
+            tfs = [],
+            **kwargs):
         """
         Calculates the focus based on the lens combo you select
 
@@ -268,7 +291,7 @@ class MFXTransfocator(TransfocatorBase):
             The target image of the lens array. By default this is
             `nominal_sample i.e. 399.88`
 
-        energy : int, optional 
+        energy : int, optional
             Select the energy in eV.
             Default uses the beam energy given by acr which is usually wrong
 
@@ -328,9 +351,10 @@ class MFXTransfocator(TransfocatorBase):
             estimate_beam_fwhm(radius=radius, energy=energy)
             focal = focal_length(radius=radius, energy=energy)
             calc = TFS_Calculator(tfs_lenses=self.tfs_lenses, prefocus_lenses=self.xrt_lenses)
-            forbidden = calc.check_forbidden(prefocus_idx, energy, radius)
-            log_level = logger.error if forbidden else logger.info
-            log_level(f"TFS Configuration is {'Forbidden' if forbidden else 'Allowed'}")
+            if prefocus_idx is not None:
+                forbidden = calc.check_forbidden(prefocus_idx, energy, radius)
+                log_level = logger.error if forbidden else logger.info
+                log_level(f"TFS Configuration is {'Forbidden' if forbidden else 'Allowed'}")
 
             logger.info(f'Calculated Focal Length: {focal} um\n')
 
@@ -487,26 +511,26 @@ class MFXTransfocator(TransfocatorBase):
             prev_lenses = lens_set
 
         return schedule
-    
+
     def plot_focus_track(self, json_file_path):
         # Load the data from the JSON file
         with open(json_file_path, 'r') as f:
             data = json.load(f)
-        
+
         # Extract energy, z_position, and inserted_lenses values
         energies = [entry['energy'] for entry in data]
         z_positions = [entry['z_position'] for entry in data]
         inserted_lenses = [entry['inserted_lenses'] for entry in data]
-        
+
         # Create the plot
         plt.figure(figsize=(12, 8))
         plt.plot(energies, z_positions, marker='o', linestyle='-', color='b')
-        
+
         # Add labels and title
         plt.title('Z Position vs Energy')
         plt.xlabel('Energy (eV)')
         plt.ylabel('Z Position (units)')
-        
+
         # Variable to keep track of the last inserted lenses shown
         last_displayed_lenses = None
 
@@ -514,14 +538,14 @@ class MFXTransfocator(TransfocatorBase):
         for energy, z_position, lenses in zip(energies, z_positions, inserted_lenses):
             # Convert list of lenses to a tuple for easier comparison
             lenses_tuple = tuple(lenses)
-            
+
             if lenses_tuple != last_displayed_lenses:
-                plt.annotate(', '.join(lenses), 
-                            (energy, z_position), 
-                            textcoords="offset points", 
-                            xytext=(0, 10), 
-                            ha='center', 
-                            fontsize=8, 
+                plt.annotate(', '.join(lenses),
+                            (energy, z_position),
+                            textcoords="offset points",
+                            xytext=(0, 10),
+                            ha='center',
+                            fontsize=8,
                             color='red',
                             arrowprops=dict(arrowstyle='->', color='red', lw=0.5))
                 last_displayed_lenses = lenses_tuple  # Update the last_displayed_lenses
@@ -571,7 +595,7 @@ class MFXTransfocator(TransfocatorBase):
         })
 
     def track_focus(self, energies, *, margin_mm=10.0, show=False,
-                    ref_focal_length_um=None, ref_z_stage_mm=None, 
+                    ref_focal_length_um=None, ref_z_stage_mm=None,
                     display=True, shrinking_rate=4, enable_prefocus=True,
                     lens_beam_energy_offset=0.0, **kwargs):
         """
@@ -664,7 +688,7 @@ class MFXTransfocator(TransfocatorBase):
 
         print(f"Tracking complete. Final energy: {track_record[-1]['energy']:.2f} eV, stage position: {track_record[-1]['z_position']:.3f} mm.")
         print(f"Lenses currently inserted: {track_record[-1]['inserted_lenses']}")
-        
+
         save_path = Path.home() / "track_focus_results.json"
         with open(save_path, "w") as f:
             json.dump(track_record, f, indent=4)

--- a/tfs/utils.py
+++ b/tfs/utils.py
@@ -16,7 +16,7 @@ MFX_prefocus_energy_range = {
     (0, 5000): (None, None),
     (5000, 10000): (2, 750),
     (10000, 12000): (1, 428),
-    (12000, 16000): (0, 333)
+    (12000, 22000): (0, 333)
 }
 
 
@@ -27,7 +27,7 @@ def focal_length(radius, energy,N=1):
     if N!=1:
         logger.error('N does not equal 1!')
     focal_length = calc.be_lens_calcs.calc_focal_length_for_single_lens(energy*1E-3,radius*1E-6)
-    
+
     return focal_length
 
 


### PR DESCRIPTION
Finished Inital Timing code. See following documentation and use cases.
    """
    Timing calibration and control system for MFX beamline laser synchronization.

    The Timing class provides comprehensive control of laser timing motors and
    performs timing calibration scans to synchronize laser pulses with X-ray
    pulses at the MFX (Macromolecular Femtosecond Crystallography) beamline.
    It manages multiple timing systems including fast delay stages and 
    time-tool correlation.

    Attributes
    ----------
    lxt : LaserTiming
        Main laser timing motor control (LAS:FS45).
    txt : object
        MFX text-based timing control from device database.
    lxt_fast1 : object
        Fast laser timing stage 1 from device database.
    lxt_fast2 : object
        Fast laser timing stage 2 from device database.
    lxt_fast1_enc : UsDigitalUsbEncoder
        USB encoder for fast timing stage 1 (MFX:USDUSB4:01:CH2).
        Provides position feedback linked to lxt_fast1 axis.
    lxt_fast2_enc : UsDigitalUsbEncoder
        USB encoder for fast timing stage 2 (MFX:USDUSB4:01:CH1).
        Provides position feedback linked to lxt_fast2 axis.
    LXTTTC : SyncAxis
        Synchronized axis combining laser timing (lxt) and time-tool 
        correlation (txt) for coordinated motion.

    Methods
    -------
    series(pv, start, end, steps, events_per_step, **kwargs)
        Execute timing calibration scan series across delay range.
    output(user, facility, exp, run, daq_num)
        Analyze and visualize timing scan data from computing facility.

    Notes
    -----
    Timing System Overview:
    - **LXT (Laser Timing)**: Controls laser arrival time relative to X-ray pulses
    - **TXT (Time Tool)**: Provides real-time timing diagnostics
    - **Fast Stages**: High-resolution delay stages for sub-picosecond control
    - **USB Encoders**: Provide accurate position feedback for fast stages

    The timing calibration process involves:
    1. Scanning laser delay over specified range
    2. Collecting detector events at each delay point
    3. Analyzing correlation between laser and X-ray signals
    4. Determining optimal timing offset for synchronization

    Typical timing precision: ~10 femtoseconds (1e-14 seconds)
    Typical scan range: -1 to +1 picoseconds around zero delay

    The class integrates with:
    - LCLS DAQ system for data acquisition
    - eLog for run documentation
    - S3DF/NERSC computing facilities for analysis
    - Laser shutter control system (5 independent shutters)

    Examples
    --------
    Initialize timing system and perform calibration scan:

    >>> from mfx.macros import Timing
    >>> timing = Timing()
    
    >>> # Check current positions
    >>> print(f"LXT position: {timing.lxt.position}")
    >>> print(f"Fast stage 1: {timing.lxt_fast1.position}")
    
    >>> # Perform timing scan on fast stage 1
    >>> timing.series(
    ...     pv=timing.lxt_fast1,
    ...     start=-500e-15,  # -500 femtoseconds
    ...     end=500e-15,     # +500 femtoseconds
    ...     steps=25,
    ...     events_per_step=1000,
    ...     sample='lysozyme',
    ...     tag='timing_cal',
    ...     record=True,
    ...     daq_num=2
    ... )
    
    >>> # Analyze the results
    >>> timing.output(
    ...     user='myuser',
    ...     facility='S3DF',
    ...     exp='mfxls1234',
    ...     run='150'
    ... )
    
    >>> # Perform clustered scan for fine calibration
    >>> timing.series(
    ...     pv=timing.lxt_fast1,
    ...     start=-200e-15,
    ...     end=200e-15,
    ...     steps=40,
    ...     events_per_step=500,
    ...     cluster=True,
    ...     center=0.0,
    ...     randomize=True,
    ...     sample='lysozyme',
    ...     daq_num=2
    ... )

    See Also
    --------
    pcdsdevices.lxe.LaserTiming : Laser timing motor control
    pcdsdevices.pseudopos.SyncAxis : Synchronized multi-axis control
    pcdsdevices.usb_encoder.UsDigitalUsbEncoder : Position encoder interface
    mfx.devices.LaserShutter : Laser shutter control

    References
    ----------
    .. [1] LCLS MFX Beamline Documentation
       https://confluence.slac.stanford.edu/display/PCDS/MFX
    """

def scan:
"""
        Execute timing calibration scan series.

        Performs a systematic scan of timing delays to calibrate laser-X-ray
        synchronization by stepping through time delays and collecting events
        at each position.

        Parameters
        ----------
        pv : object
            Process variable (timing motor) to scan. Should have callable
            interface for setting position.
        start : float
            Starting time delay value in seconds.
        end : float
            Ending time delay value in seconds.
        steps : int
            Number of delay steps in the scan.
        events_per_step : int
            Number of DAQ events to collect at each step.
        sample : str, optional
            Sample name for data logging, by default None.
        tag : str, optional
            Additional tag for run identification, by default None.
        run_number : int, optional
            Specific run number to assign. If None, auto-increments,
            by default None.
        record : bool, optional
            Whether to record data to eLog and database, by default True.
        inspire : bool, optional
            Enable inspire mode for data collection, by default False.
        daq_num : int, optional
            DAQ station number (1 or 2), by default 2.
        cluster : bool, optional
            Whether to cluster scan points around center position,
            by default False.
        center : float, optional
            Center position for clustered scanning. Required if cluster=True,
            by default None.
        randomize : bool, optional
            Randomize order of scan positions, by default False.
        delay : bool, optional
            Include additional delay scan, by default False.
        analysis : bool, optional
            Prompt for automatic analysis after scan completion,
            by default True.

        Returns
        -------
        None
            Executes scan and optionally triggers analysis.

        Raises
        ------
        ValueError
            If cluster=True but center is None.
            If daq_num is not 1 or 2.

        Notes
        -----
        Scan Procedure:
        1. Records initial laser shutter states (shutters 1-5)
        2. Generates scan positions (linear, clustered, or randomized)
        3. For each position:
            - Moves timing motor to target delay
            - Collects specified number of events
            - Records shutter states
        4. Returns motor to original position
        5. Posts scan metadata to eLog if record=True
        6. Optionally launches analysis pipeline

        The scan records all shutter states and motor positions for each
        step to enable post-processing and correlation analysis.

        Clustering mode concentrates scan points around a center position
        for higher resolution characterization of timing features.

        Examples
        --------
        >>> timing = Timing()
        >>> # Linear scan
        >>> timing.series(
        ...     pv=timing.lxt_fast1,
        ...     start=-1e-12,
        ...     end=1e-12,
        ...     steps=20,
        ...     events_per_step=1000,
        ...     sample='water',
        ...     daq_num=2
        ... )

        >>> # Clustered scan around zero delay
        >>> timing.series(
        ...     pv=timing.lxt_fast1,
        ...     start=-2e-12,
        ...     end=2e-12,
        ...     steps=30,
        ...     events_per_step=500,
        ...     cluster=True,
        ...     center=0.0,
        ...     randomize=True
        ... )


def output
        """
        Analysis and output for timing scan data.

        Provides methods to analyze timing calibration data and generate plots
        on computing facilities (S3DF or NERSC).

        Parameters
        ----------
        user : str
            Username for remote computing facility authentication.
        facility : str, optional
            Computing facility to use for analysis, by default 'S3DF'.
            Options: 'S3DF' or 'NERSC'.
        exp : str, optional
            Experiment name/ID. If None, retrieves from current DAQ station,
            by default None.
        run : str, optional
            Run number to analyze. If None, retrieves from current DAQ station,
            by default None.
        daq_num : int, optional
            DAQ station number (1 or 2), by default 2.
            Station 0 corresponds to daq_num=2, station 1 to daq_num=1.

        Returns
        -------
        None
            Executes remote analysis script and displays results.

        Raises
        ------
        ValueError
            If daq_num is not 1 or 2.

        Notes
        -----
        Analysis Process:
        1. Retrieve data from DAQ files on remote facility
        2. Extract detector intensities vs. time
        3. Identify timing correlation peaks
        4. Compare to reference timing
        5. Calculate timing offset
        6. Generate calibration plots

        For NERSC facility, requires valid sshproxy token. The method will
        prompt for token renewal if needed.

        The analysis script path is:
        /sdf/group/lcls/ds/tools/mfx/scripts/analyze_timing.py

        Examples
        --------
        >>> timing = Timing()
        >>> timing.output(
        ...     user='myuser',
        ...     facility='S3DF',
        ...     exp='mfxls1234',
        ...     run='100',
        ...     daq_num=2
        ... )

See following commit summaries:
dc1f157 (HEAD -> 281-dev-timing-code, origin/281-dev-timing-code) add more docstrings
cae7d55 added formated doc strings
678299b removed shutter status func
6ad33eb add timing check
dcb553d add timing reload
1830fd9 add shutter status to elog and open/close arg
b44cdfb fixed the low end of clustering
1cfec15 add analysis arg and fixed center in scan
dfa7a3e Centering fixed
17ad846 Fix float error
8f7bb0b Add center of cluster arg
cd9fc99 added delay and list scans
870ac79 increased MFX_prefocus_energy_range
190239c fixed no prefocus for try_combo
91e764b made absolute
84f9c30 fix elog posting
6d63f40 fixed logger message
b4933ad update qadc roi
355fe43 Merge branch '281-dev-timing-code' of github.com:pcdshub/mfx into 281-dev-timing-code
5903383 fixed pv config
15db9b3 fixed source s3df
ec1c1fc fixed 2d array issue
f27ae73 Merge branch '281-dev-timing-code' of github.com:pcdshub/mfx into 281-dev-timing-code
28d4415 fixed proxy jump
b416b66 fixed fitting
77dbdb4 first draft working timing analysis
505dbb0 fixed timing loading and pv record
779cd38 Added timing scan code