### PR TITLE
Add k_xas_scan method and commissioning runbook

### DIFF
--- a/docs/beamtime_20260624.md
+++ b/docs/beamtime_20260624.md
@@ -36,7 +36,7 @@ plain_scan = np.arange(7095, 7196, 1.0)  # 101 points, 7095–7195 eV
 summary = exafs.k_xas_scan(
     k_positions=plain_scan,
     dccm_offsets=[0.0],          # DCCM parked at K center
-    dwell_time=1.0,              # 1s per point (10 shots at 10 Hz)
+    dwell_time=3.0,              # 3s per point (30 shots at 10 Hz)
     k_move_mode='pause',         # pause DAQ during K move
     track_feespec=True,          # FEE spec tracks K
     crystal_angle_offset=0.0,    # adjust if FEE cal is off
@@ -50,7 +50,7 @@ summary = exafs.k_xas_scan(
 summary = exafs.k_xas_scan(
     k_positions=plain_scan,
     dccm_offsets=[0.0],
-    dwell_time=1.0,
+    dwell_time=3.0,
     k_move_mode='concurrent',    # don't pause DAQ during K move
     track_feespec=True,
     record=True,
@@ -83,7 +83,7 @@ roi_scan = np.array([
 summary = exafs.k_xas_scan(
     k_positions=roi_scan,
     dccm_offsets=[0.0],
-    dwell_time=1.0,
+    dwell_time=3.0,
     k_move_mode='pause',
     track_feespec=True,
     record=True,
@@ -105,7 +105,7 @@ summary = exafs.k_xas_scan(
     k_step_eV=4.0,               # K moves every 4 eV
     dccm_window_eV=2.0,          # DCCM scans +/-2 eV around K
     dccm_step_eV=1.0,            # 1 eV DCCM steps within window
-    dwell_time=1.0,
+    dwell_time=3.0,
     k_move_mode='pause',
     track_feespec=True,
     record=True,
@@ -122,7 +122,7 @@ summary = exafs.k_xas_scan(
     k_step_eV=2.0,               # K moves every 2 eV (seamless tiling)
     dccm_window_eV=1.0,          # +/-1 eV around K
     dccm_step_eV=0.5,            # 0.5 eV DCCM steps
-    dwell_time=1.0,
+    dwell_time=3.0,
     k_move_mode='pause',
     track_feespec=True,
     record=True,
@@ -150,6 +150,30 @@ exafs.k_xas_scan(
     sample='Fe_foil_stochastic',
 )
 ```
+
+**Multi-position variant (shift 2):** Step K to each side of the edge to fill
+in statistics more uniformly across the SASE bandwidth. NOT YET IMPLEMENTED
+as a single automated call — run manually for now:
+
+```python
+# Collect at multiple K positions bracketing the edge
+# Each position collects pink beam centered there
+for k_eV, label in [(7105.0, 'below_edge'),
+                     (7112.0, 'at_edge'),
+                     (7119.0, 'above_edge')]:
+    exafs.k_xas_scan(
+        k_positions=[k_eV],
+        dccm_offsets=[0.0],
+        dwell_time=300.0,        # 5 min per position
+        k_move_mode='pause',
+        track_feespec=True,
+        record=True,
+        sample=f'Fe_foil_stochastic_{label}',
+    )
+```
+
+TODO: Implement as a dedicated `stochastic_rixs_scan(k_centers=[...], dwell=300)`
+method that automates stepping through multiple K park positions in a single call.
 
 ---
 
@@ -198,16 +222,28 @@ exafs.k_xas_scan(
 
 ## Shift Schedule
 
+### Priorities
+1. **2–4 PM ACR coordination is FIXED** (non-negotiable, accelerator staff scheduled)
+2. **Wolter first-light is high priority** — takes as long as needed
+3. **Stochastic RIXS requires Wolter + von Hamos working** — most flexible
+
+### Dependencies
+- Stochastic XANES/RIXS needs: Wolter focused, von Hamos aligned (Fe Ka, LiNbO3 (23-4)), SEER aligned (Ge(440))
+- K scan commissioning needs: FEE spec working, Fe foil in beam (no Wolter/von Hamos required)
+- Wolter work can proceed independently of spectrometers
+
 ### Both Shifts (6/24 and 6/26)
 
-| Time | Activity | Recipe |
-|------|----------|--------|
-| 06:00–08:00 | Setup, beam delivery, alignment | — |
-| 08:00–10:00 | Wolter first-light & knife-edge scans | Recipe 5 |
-| 10:00–12:00 | Stochastic XANES/RIXS (pink beam, Fe foil) | Recipe 4 |
-| 12:00–14:00 | Stochastic XANES/RIXS (ferricyanide) | Recipe 4 |
-| 14:00–16:00 | **Accelerator coordination: K scan commissioning** | Recipes 1–3 |
-| 16:00–18:00 | Follow-up measurements / repeat best configs | — |
+| Time | Activity | Notes |
+|------|----------|-------|
+| 06:00–08:00 | Setup, beam delivery, initial alignment | |
+| 08:00–14:00 | **Wolter first-light & knife-edge** (Recipe 5) | High priority, take time needed |
+| | **In parallel:** Align von Hamos on Fe Ka (LiNbO3 (23-4)) | Can proceed without Wolter beam |
+| | **In parallel:** Align SEER spectrometer (Ge(440)) | |
+| | If Wolter ready early: Stochastic RIXS (Recipe 4) | Requires Wolter + von Hamos + SEER |
+| | If Wolter not ready: K scan tests without Wolter (Recipes 1–3) | Only needs FEE spec + Fe foil |
+| **14:00–16:00** | **ACR coordination: K scan commissioning (FIXED)** | Recipes 1–3 |
+| 16:00–18:00 | Stochastic RIXS or repeat best K-scan configs | Depends on earlier progress |
 
 ### 2–4 PM K Scan Commissioning Plan (with accelerator control room)
 
@@ -348,7 +384,7 @@ Use `Exafs(simulate=True)` — hardware packages not needed for simulation.
 | `dccm_offsets` | DCCM points relative to K | `[0.0]` or `[-2,-1,0,1,2]` |
 | `dccm_window_eV` | Auto DCCM range (±) | 1.0 – 3.0 eV |
 | `k_move_mode` | DAQ behavior during K | `'pause'` or `'concurrent'` |
-| `dwell_time` | Collection time per point (s) | 1.0 – 5.0 |
+| `dwell_time` | Collection time per point (s) | 3.0 (default for 10 Hz, 30 shots) |
 | `track_feespec` | FEE spec follows K | `True` |
 | `crystal_angle_offset` | FEE cal tweak (deg) | 0.0 (adjust if needed) |
 | `record` | DAQ records data | `True` for real runs |

--- a/docs/beamtime_20260624.md
+++ b/docs/beamtime_20260624.md
@@ -7,9 +7,24 @@
 
 ---
 
-## Quick Reference: Executable Recipes
+## Table of Contents
 
-### Setup (start of each shift)
+| # | Section | Description |
+|---|---------|-------------|
+| 1 | [Executable Recipes](#1-executable-recipes) | Ready-to-run scan configurations |
+| 2 | [Shift Schedule](#2-shift-schedule) | Timeline, priorities, and dependencies |
+| 3 | [K Scan Commissioning Plan](#3-k-scan-commissioning-plan-2-4-pm) | ACR coordination testing sequence |
+| 4 | [Architecture](#4-architecture) | How `k_xas_scan` works internally |
+| 5 | [XRT Spectrometer Tracking](#5-xrt-spectrometer-tracking) | FEE spectrometer control and calibration |
+| 6 | [Troubleshooting](#6-troubleshooting) | Common issues and fixes |
+| 7 | [Parameter Reference](#7-parameter-reference) | All scan parameters at a glance |
+| 8 | [Recent Code Changes](#8-recent-code-changes) | What's new on the branch |
+
+---
+
+## 1. Executable Recipes
+
+### 1.1 Setup (start of each shift)
 
 ```python
 from mfx.exafs import Exafs  # https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L39
@@ -25,10 +40,31 @@ exafs = Exafs(simulate=True)
 
 ---
 
-### Recipe 1: Plain K Scan (1 eV steps, undulator moves every point)
+### 1.2 Recipe Summary
 
-K moves to each energy, DCCM stays at the K center. Tests undulator dead-time
-at 1 eV step size. Use during 2–4 PM accelerator coordination window.
+| Recipe | Name | K Mode | DCCM Mode | Use Case |
+|--------|------|--------|-----------|----------|
+| 1 | [Plain K Scan](#13-recipe-1-plain-k-scan) | Uniform 1 eV steps | Parked at center | Baseline dead-time measurement |
+| 2 | [ROI K Scan](#14-recipe-2-roi-k-scan) | Variable spacing | Parked at center | Resolve pre-edge features |
+| 3 | [DCCM Probes](#15-recipe-3-dccm-probes-around-k) | Large steps (2–4 eV) | Tiles window | Minimize undulator moves |
+| 4 | [Stochastic RIXS](#16-recipe-4-stochastic-xanesrixs) | Single position | Parked at center | Pink beam, offline sort |
+| 5 | [Wolter Knife-Edge](#17-recipe-5-wolter-lens-knife-edge-scans) | N/A | N/A | Focus characterization |
+| 6 | [FEE Cal Check](#18-recipe-6-fee-spectrometer-calibration-check) | Single position | Parked at center | Spectrometer alignment |
+
+---
+
+### 1.3 Recipe 1: Plain K Scan
+
+> **Purpose:** 1 eV steps, undulator moves every point. Tests undulator dead-time.  
+> **When:** 2–4 PM accelerator coordination window.
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| Energy range | 7095–7195 eV | Full Fe K-edge |
+| Step size | 1.0 eV | 101 points total |
+| DCCM | Parked (offset = 0) | Only K moves |
+| Dwell | 3.0 s | 30 shots at 10 Hz |
+| K move mode | `pause` | Clean dead-time measurement |
 
 ```python
 plain_scan = np.arange(7095, 7196, 1.0)  # 101 points, 7095–7195 eV
@@ -60,10 +96,17 @@ summary = exafs.k_xas_scan(
 
 ---
 
-### Recipe 2: ROI K Scan (variable spacing, undulator at every point)
+### 1.4 Recipe 2: ROI K Scan
 
-Fine steps at the edge (0.3 eV), coarse pre/post-edge. Designed to resolve
-the ferricyanide t2g pre-edge peak.
+> **Purpose:** Variable spacing — fine steps at the edge (0.3 eV), coarse pre/post-edge.  
+> **Target:** Resolve the ferricyanide t2g pre-edge peak.
+
+| Region | Energy Range (eV) | Step Size | Points |
+|--------|-------------------|-----------|--------|
+| Pre-edge | 7095–7106 | ~3 eV | 4 |
+| Edge (fine) | 7106.3–7115.9 | 0.3 eV | 33 |
+| Post-edge (coarse) | 7117–7145 | 1 eV | 29 |
+| EXAFS (k-spaced) | 7145.2–7194 | ~1.8–3 eV | 18 |
 
 ```python
 roi_scan = np.array([
@@ -93,11 +136,17 @@ summary = exafs.k_xas_scan(
 
 ---
 
-### Recipe 3: DCCM Probes Around K (minimize undulator moves)
+### 1.5 Recipe 3: DCCM Probes Around K
 
-K steps in larger increments; DCCM tiles a window around each K center.
-Reduces total undulator moves — useful if dead-time is irreducible.
+> **Purpose:** K steps in larger increments; DCCM tiles a window around each K center.  
+> **When:** Use if undulator dead-time is irreducible — minimizes total K moves.
 
+| Configuration | K step | DCCM window | DCCM step | Points per K | Total K moves |
+|---------------|--------|-------------|-----------|--------------|---------------|
+| Standard | 4.0 eV | +/- 2.0 eV | 1.0 eV | 5 | 26 |
+| Fine | 2.0 eV | +/- 1.0 eV | 0.5 eV | 5 | 51 |
+
+**Standard (4 eV K steps):**
 ```python
 summary = exafs.k_xas_scan(
     start_eV=7095,
@@ -114,7 +163,7 @@ summary = exafs.k_xas_scan(
 # Produces 5 DCCM points per K position: [-2, -1, 0, +1, +2] eV offsets
 ```
 
-**Narrower K steps for finer coverage:**
+**Fine (2 eV K steps, seamless tiling):**
 ```python
 summary = exafs.k_xas_scan(
     start_eV=7095,
@@ -132,14 +181,21 @@ summary = exafs.k_xas_scan(
 
 ---
 
-### Recipe 4: Stochastic XANES/RIXS (Pink Beam)
+### 1.6 Recipe 4: Stochastic XANES/RIXS
 
-Park undulator at Fe K-edge. FEE spec resolves incident spectrum shot-by-shot.
-Von Hamos resolves Fe Ka emission. SEER provides secondary beam energy readback.
-Analysis is offline (sort by FEE-measured incident energy).
+> **Purpose:** Park undulator at Fe K-edge. FEE spec resolves incident spectrum shot-by-shot.  
+> **Detectors:** Von Hamos resolves Fe Ka emission. SEER provides secondary beam energy readback.  
+> **Analysis:** Offline — sort by FEE-measured incident energy.
 
+| Parameter | Single position | Multi-position |
+|-----------|----------------|----------------|
+| K positions | 7112.0 eV (edge) | 7105, 7112, 7119 eV |
+| Dwell per position | 300 s (5 min) | 300 s each |
+| Total shots | 3000 | 9000 |
+| Automation | Single call | Manual loop (see below) |
+
+**Single-position (basic):**
 ```python
-# Park K at Fe edge, collect N shots
 exafs.k_xas_scan(
     k_positions=[7112.0],        # single K position at edge
     dccm_offsets=[0.0],          # DCCM at center of SASE distribution
@@ -156,8 +212,6 @@ in statistics more uniformly across the SASE bandwidth. NOT YET IMPLEMENTED
 as a single automated call — run manually for now:
 
 ```python
-# Collect at multiple K positions bracketing the edge
-# Each position collects pink beam centered there
 for k_eV, label in [(7105.0, 'below_edge'),
                      (7112.0, 'at_edge'),
                      (7119.0, 'above_edge')]:
@@ -172,14 +226,15 @@ for k_eV, label in [(7105.0, 'below_edge'),
     )
 ```
 
-TODO: Implement as a dedicated `stochastic_rixs_scan(k_centers=[...], dwell=300)`
-method that automates stepping through multiple K park positions in a single call.
+> **TODO:** Implement as a dedicated `stochastic_rixs_scan(k_centers=[...], dwell=300)`
+> method that automates stepping through multiple K park positions in a single call.
 
 ---
 
-### Recipe 5: Wolter Lens Knife-Edge Scans
+### 1.7 Recipe 5: Wolter Lens Knife-Edge Scans
 
-Standard bluesky relative scan for focus characterization:
+> **Purpose:** Standard bluesky relative scan for focus characterization.  
+> **Prerequisite:** Wire or knife-edge stage at IP.
 
 ```python
 from bluesky import plan_stubs as bps
@@ -197,13 +252,12 @@ stage. Check `hutch_python` namespace for available motors.
 
 ---
 
-### Recipe 6: FEE Spectrometer Calibration Check
+### 1.8 Recipe 6: FEE Spectrometer Calibration Check
 
-If the FEE spec doesn't track well, recalibrate crystal_angle_offset:
+> **Purpose:** Verify/correct FEE spectrometer crystal alignment.  
+> **When:** If FEE spec doesn't track well during K scans.
 
 ```python
-# Check current calibration visually:
-# Move to known energy, see if FEE spec catches the line
 exafs.k_xas_scan(
     k_positions=[7112.0],
     dccm_offsets=[0.0],
@@ -220,93 +274,379 @@ exafs.k_xas_scan(
 
 ---
 
-## Shift Schedule
+## 2. Shift Schedule
 
-### Priorities
-1. **2–4 PM ACR coordination is FIXED** (non-negotiable, accelerator staff scheduled)
-2. **Wolter first-light is high priority** — takes as long as needed
-3. **Stochastic RIXS requires Wolter + von Hamos working** — most flexible
+### 2.1 Priorities (ranked)
 
-### Dependencies
+| Priority | Activity | Constraint |
+|----------|----------|------------|
+| 1 (FIXED) | 2–4 PM ACR coordination | Non-negotiable, accelerator staff scheduled |
+| 2 (HIGH) | Wolter first-light | Takes as long as needed |
+| 3 (FLEX) | Stochastic RIXS | Requires Wolter + von Hamos + SEER working |
 
-**Von Hamos alignment:**
-- Full alignment requires focused beam from Wolter → Fe foil at IP
-- Rough alignment (crystal geometry, camera positioning) can proceed with unfocused beam
-- Cannot run simultaneously with Wolter knife-edge (wire in IP) or YAG pointing (YAG in IP)
+### 2.2 Dependencies and Mutual Exclusions
 
-**Wolter first-light:**
-- Needs wire at IP for knife-edge beam characterization
-- Needs YAG at IP for beam pointing
-- Wire/YAG at IP conflicts with Fe foil at IP (mutual exclusion)
+```
+                ┌──────────────────────────────────────────────────┐
+                │           Interaction Point (IP)                  │
+                │                                                  │
+                │   Only ONE of these at a time:                   │
+                │   ┌──────────┐ ┌──────────┐ ┌──────────┐       │
+                │   │ Fe foil  │ │   YAG    │ │   Wire   │       │
+                │   └──────────┘ └──────────┘ └──────────┘       │
+                └──────────────────────────────────────────────────┘
+                         │               │             │
+                         ▼               ▼             ▼
+               ┌──────────────┐  ┌─────────────┐  ┌────────────────┐
+               │ K scan comm. │  │ Wolter beam │  │ Wolter knife-  │
+               │ von Hamos    │  │ pointing    │  │ edge           │
+               │ (full align) │  │             │  │                │
+               └──────────────┘  └─────────────┘  └────────────────┘
+```
 
-**Mutual exclusions at IP:** Only one of {Fe foil, YAG screen, wire} can occupy the IP at a time. Coordinate swaps between Wolter characterization and von Hamos alignment.
+| Activity | Needs at IP | Can proceed without Wolter? | Notes |
+|----------|-------------|----------------------------|-------|
+| Von Hamos full alignment | Fe foil | No (needs focused beam) | Rough alignment OK with unfocused |
+| Von Hamos rough alignment | Nothing | Yes | Crystal geometry, camera positioning |
+| Wolter knife-edge | Wire | N/A | |
+| Wolter beam pointing | YAG | N/A | |
+| K scan commissioning | Fe foil | Yes | Only needs FEE spec — fallback activity |
+| Stochastic RIXS | Fe foil | No | Last priority — needs everything |
 
-**Stochastic XANES/RIXS:** Wolter focused + von Hamos aligned (Fe Ka, LiNbO3 (23-4)) + SEER aligned (Ge(440)). Last priority — requires everything working.
+### 2.3 Timeline (Both Shifts: 6/24 and 6/26)
 
-**K scan commissioning:**
-- Only needs FEE spec working (XRT spectrometer)
-- Can proceed even if Wolter and von Hamos are not ready — fallback activity
-- Fe foil at IP needed for signal, but not Wolter focus
-
-### Both Shifts (6/24 and 6/26)
+```
+06:00                    08:00                              14:00    16:00    18:00
+  │                        │                                 │        │        │
+  ├── Setup & alignment ──►├── Wolter first-light ─────────►│        │        │
+  │                        │   (HIGH PRIORITY)               │        │        │
+  │                        │                                 │        │        │
+  │                        ├── ∥ Von Hamos align (parallel) ─┤        │        │
+  │                        │                                 │        │        │
+  │                        ├── ∥ SEER align (parallel) ──────┤        │        │
+  │                        │                                 │        │        │
+  │                        │   If Wolter ready early:        │        │        │
+  │                        │   → Stochastic RIXS (Recipe 4)  │        │        │
+  │                        │   If Wolter NOT ready:          │        │        │
+  │                        │   → K scan tests (Recipes 1–3)  │        │        │
+  │                        │                                 │        │        │
+  │                        │                          ┌──────┴────────┐        │
+  │                        │                          │ ACR K-SCAN    │        │
+  │                        │                          │ COMMISSIONING │        │
+  │                        │                          │ (FIXED 2–4PM) │        │
+  │                        │                          │ Recipes 1–3   │        │
+  │                        │                          └──────┬────────┘        │
+  │                        │                                 │        │        │
+  │                        │                                 ├────────┤        │
+  │                        │                                 │ Wrap-up│        │
+  │                        │                                 │ Best   │        │
+  │                        │                                 │ configs│        │
+  │                        │                                 └────────┴────────┘
+```
 
 | Time | Activity | Notes |
 |------|----------|-------|
 | 06:00–08:00 | Setup, beam delivery, initial alignment | |
 | 08:00–14:00 | **Wolter first-light & knife-edge** (Recipe 5) | High priority, take time needed |
-| | **In parallel:** Align von Hamos on Fe Ka (LiNbO3 (23-4)) | Can proceed without Wolter beam |
-| | **In parallel:** Align SEER spectrometer (Ge(440)) | |
+| | *In parallel:* Align von Hamos on Fe Ka (LiNbO3 (23-4)) | Can proceed without Wolter beam |
+| | *In parallel:* Align SEER spectrometer (Ge(440)) | |
 | | If Wolter ready early: Stochastic RIXS (Recipe 4) | Requires Wolter + von Hamos + SEER |
-| | If Wolter not ready: K scan tests without Wolter (Recipes 1–3) | Only needs FEE spec + Fe foil |
+| | If Wolter not ready: K scan tests (Recipes 1–3) | Only needs FEE spec + Fe foil |
 | **14:00–16:00** | **ACR coordination: K scan commissioning (FIXED)** | Recipes 1–3 |
 | 16:00–18:00 | Stochastic RIXS or repeat best K-scan configs | Depends on earlier progress |
 
-### 2–4 PM K Scan Commissioning Plan (with accelerator control room)
+---
 
-**Goals to test in order:**
+## 3. K Scan Commissioning Plan (2–4 PM)
 
-1. **Baseline timing**: Run Recipe 1 (plain scan, pause mode). Measure dead-time per K step.
-2. **Step-size independence**: Run Recipe 1 with `k_step_eV` of 1, 2, 5, 10 eV. Compare dead-times.
-3. **Concurrent collection**: Run Recipe 1 concurrent mode. Compare data quality in-transit vs settled.
-4. **Wider deadbands**: Accelerator adjusts gantry deadbands. Repeat baseline scan.
-5. **Phase shifter preloading**: Accelerator preloads positions. Repeat baseline scan.
-6. **DCCM windowing**: If dead-time is irreducible, test Recipe 3 to minimize K moves.
+> **Context:** Joint session with accelerator control room (ACR). Non-negotiable time slot.
+
+### 3.1 Testing Sequence
+
+| Step | Test | Recipe | What to measure | Pass criteria |
+|------|------|--------|-----------------|---------------|
+| 1 | Baseline timing | 1 (pause) | Dead-time per K step | Establish baseline |
+| 2 | Step-size independence | 1 (varied) | Dead-time vs step size (1, 2, 5, 10 eV) | Dead-time independent of step |
+| 3 | Concurrent collection | 1 (concurrent) | Data quality in-transit vs settled | Usable in-transit data |
+| 4 | Wider deadbands | 1 (pause) | Dead-time after ACR adjusts gantry | Reduced dead-time |
+| 5 | Phase shifter preloading | 1 (pause) | Dead-time with preloaded positions | Further reduction |
+| 6 | DCCM windowing | 3 | Coverage with fewer K moves | Good spectra, fewer moves |
+
+### 3.2 Decision Tree
+
+```
+Start: Run Recipe 1 (pause mode, 1 eV steps)
+  │
+  ├─ Dead-time < 5s per step?
+  │   ├─ YES → Proceed with Recipe 1 for all scans
+  │   └─ NO ──┐
+  │            ▼
+  │   Ask ACR: widen gantry deadbands
+  │     │
+  │     ├─ Dead-time reduced?
+  │     │   ├─ YES → Re-baseline, continue
+  │     │   └─ NO ──┐
+  │     │            ▼
+  │     │   Ask ACR: preload phase shifter
+  │     │     │
+  │     │     ├─ Improved?
+  │     │     │   ├─ YES → Re-baseline, continue
+  │     │     │   └─ NO → Switch to Recipe 3 (DCCM probes)
+  │     │     │           or concurrent mode (Recipe 1)
+```
 
 ---
 
-## Recent Code Changes
+## 4. Architecture
 
-### 1. [`k_xas_scan`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L1696) method (new)
+### 4.1 `k_xas_scan` Flow Diagram
 
-**File:** [`mfx/exafs.py`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py)  
-**Commit:** [`8a13e51`](https://github.com/pcdshub/mfx/commit/8a13e51) + subsequent
+```
+k_xas_scan()
+│
+├─ 1. Compute K positions
+│     ├─ From start/end/step (uniform)
+│     └─ OR from k_positions array (custom)
+│
+├─ 2. Compute DCCM offsets
+│     ├─ From window/step (auto)
+│     └─ OR from dccm_offsets list (custom)
+│
+├─ 3. Store initial positions (for restore)
+│
+└─ 4. For each run:
+     ├─ Setup DAQ (record if enabled)
+     │
+     └─ For each K position:
+         │
+         ├─── [pause mode] ─────────────────────────────────────┐
+         │    1. Pause DAQ                                       │
+         │    2. Move FEE spec → target θ, 2θ, Y                │
+         │    3. Move K (undulator)                              │
+         │    4. Fine-tune FEE spec crystal angle                │
+         │    5. Resume DAQ                                      │
+         │                                                       │
+         ├─── [concurrent mode] ────────────────────────────────┐
+         │    1. Move FEE spec                                   │
+         │    2. Request K move (non-blocking)                   │
+         │    3. Begin DCCM stepping immediately                 │
+         │                                                       │
+         └─ For each DCCM offset:
+              ├─ Move DCCM to (K + offset) / 1000 keV
+              │   └─ Crystal only — NO vernier!
+              ├─ Check beam (if flux_threshold set)
+              ├─ Dwell (collect data)
+              └─ Record summary point
+     │
+     └─ Return to initial positions
+```
+
+> **Key constraint:** DCCM moves are crystal-only (`self.dccm.energy.move()`).
+> No vernier PV is touched. This is critical for 10 Hz secondary program operation.
+
+### 4.2 Mode Comparison
+
+| Aspect | `pause` mode | `concurrent` mode |
+|--------|-------------|-------------------|
+| DAQ during K move | Paused | Running |
+| Data during transit | None | Collected (may be noisy) |
+| FEE spec state | Fully settled before resume | Settled before K requested |
+| Dead-time impact | Full wait | Zero wait (but data quality varies) |
+| Best for | Clean measurements, commissioning | Production scans if dead-time > 10s |
+
+---
+
+## 5. XRT Spectrometer Tracking
+
+### 5.1 Overview
+
+The XRT spectrometer ([`XRTspec`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L14) in [`mfx/xrt_spec.py`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py)) is a Si(111) Bragg
+spectrometer in the FEE (Front-End Enclosure). It diffracts from the
+transmitted beam upstream of the hutch and provides a shot-by-shot
+measurement of the incident photon energy spectrum.
+
+> **Why it matters:** During a K scan the undulator changes energy at each step.
+> The XRT spectrometer must track so that the diffracted beam stays on its camera.
+> Without tracking, the Bragg condition is no longer satisfied and the spectrometer sees nothing.
+
+### 5.2 Tracking Sequence
+
+| Step | Function | What it does |
+|------|----------|--------------|
+| 1 | [`move_feespec_energy(E)`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L267) | Full repositioning (theta, 2-theta, camera Y) |
+| 2 | [`check_feespec_crystal_angle(E)`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L321) | Fine correction after K settles |
+
+**`move_feespec_energy(E)` details:**
+
+```
+1. Stop camera acquisition (avoid motion blur)
+2. Store current positions (rollback reference)
+3. Compute targets via get_feespec_positions()
+4. Move crystal angle (θ), camera angle (2θ), camera Y
+5. Check XRT transmission alarm
+   └─ If alarm → rollback to stored positions
+```
+
+**`check_feespec_crystal_angle(E)` details:**
+
+```
+1. Compare current θ to calculated target
+2. Only move if difference > 0.01°
+3. Restart camera acquisition
+4. Check XRT transmission alarm
+```
+
+### 5.3 Calibration Formulas
+
+Empirical calibration for Si(111) at MFX (in [`mfx/xrt_spec.py`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L235)):
+
+| Axis | Formula | Units |
+|------|---------|-------|
+| Crystal angle (theta) | `140.08 - 21.2*E + 1.02*E^2` | degrees |
+| Camera angle (2-theta) | `-1.91 + 2*theta` | degrees |
+| Camera Y | `-4.92 - 0.111*E` | mm |
+
+where E is photon energy in **keV** (e.g. 7.112 for Fe K-edge).
+
+### 5.4 `crystal_angle_offset`
+
+| Property | Value |
+|----------|-------|
+| What it shifts | Crystal angle only (not camera angle or Y) |
+| Effect | Moves where diffracted line lands on camera |
+| Positive value | Increases crystal angle |
+| Default | 0.0 |
+| Adjust via | Recipe 6 (empirical) |
+
+### 5.5 Safety: XRT Transmission Alarm
+
+After every move, the code reads `XRT:HXS:TRNS.SEVR`:
+
+| Alarm state | Action |
+|-------------|--------|
+| `NO_ALARM` | Continue normally |
+| Any other severity | **Rollback** — return to previous position |
+
+This prevents the crystal from blocking the beam or scattering into optics in a bad configuration.
+
+### 5.6 Tracking in the K Scan Loop
+
+```
+┌─────────────── PAUSE MODE ───────────────┐    ┌────────── CONCURRENT MODE ──────────┐
+│                                           │    │                                     │
+│  1. Pause DAQ                             │    │  1. move_feespec_energy(k_keV)      │
+│  2. move_feespec_energy(k_keV)            │    │  2. Request K move (non-blocking)   │
+│     └─ full move: θ, 2θ, Y               │    │  3. Begin DCCM stepping immediately │
+│  3. Move undulator K                      │    │                                     │
+│  4. check_feespec_crystal_angle(k_keV)    │    │  Note: FEE spec already at target   │
+│     └─ fine-tune θ after settle           │    │  → incident energy readback valid   │
+│  5. Resume DAQ                            │    │    even during K transit             │
+│                                           │    │                                     │
+│  Spec fully settled before data collected │    │  Early DCCM points may have K in    │
+│                                           │    │  transit                             │
+└───────────────────────────────────────────┘    └─────────────────────────────────────┘
+```
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| "DAQ is in error state" | DAQ not clean before scan | Check DAQ GUI, clear errors |
+| FEE spec not tracking | Bad `crystal_angle_offset` | Run Recipe 6, adjust offset |
+| FEE spec not tracking | Camera not acquiring | Check `CAMR:FEE1:441:Acquire` PV |
+| K move takes > 30s | Undulator dead-time | See escalation ladder below |
+| Import errors offline | Hardware packages missing | Use `Exafs(simulate=True)` |
+
+### 6.1 K Move Dead-Time Escalation
+
+```
+Observed dead-time > acceptable threshold
+  │
+  ├─ Step 1: Ask ACR to widen gantry deadbands
+  │     └─ Re-measure
+  │
+  ├─ Step 2: Ask ACR to preload phase shifter positions
+  │     └─ Re-measure
+  │
+  └─ Step 3: Switch to concurrent mode (collect during transit)
+        └─ Accept some data quality tradeoff
+```
+
+---
+
+## 7. Parameter Reference
+
+### 7.1 Scan Configuration
+
+| Parameter | Type | What it controls | Typical values |
+|-----------|------|-----------------|----------------|
+| `k_positions` | array | Custom K energy array (eV) | `np.arange(7095, 7196, 1.0)` or ROI array |
+| `start_eV` | float | Auto-generate K range start | 7095 |
+| `end_eV` | float | Auto-generate K range end | 7195 |
+| `k_step_eV` | float | Uniform K spacing | 1.0 – 10.0 eV |
+| `dccm_offsets` | list | DCCM points relative to K | `[0.0]` or `[-2,-1,0,1,2]` |
+| `dccm_window_eV` | float | Auto DCCM range (plus/minus) | 1.0 – 3.0 eV |
+| `dccm_step_eV` | float | DCCM step within window | 0.5 – 1.0 eV |
+
+### 7.2 Execution Control
+
+| Parameter | Type | What it controls | Typical values |
+|-----------|------|-----------------|----------------|
+| `k_move_mode` | str | DAQ behavior during K move | `'pause'` or `'concurrent'` |
+| `dwell_time` | float | Collection time per point (s) | 3.0 (30 shots at 10 Hz) |
+| `track_feespec` | bool | FEE spec follows K | `True` |
+| `crystal_angle_offset` | float | FEE cal tweak (deg) | 0.0 (adjust if needed) |
+| `record` | bool | DAQ records data | `True` for real runs |
+| `simulate` | bool | Offline testing (no hardware) | `True` for dry-run |
+| `sample` | str | Sample label in metadata | `'Fe_foil'`, `'ferricyanide'` |
+
+---
+
+## 8. Recent Code Changes
+
+### 8.1 Summary
+
+| Change | Commit | Key Impact |
+|--------|--------|-----------|
+| `k_xas_scan` method (new) | [`8a13e51`](https://github.com/pcdshub/mfx/commit/8a13e51) | K-primary scanning mode |
+| Energy rounding/dedup | [`70ba850`](https://github.com/pcdshub/mfx/commit/70ba850) | 0.1 eV rounding, no duplicates, sorted |
+| Offline simulation | Same series | `simulate=True` works without EPICS |
+
+### 8.2 `k_xas_scan` Method
+
+**File:** [`mfx/exafs.py`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py) | **Line:** [`L1696`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L1696)
 
 K-primary scanning mode where the undulator is the primary axis and DCCM
-tiles around each K position. Key features:
+tiles around each K position.
 
-- **No vernier requests** — uses `dccm.energy` (crystal only), safe for secondary program
-- **Two K move modes**: `'pause'` (stop DAQ, move, resume) and `'concurrent'` (move during collection)
-- **Custom K positions**: pass `k_positions=array` for non-uniform spacing
-- **DCCM window**: configurable offsets around each K center
-- **FEE spec tracking**: moves spectrometer crystal at each K step ([`XRTspec`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L14))
+| Feature | Description |
+|---------|-------------|
+| No vernier requests | Uses `dccm.energy` (crystal only), safe for secondary program |
+| Two K move modes | `'pause'` (stop DAQ, move, resume) and `'concurrent'` (move during collection) |
+| Custom K positions | Pass `k_positions=array` for non-uniform spacing |
+| DCCM window | Configurable offsets around each K center |
+| FEE spec tracking | Moves spectrometer crystal at each K step ([`XRTspec`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L14)) |
 
-### 2. Energy rounding/deduplication
+### 8.3 Energy Rounding/Deduplication
 
 **Commit:** [`70ba850`](https://github.com/pcdshub/mfx/commit/70ba850)
 
-All energy arrays are now:
-- Rounded to 0.1 eV
-- Deduplicated (no repeated energy points)
-- Sorted ascending
+All energy arrays are now processed through:
 
-Applies to both [`build_energy_range()`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L2164) (used by [`long_escan`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L1385)) and [`k_xas_scan`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L1696).
+| Step | Operation | Purpose |
+|------|-----------|---------|
+| 1 | Round to 0.1 eV | Avoid floating-point noise |
+| 2 | Deduplicate | No repeated energy points |
+| 3 | Sort ascending | Monotonic scan direction |
 
-### 3. Offline simulation support
+Applies to both [`build_energy_range()`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L2164) and [`k_xas_scan`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L1696).
 
-**Same commit series**
+### 8.4 Offline Simulation
 
-[`Exafs(simulate=True)`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L39) now works without EPICS, DAQ, or any hardware packages.
-Uses lightweight mock motors. Useful for testing scan configurations before beam:
+[`Exafs(simulate=True)`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L39) works without EPICS, DAQ, or any hardware packages.
+Uses lightweight mock motors.
 
 ```python
 exafs = Exafs(simulate=True)
@@ -314,159 +654,3 @@ summary = exafs.k_xas_scan(k_positions=roi_scan, dccm_offsets=[0.0],
     dwell_time=0.01, simulate=True)
 print(f"{len(summary)} points, range: {summary[0]['dccm_energy_eV']}-{summary[-1]['dccm_energy_eV']} eV")
 ```
-
----
-
-## Architecture: How [`k_xas_scan`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L1696) Works
-
-```
-k_xas_scan()
-│
-├─ Compute K positions (from start/end/step OR custom array)
-├─ Compute DCCM offsets (from window/step OR custom list)
-├─ Store initial positions
-│
-└─ For each run:
-    ├─ Setup DAQ (record if enabled)
-    │
-    └─ For each K position:
-        ├─ Move K (pause or concurrent mode)
-        │   ├─ [pause]: pause DAQ → move FEE spec → move K → verify FEE → resume DAQ
-        │   └─ [concurrent]: move FEE spec → request K (non-blocking)
-        │
-        └─ For each DCCM offset:
-            ├─ Move DCCM to (K + offset) / 1000 keV [crystal only, no vernier]
-            ├─ Check beam (if flux_threshold set)
-            ├─ Dwell (collect data)
-            └─ Record summary point
-    │
-    └─ Return to initial positions
-```
-
-**Key constraint:** DCCM moves are crystal-only (`self.dccm.energy.move()`).
-No vernier PV is touched. This is critical for 10 Hz secondary program operation.
-
----
-
-## XRT Spectrometer Tracking
-
-The XRT spectrometer ([`XRTspec`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L14) in [`mfx/xrt_spec.py`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py)) is a Si(111) Bragg
-spectrometer in the FEE (Front-End Enclosure). It diffracts from the
-transmitted beam upstream of the hutch and provides a shot-by-shot
-measurement of the incident photon energy spectrum.
-
-### Why it matters for K scanning
-
-During a K scan the undulator changes energy at each step. The XRT
-spectrometer must track so that the diffracted beam stays on its camera.
-Without tracking, the Bragg condition is no longer satisfied and the
-spectrometer sees nothing. With `track_feespec=True` the scan loop
-automatically repositions the spectrometer at every K step.
-
-### How tracking works
-
-At each K step (energy E in keV):
-
-1. **[`move_feespec_energy(E)`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L267)** — full repositioning:
-   - Stops camera acquisition (avoids motion blur)
-   - Stores current positions as rollback reference
-   - Computes target positions via [`get_feespec_positions()`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L117)
-   - Moves crystal angle (θ), camera angle (2θ), and camera Y
-   - Checks XRT transmission alarm — rolls back if alarm fires
-
-2. **[`check_feespec_crystal_angle(E)`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L321)** — fine correction after K settles:
-   - Compares current crystal angle to calculated target
-   - Only moves if difference > 0.01°
-   - Restarts camera acquisition after move
-   - Also checks XRT transmission
-
-### Calibration formulas
-
-Empirical calibration for Si(111) at MFX (in [`mfx/xrt_spec.py`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L235)):
-
-```
-crystal_angle (θ)  = 140.08 − 21.2·E + 1.02·E²    [degrees]
-camera_angle  (2θ) = −1.91 + 2·crystal_angle       [degrees]
-camera_y           = −4.92 − 0.111·E                [mm]
-```
-
-where E is photon energy in keV (e.g. 7.112 for Fe K-edge).
-
-### crystal_angle_offset
-
-`crystal_angle_offset` adds a constant to the crystal angle without
-changing the camera angle or camera Y. This shifts where the diffracted
-line lands on the camera. Use it to correct systematic calibration drift.
-
-- Positive values increase the crystal angle
-- Only affects the crystal; camera geometry unchanged
-- Adjust if the spectral line is off-center on the FEE camera
-- Start with 0.0, tweak empirically (Recipe 6)
-
-### Safety
-
-After every move, the code reads `XRT:HXS:TRNS.SEVR`. If the alarm
-severity is anything other than `NO_ALARM`, the spectrometer returns to
-its previous position. This prevents the crystal from blocking the beam
-or scattering into optics in a bad configuration.
-
-### Sequence in the K scan loop
-
-```
-For each K position:
-  [pause mode]
-    1. Pause DAQ
-    2. move_feespec_energy(k_keV)    ← full move (θ, 2θ, Y)
-    3. Move undulator K
-    4. check_feespec_crystal_angle(k_keV)  ← fine-tune θ after settle
-    5. Resume DAQ
-
-  [concurrent mode]
-    1. move_feespec_energy(k_keV)
-    2. Request K move (non-blocking)
-    3. Begin DCCM stepping immediately
-```
-
-In pause mode the spectrometer is fully settled before data collection
-resumes. In concurrent mode, early DCCM points may be collected while
-the undulator is still in transit — the spectrometer is already at the
-target position, so incident energy readback remains valid.
-
----
-
-## Troubleshooting
-
-### "DAQ is in error state"
-DAQ must be in a clean state before scanning. Check DAQ GUI, clear errors.
-
-### FEE spec not tracking
-- Check `crystal_angle_offset` value
-- Verify FEE camera is acquiring (`CAMR:FEE1:441:Acquire`)
-- Run calibration check (Recipe 6)
-
-### K move takes >30s
-This is the known dead-time issue. Log the timing and try:
-1. Ask ACR to widen gantry deadbands
-2. Ask ACR to preload phase shifter positions
-3. Switch to concurrent mode to collect during transit
-
-### Import errors offline
-Use `Exafs(simulate=True)` — hardware packages not needed for simulation.
-
----
-
-## Key Parameters Quick Reference
-
-| Parameter | What it controls | Typical values |
-|-----------|-----------------|----------------|
-| `k_positions` | Custom K energy array (eV) | `np.arange(7095, 7196, 1.0)` or ROI array |
-| `start_eV` / `end_eV` | Auto-generate K range | 7095 / 7195 |
-| `k_step_eV` | Uniform K spacing | 1.0 – 10.0 eV |
-| `dccm_offsets` | DCCM points relative to K | `[0.0]` or `[-2,-1,0,1,2]` |
-| `dccm_window_eV` | Auto DCCM range (±) | 1.0 – 3.0 eV |
-| `k_move_mode` | DAQ behavior during K | `'pause'` or `'concurrent'` |
-| `dwell_time` | Collection time per point (s) | 3.0 (default for 10 Hz, 30 shots) |
-| `track_feespec` | FEE spec follows K | `True` |
-| `crystal_angle_offset` | FEE cal tweak (deg) | 0.0 (adjust if needed) |
-| `record` | DAQ records data | `True` for real runs |
-| `simulate` | Offline testing | `True` for dry-run |

--- a/docs/beamtime_20260624.md
+++ b/docs/beamtime_20260624.md
@@ -12,7 +12,7 @@
 ### Setup (start of each shift)
 
 ```python
-from mfx.exafs import Exafs
+from mfx.exafs import Exafs  # https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L39
 import numpy as np
 
 exafs = Exafs(simulate=False)
@@ -228,9 +228,25 @@ exafs.k_xas_scan(
 3. **Stochastic RIXS requires Wolter + von Hamos working** — most flexible
 
 ### Dependencies
-- Stochastic XANES/RIXS needs: Wolter focused, von Hamos aligned (Fe Ka, LiNbO3 (23-4)), SEER aligned (Ge(440))
-- K scan commissioning needs: FEE spec working, Fe foil in beam (no Wolter/von Hamos required)
-- Wolter work can proceed independently of spectrometers
+
+**Von Hamos alignment:**
+- Full alignment requires focused beam from Wolter → Fe foil at IP
+- Rough alignment (crystal geometry, camera positioning) can proceed with unfocused beam
+- Cannot run simultaneously with Wolter knife-edge (wire in IP) or YAG pointing (YAG in IP)
+
+**Wolter first-light:**
+- Needs wire at IP for knife-edge beam characterization
+- Needs YAG at IP for beam pointing
+- Wire/YAG at IP conflicts with Fe foil at IP (mutual exclusion)
+
+**Mutual exclusions at IP:** Only one of {Fe foil, YAG screen, wire} can occupy the IP at a time. Coordinate swaps between Wolter characterization and von Hamos alignment.
+
+**Stochastic XANES/RIXS:** Wolter focused + von Hamos aligned (Fe Ka, LiNbO3 (23-4)) + SEER aligned (Ge(440)). Last priority — requires everything working.
+
+**K scan commissioning:**
+- Only needs FEE spec working (XRT spectrometer)
+- Can proceed even if Wolter and von Hamos are not ready — fallback activity
+- Fe foil at IP needed for signal, but not Wolter focus
 
 ### Both Shifts (6/24 and 6/26)
 
@@ -260,10 +276,10 @@ exafs.k_xas_scan(
 
 ## Recent Code Changes
 
-### 1. `k_xas_scan` method (new)
+### 1. [`k_xas_scan`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L1696) method (new)
 
-**File:** `mfx/exafs.py`  
-**Commit:** `8a13e51` + subsequent
+**File:** [`mfx/exafs.py`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py)  
+**Commit:** [`8a13e51`](https://github.com/pcdshub/mfx/commit/8a13e51) + subsequent
 
 K-primary scanning mode where the undulator is the primary axis and DCCM
 tiles around each K position. Key features:
@@ -272,24 +288,24 @@ tiles around each K position. Key features:
 - **Two K move modes**: `'pause'` (stop DAQ, move, resume) and `'concurrent'` (move during collection)
 - **Custom K positions**: pass `k_positions=array` for non-uniform spacing
 - **DCCM window**: configurable offsets around each K center
-- **FEE spec tracking**: moves spectrometer crystal at each K step
+- **FEE spec tracking**: moves spectrometer crystal at each K step ([`XRTspec`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L14))
 
 ### 2. Energy rounding/deduplication
 
-**Commit:** `70ba850`
+**Commit:** [`70ba850`](https://github.com/pcdshub/mfx/commit/70ba850)
 
 All energy arrays are now:
 - Rounded to 0.1 eV
 - Deduplicated (no repeated energy points)
 - Sorted ascending
 
-Applies to both `build_energy_range()` (used by `long_escan`) and `k_xas_scan`.
+Applies to both [`build_energy_range()`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L2164) (used by [`long_escan`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L1385)) and [`k_xas_scan`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L1696).
 
 ### 3. Offline simulation support
 
 **Same commit series**
 
-`Exafs(simulate=True)` now works without EPICS, DAQ, or any hardware packages.
+[`Exafs(simulate=True)`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L39) now works without EPICS, DAQ, or any hardware packages.
 Uses lightweight mock motors. Useful for testing scan configurations before beam:
 
 ```python
@@ -301,7 +317,7 @@ print(f"{len(summary)} points, range: {summary[0]['dccm_energy_eV']}-{summary[-1
 
 ---
 
-## Architecture: How `k_xas_scan` Works
+## Architecture: How [`k_xas_scan`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/exafs.py#L1696) Works
 
 ```
 k_xas_scan()
@@ -332,24 +348,89 @@ No vernier PV is touched. This is critical for 10 Hz secondary program operation
 
 ---
 
-## FEE Spectrometer Tracking
+## XRT Spectrometer Tracking
 
-The FEE spectrometer uses Si(111) Bragg diffraction. At each K step:
+The XRT spectrometer ([`XRTspec`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L14) in [`mfx/xrt_spec.py`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py)) is a Si(111) Bragg
+spectrometer in the FEE (Front-End Enclosure). It diffracts from the
+transmitted beam upstream of the hutch and provides a shot-by-shot
+measurement of the incident photon energy spectrum.
 
-1. `move_feespec_energy(k_keV)` — moves crystal angle, camera angle, and camera Y
-2. `check_feespec_crystal_angle(k_keV)` — fine-tunes crystal angle after K settles
+### Why it matters for K scanning
 
-Empirical calibration (in `mfx/xrt_spec.py`):
+During a K scan the undulator changes energy at each step. The XRT
+spectrometer must track so that the diffracted beam stays on its camera.
+Without tracking, the Bragg condition is no longer satisfied and the
+spectrometer sees nothing. With `track_feespec=True` the scan loop
+automatically repositions the spectrometer at every K step.
+
+### How tracking works
+
+At each K step (energy E in keV):
+
+1. **[`move_feespec_energy(E)`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L267)** — full repositioning:
+   - Stops camera acquisition (avoids motion blur)
+   - Stores current positions as rollback reference
+   - Computes target positions via [`get_feespec_positions()`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L117)
+   - Moves crystal angle (θ), camera angle (2θ), and camera Y
+   - Checks XRT transmission alarm — rolls back if alarm fires
+
+2. **[`check_feespec_crystal_angle(E)`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L321)** — fine correction after K settles:
+   - Compares current crystal angle to calculated target
+   - Only moves if difference > 0.01°
+   - Restarts camera acquisition after move
+   - Also checks XRT transmission
+
+### Calibration formulas
+
+Empirical calibration for Si(111) at MFX (in [`mfx/xrt_spec.py`](https://github.com/pcdshub/mfx/blob/k_xas_scanning/mfx/xrt_spec.py#L235)):
+
 ```
-crystal_angle = 140.08 - 21.2*E + 1.02*E²   (E in keV)
-camera_angle  = -1.91 + 2*crystal_angle
-camera_y      = -4.92 - 0.111*E
+crystal_angle (θ)  = 140.08 − 21.2·E + 1.02·E²    [degrees]
+camera_angle  (2θ) = −1.91 + 2·crystal_angle       [degrees]
+camera_y           = −4.92 − 0.111·E                [mm]
 ```
 
-`crystal_angle_offset` shifts only the crystal without changing camera geometry.
-Positive values increase the angle. Adjust if FEE line is off-center.
+where E is photon energy in keV (e.g. 7.112 for Fe K-edge).
 
-Safety: if XRT transmission alarms, spectrometer rolls back to previous position.
+### crystal_angle_offset
+
+`crystal_angle_offset` adds a constant to the crystal angle without
+changing the camera angle or camera Y. This shifts where the diffracted
+line lands on the camera. Use it to correct systematic calibration drift.
+
+- Positive values increase the crystal angle
+- Only affects the crystal; camera geometry unchanged
+- Adjust if the spectral line is off-center on the FEE camera
+- Start with 0.0, tweak empirically (Recipe 6)
+
+### Safety
+
+After every move, the code reads `XRT:HXS:TRNS.SEVR`. If the alarm
+severity is anything other than `NO_ALARM`, the spectrometer returns to
+its previous position. This prevents the crystal from blocking the beam
+or scattering into optics in a bad configuration.
+
+### Sequence in the K scan loop
+
+```
+For each K position:
+  [pause mode]
+    1. Pause DAQ
+    2. move_feespec_energy(k_keV)    ← full move (θ, 2θ, Y)
+    3. Move undulator K
+    4. check_feespec_crystal_angle(k_keV)  ← fine-tune θ after settle
+    5. Resume DAQ
+
+  [concurrent mode]
+    1. move_feespec_energy(k_keV)
+    2. Request K move (non-blocking)
+    3. Begin DCCM stepping immediately
+```
+
+In pause mode the spectrometer is fully settled before data collection
+resumes. In concurrent mode, early DCCM points may be collected while
+the undulator is still in transit — the spectrometer is already at the
+target position, so incident energy readback remains valid.
 
 ---
 

--- a/docs/beamtime_20260624.md
+++ b/docs/beamtime_20260624.md
@@ -307,7 +307,7 @@ exafs.k_xas_scan(
 | Activity | Needs at IP | Can proceed without Wolter? | Notes |
 |----------|-------------|----------------------------|-------|
 | Von Hamos full alignment | Fe foil | No (needs focused beam) | Rough alignment OK with unfocused |
-| Von Hamos rough alignment | Nothing | Yes | Crystal geometry, camera positioning |
+| Von Hamos rough alignment | Fe Foil | Yes | Crystal geometry, camera positioning |
 | Wolter knife-edge | Wire | N/A | |
 | Wolter beam pointing | YAG | N/A | |
 | K scan commissioning | Fe foil | Yes | Only needs FEE spec — fallback activity |

--- a/docs/beamtime_20260624.md
+++ b/docs/beamtime_20260624.md
@@ -1,0 +1,355 @@
+# MFX Beamtime: K-Scan Commissioning & Wolter First Light
+
+**Dates:** June 24 & June 26, 2026 (6 AM – 6 PM, 10 Hz secondary program)  
+**Samples:** Fe foil, ferricyanide (K4[Fe(CN)6])  
+**Spectrometers:** 6x von Hamos (cylindrical, Fe Ka), FEE spectrometer, SEER  
+**Constraints:** No vernier moves (primary 120 Hz program on another instrument). TFS locked out.
+
+---
+
+## Quick Reference: Executable Recipes
+
+### Setup (start of each shift)
+
+```python
+from mfx.exafs import Exafs
+import numpy as np
+
+exafs = Exafs(simulate=False)
+```
+
+If testing offline (no EPICS):
+```python
+exafs = Exafs(simulate=True)
+```
+
+---
+
+### Recipe 1: Plain K Scan (1 eV steps, undulator moves every point)
+
+K moves to each energy, DCCM stays at the K center. Tests undulator dead-time
+at 1 eV step size. Use during 2–4 PM accelerator coordination window.
+
+```python
+plain_scan = np.arange(7095, 7196, 1.0)  # 101 points, 7095–7195 eV
+
+summary = exafs.k_xas_scan(
+    k_positions=plain_scan,
+    dccm_offsets=[0.0],          # DCCM parked at K center
+    dwell_time=1.0,              # 1s per point (10 shots at 10 Hz)
+    k_move_mode='pause',         # pause DAQ during K move
+    track_feespec=True,          # FEE spec tracks K
+    crystal_angle_offset=0.0,    # adjust if FEE cal is off
+    record=True,
+    sample='Fe_foil',
+)
+```
+
+**Concurrent variant** (collect data during K transit):
+```python
+summary = exafs.k_xas_scan(
+    k_positions=plain_scan,
+    dccm_offsets=[0.0],
+    dwell_time=1.0,
+    k_move_mode='concurrent',    # don't pause DAQ during K move
+    track_feespec=True,
+    record=True,
+    sample='Fe_foil',
+)
+```
+
+---
+
+### Recipe 2: ROI K Scan (variable spacing, undulator at every point)
+
+Fine steps at the edge (0.3 eV), coarse pre/post-edge. Designed to resolve
+the ferricyanide t2g pre-edge peak.
+
+```python
+roi_scan = np.array([
+    7095., 7098., 7101., 7104., 7106.3, 7106.6, 7106.9, 7107.2,
+    7107.5, 7107.8, 7108.1, 7108.4, 7108.7, 7109., 7109.3, 7109.6,
+    7109.9, 7110.2, 7110.5, 7110.8, 7111.1, 7111.4, 7111.7, 7112.,
+    7112.3, 7112.6, 7112.9, 7113.2, 7113.5, 7113.8, 7114.1, 7114.4,
+    7114.7, 7115., 7115.3, 7115.6, 7115.9, 7117., 7118., 7119.,
+    7120., 7121., 7122., 7123., 7124., 7125., 7126., 7127.,
+    7128., 7129., 7130., 7131., 7132., 7133., 7134., 7135.,
+    7136., 7137., 7138., 7139., 7140., 7141., 7142., 7143.,
+    7144., 7145., 7145.2, 7146.8, 7148.4, 7150.2, 7151.9, 7153.8,
+    7155.8, 7157.8, 7159.9, 7162., 7164.3, 7166.6, 7169., 7171.5,
+    7174., 7176.7, 7179.4, 7182.2, 7185., 7187.9, 7191., 7194.
+])
+
+summary = exafs.k_xas_scan(
+    k_positions=roi_scan,
+    dccm_offsets=[0.0],
+    dwell_time=1.0,
+    k_move_mode='pause',
+    track_feespec=True,
+    record=True,
+    sample='ferricyanide',
+)
+```
+
+---
+
+### Recipe 3: DCCM Probes Around K (minimize undulator moves)
+
+K steps in larger increments; DCCM tiles a window around each K center.
+Reduces total undulator moves — useful if dead-time is irreducible.
+
+```python
+summary = exafs.k_xas_scan(
+    start_eV=7095,
+    end_eV=7195,
+    k_step_eV=4.0,               # K moves every 4 eV
+    dccm_window_eV=2.0,          # DCCM scans +/-2 eV around K
+    dccm_step_eV=1.0,            # 1 eV DCCM steps within window
+    dwell_time=1.0,
+    k_move_mode='pause',
+    track_feespec=True,
+    record=True,
+    sample='Fe_foil',
+)
+# Produces 5 DCCM points per K position: [-2, -1, 0, +1, +2] eV offsets
+```
+
+**Narrower K steps for finer coverage:**
+```python
+summary = exafs.k_xas_scan(
+    start_eV=7095,
+    end_eV=7195,
+    k_step_eV=2.0,               # K moves every 2 eV (seamless tiling)
+    dccm_window_eV=1.0,          # +/-1 eV around K
+    dccm_step_eV=0.5,            # 0.5 eV DCCM steps
+    dwell_time=1.0,
+    k_move_mode='pause',
+    track_feespec=True,
+    record=True,
+    sample='Fe_foil',
+)
+```
+
+---
+
+### Recipe 4: Stochastic XANES/RIXS (Pink Beam)
+
+Park undulator at Fe K-edge. FEE spec resolves incident spectrum shot-by-shot.
+Von Hamos resolves Fe Ka emission. SEER provides secondary beam energy readback.
+Analysis is offline (sort by FEE-measured incident energy).
+
+```python
+# Park K at Fe edge, collect N shots
+exafs.k_xas_scan(
+    k_positions=[7112.0],        # single K position at edge
+    dccm_offsets=[0.0],          # DCCM at center of SASE distribution
+    dwell_time=300.0,            # 5 min collection (3000 shots at 10 Hz)
+    k_move_mode='pause',
+    track_feespec=True,
+    record=True,
+    sample='Fe_foil_stochastic',
+)
+```
+
+---
+
+### Recipe 5: Wolter Lens Knife-Edge Scans
+
+Standard bluesky relative scan for focus characterization:
+
+```python
+from bluesky import plan_stubs as bps
+import bluesky.plans as bp
+
+# Example: scan wire across beam at Wolter focus
+RE(bp.dscan([daq], wolter_wire_x, -0.5, 0.5, 50))
+
+# Or absolute scan if you know the range:
+RE(bp.scan([daq], wolter_wire_x, 10.0, 11.0, 100))
+```
+
+Replace `wolter_wire_x` with the actual motor object for the knife-edge
+stage. Check `hutch_python` namespace for available motors.
+
+---
+
+### Recipe 6: FEE Spectrometer Calibration Check
+
+If the FEE spec doesn't track well, recalibrate crystal_angle_offset:
+
+```python
+# Check current calibration visually:
+# Move to known energy, see if FEE spec catches the line
+exafs.k_xas_scan(
+    k_positions=[7112.0],
+    dccm_offsets=[0.0],
+    dwell_time=5.0,
+    track_feespec=True,
+    crystal_angle_offset=0.0,    # start with 0
+    record=False,
+    simulate=False,
+    sample='cal_check',
+)
+# If line is off-center on FEE camera, adjust crystal_angle_offset
+# Positive offset increases crystal angle
+```
+
+---
+
+## Shift Schedule
+
+### Both Shifts (6/24 and 6/26)
+
+| Time | Activity | Recipe |
+|------|----------|--------|
+| 06:00–08:00 | Setup, beam delivery, alignment | — |
+| 08:00–10:00 | Wolter first-light & knife-edge scans | Recipe 5 |
+| 10:00–12:00 | Stochastic XANES/RIXS (pink beam, Fe foil) | Recipe 4 |
+| 12:00–14:00 | Stochastic XANES/RIXS (ferricyanide) | Recipe 4 |
+| 14:00–16:00 | **Accelerator coordination: K scan commissioning** | Recipes 1–3 |
+| 16:00–18:00 | Follow-up measurements / repeat best configs | — |
+
+### 2–4 PM K Scan Commissioning Plan (with accelerator control room)
+
+**Goals to test in order:**
+
+1. **Baseline timing**: Run Recipe 1 (plain scan, pause mode). Measure dead-time per K step.
+2. **Step-size independence**: Run Recipe 1 with `k_step_eV` of 1, 2, 5, 10 eV. Compare dead-times.
+3. **Concurrent collection**: Run Recipe 1 concurrent mode. Compare data quality in-transit vs settled.
+4. **Wider deadbands**: Accelerator adjusts gantry deadbands. Repeat baseline scan.
+5. **Phase shifter preloading**: Accelerator preloads positions. Repeat baseline scan.
+6. **DCCM windowing**: If dead-time is irreducible, test Recipe 3 to minimize K moves.
+
+---
+
+## Recent Code Changes
+
+### 1. `k_xas_scan` method (new)
+
+**File:** `mfx/exafs.py`  
+**Commit:** `8a13e51` + subsequent
+
+K-primary scanning mode where the undulator is the primary axis and DCCM
+tiles around each K position. Key features:
+
+- **No vernier requests** — uses `dccm.energy` (crystal only), safe for secondary program
+- **Two K move modes**: `'pause'` (stop DAQ, move, resume) and `'concurrent'` (move during collection)
+- **Custom K positions**: pass `k_positions=array` for non-uniform spacing
+- **DCCM window**: configurable offsets around each K center
+- **FEE spec tracking**: moves spectrometer crystal at each K step
+
+### 2. Energy rounding/deduplication
+
+**Commit:** `70ba850`
+
+All energy arrays are now:
+- Rounded to 0.1 eV
+- Deduplicated (no repeated energy points)
+- Sorted ascending
+
+Applies to both `build_energy_range()` (used by `long_escan`) and `k_xas_scan`.
+
+### 3. Offline simulation support
+
+**Same commit series**
+
+`Exafs(simulate=True)` now works without EPICS, DAQ, or any hardware packages.
+Uses lightweight mock motors. Useful for testing scan configurations before beam:
+
+```python
+exafs = Exafs(simulate=True)
+summary = exafs.k_xas_scan(k_positions=roi_scan, dccm_offsets=[0.0],
+    dwell_time=0.01, simulate=True)
+print(f"{len(summary)} points, range: {summary[0]['dccm_energy_eV']}-{summary[-1]['dccm_energy_eV']} eV")
+```
+
+---
+
+## Architecture: How `k_xas_scan` Works
+
+```
+k_xas_scan()
+│
+├─ Compute K positions (from start/end/step OR custom array)
+├─ Compute DCCM offsets (from window/step OR custom list)
+├─ Store initial positions
+│
+└─ For each run:
+    ├─ Setup DAQ (record if enabled)
+    │
+    └─ For each K position:
+        ├─ Move K (pause or concurrent mode)
+        │   ├─ [pause]: pause DAQ → move FEE spec → move K → verify FEE → resume DAQ
+        │   └─ [concurrent]: move FEE spec → request K (non-blocking)
+        │
+        └─ For each DCCM offset:
+            ├─ Move DCCM to (K + offset) / 1000 keV [crystal only, no vernier]
+            ├─ Check beam (if flux_threshold set)
+            ├─ Dwell (collect data)
+            └─ Record summary point
+    │
+    └─ Return to initial positions
+```
+
+**Key constraint:** DCCM moves are crystal-only (`self.dccm.energy.move()`).
+No vernier PV is touched. This is critical for 10 Hz secondary program operation.
+
+---
+
+## FEE Spectrometer Tracking
+
+The FEE spectrometer uses Si(111) Bragg diffraction. At each K step:
+
+1. `move_feespec_energy(k_keV)` — moves crystal angle, camera angle, and camera Y
+2. `check_feespec_crystal_angle(k_keV)` — fine-tunes crystal angle after K settles
+
+Empirical calibration (in `mfx/xrt_spec.py`):
+```
+crystal_angle = 140.08 - 21.2*E + 1.02*E²   (E in keV)
+camera_angle  = -1.91 + 2*crystal_angle
+camera_y      = -4.92 - 0.111*E
+```
+
+`crystal_angle_offset` shifts only the crystal without changing camera geometry.
+Positive values increase the angle. Adjust if FEE line is off-center.
+
+Safety: if XRT transmission alarms, spectrometer rolls back to previous position.
+
+---
+
+## Troubleshooting
+
+### "DAQ is in error state"
+DAQ must be in a clean state before scanning. Check DAQ GUI, clear errors.
+
+### FEE spec not tracking
+- Check `crystal_angle_offset` value
+- Verify FEE camera is acquiring (`CAMR:FEE1:441:Acquire`)
+- Run calibration check (Recipe 6)
+
+### K move takes >30s
+This is the known dead-time issue. Log the timing and try:
+1. Ask ACR to widen gantry deadbands
+2. Ask ACR to preload phase shifter positions
+3. Switch to concurrent mode to collect during transit
+
+### Import errors offline
+Use `Exafs(simulate=True)` — hardware packages not needed for simulation.
+
+---
+
+## Key Parameters Quick Reference
+
+| Parameter | What it controls | Typical values |
+|-----------|-----------------|----------------|
+| `k_positions` | Custom K energy array (eV) | `np.arange(7095, 7196, 1.0)` or ROI array |
+| `start_eV` / `end_eV` | Auto-generate K range | 7095 / 7195 |
+| `k_step_eV` | Uniform K spacing | 1.0 – 10.0 eV |
+| `dccm_offsets` | DCCM points relative to K | `[0.0]` or `[-2,-1,0,1,2]` |
+| `dccm_window_eV` | Auto DCCM range (±) | 1.0 – 3.0 eV |
+| `k_move_mode` | DAQ behavior during K | `'pause'` or `'concurrent'` |
+| `dwell_time` | Collection time per point (s) | 1.0 – 5.0 |
+| `track_feespec` | FEE spec follows K | `True` |
+| `crystal_angle_offset` | FEE cal tweak (deg) | 0.0 (adjust if needed) |
+| `record` | DAQ records data | `True` for real runs |
+| `simulate` | Offline testing | `True` for dry-run |

--- a/mfx/docs/EXAFS_SCAN_SYSTEM.md
+++ b/mfx/docs/EXAFS_SCAN_SYSTEM.md
@@ -1,0 +1,631 @@
+# MFX EXAFS Scan System — Technical Documentation
+
+## Overview
+
+The EXAFS (Extended X-ray Absorption Fine Structure) scan system at MFX provides automated energy scanning from the pre-edge through the EXAFS region. It coordinates multiple hardware subsystems — monochromator, undulator, vernier, transfocator, and FEE spectrometer — to maintain beam quality while stepping through hundreds of energy points.
+
+The primary entry point is `Exafs.long_escan()` in `exafs.py`.
+
+---
+
+## File Map
+
+| File | Role |
+|------|------|
+| `exafs.py` | Main controller (`Exafs` class) and energy range builder (`EXAFSEnergyRangeBuilder`) |
+| `dccm.py` | Double Crystal Channel-cut Monochromator device classes (Bragg angle ↔ energy) |
+| `xrt_spec.py` | FEE spectrometer tracking (crystal/camera angle calculations and motion) |
+| `xas.py` | Simpler XAS scan utilities (`continuous_dccmscan`, `run_dccmscan`) |
+| `optimize/beamline_hw.py` | Device initialization (vernier PV, intensity diagnostics) |
+| `optimize/beam.py` | Undulator beam alignment |
+| `optimize/beam_status.py` | Beam flux monitoring (`BeamCheck`) |
+| `devices.py` | LaserShutter and other device definitions |
+| `beamline.py` | Top-level hardware instantiation |
+
+---
+
+## Hardware Subsystems
+
+### 1. DCCM (Double Crystal Channel-cut Monochromator)
+
+**File:** `dccm.py`  
+**PV Prefix:** `SP1L0:DCCM`
+
+The DCCM uses two matched Si(111) crystals in a channel-cut geometry. Energy selection uses Bragg's Law:
+
+```
+E (keV) = 12.398 / (2 × d × sin(θ))
+d = 3.13560114 Å  (Silicon 111)
+```
+
+Three energy control modes are available:
+
+| Mode | Class | Behavior |
+|------|-------|----------|
+| Basic | `DCCMEnergy` | Moves crystals (th1, th2) only |
+| With Vernier | `DCCMEnergyWithVernier` | Moves crystals + requests MCC vernier change |
+| With ACR Status | `DCCMEnergyWithACRStatus` | Moves crystals + vernier + waits for ACR completion |
+
+The `long_escan` uses `energy_with_vernier` mode — each DCCM move automatically requests the Machine Control Center (MCC) to adjust the vernier energy so the undulator stays tuned.
+
+**Motor Axes:**
+- `th1` / `th2` — Bragg angle (BeckhoffAxis)
+- `tx` — Chamber translation X
+- `txd` / `tyd` — YAG diagnostic positioning
+
+---
+
+### 2. Undulator K Parameter
+
+**Class:** `BeamEnergyRequestACRWait` from `pcdsdevices.beam_stats`  
+**PV Prefix:** `MFX`, **ACR Status Suffix:** `AO805`
+
+The undulator K parameter sets the fundamental harmonic of the free-electron laser. Unlike the DCCM (which moves continuously), the K motor is stepped in large jumps (default: 120 eV) because each K move disrupts the DAQ — the run must be paused, the undulator repositioned, and the run resumed.
+
+Two ACR energy request objects are used:
+- `acr_energy_v` (pv_index=1) — Vernier energy requests
+- `acr_energy_k` (pv_index=2) — Undulator K energy requests
+
+**K stepping logic** (in `_request_k_energy_update`):
+1. Calculate distance between current scan energy and K setpoint
+2. If distance exceeds `k_stepsize / 2`, a K move is needed
+3. Next K position = current K ± k_stepsize (direction depends on `reverse`)
+4. Minimum K energy enforced by `min_k_keV` with 1 eV safety margin
+
+---
+
+### 3. Vernier Energy
+
+**Device:** Initialized from `mfx.optimize.beamline_hw.init_devices()["vernier_energy"]`
+
+The vernier provides fine energy tuning independent of the DCCM crystals. The offset between vernier and DCCM drifts with energy, so a calibration system ("track-and-check", or **tchk**) measures and stores the offset at each K energy.
+
+**Alignment Procedure** (`align_vernier_to_dccm`):
+1. Read current DCCM energy
+2. Scan vernier ±2.5 eV around DCCM energy (21 steps, 50 events per step)
+3. Average intensity at each point (10 ms between readings)
+4. Move to position with maximum intensity
+5. Calculate offset = vernier_position − DCCM_energy
+
+**Tracking Modes** (`tchk` parameter):
+| Value | Behavior |
+|-------|----------|
+| `False` | No vernier tracking |
+| `True` | Full alignment at every K energy boundary |
+| `'single'` | Measure once per energy, cache for subsequent runs |
+
+**Diagnostics available:**
+- `'dg1'` — MFX DG1 intensity (upstream)
+- `'dg2'` — MFX DG2 beam monitor (default)
+- `'xcs1'` — XCS hutch intensity
+
+---
+
+### 4. Transfocator (Focus Tracking)
+
+**Library:** `tfs` (external)  
+**PV Prefix:** `MFX:LENS`
+
+The transfocator uses compound refractive lenses (CRLs) to maintain focus as energy changes. Since focal length is energy-dependent, the lens configuration and Z-stage position must track the scan.
+
+**Initialization** (`_init_tfs`):
+- Creates `Transfocator("MFX:LENS")` (or simulated version)
+- Optionally pre-computes a focus tracking map showing Z-position and lens configuration vs. energy
+
+**Per-energy-point motion** (`_move_tfs_to_energy`):
+1. Look up nearest energy entry in `track_focus_results.json`
+2. Move Z-stage to stored position (+ optional `tfs_offset`)
+3. Insert/remove lenses to match stored configuration
+4. Set attenuation if provided (with 20s fault-state timeout)
+
+**Configuration parameters:**
+- `tfs_margin_mm` — safety margin (default: 5.0 mm)
+- `ref_focal_length_um` — reference focal length
+- `ref_z_stage_mm` — reference Z position
+- `tfs_target` — target focal position (default: 400.37)
+- `avoid_forbidden_combo` — skip unsafe lens combinations
+- `enable_prefocus` — allow prefocusing lenses
+
+---
+
+### 5. FEE Spectrometer
+
+**File:** `xrt_spec.py`  
+**Class:** `XRTspec`  
+**Hardware:** `HXRSpectrometer("STEP:XRT1")`
+
+The Front-End Enclosure spectrometer monitors photon energy in real-time. Its geometry is calibrated empirically:
+
+```
+crystal_angle = 140.08 − 21.2×E + 1.02×E²  (degrees)
+camera_angle  = −1.91 + 2 × crystal_angle    (degrees)
+camera_y      = −4.92 − 0.111×E              (mm)
+```
+
+Where E is photon energy in keV. An optional `crystal_angle_offset` allows fine-tuning.
+
+**Safety:** After every move, XRT transmission alarm (`XRT:HXS:TRNS.SEVR`) is checked. If not `NO_ALARM`, motors return to their previous positions.
+
+**Tracking modes during EXAFS scans:**
+- `track_feespec` — move crystal + camera + Y at K boundaries
+- `track_feespec_cam` — move only camera angle at each energy point (less disruptive)
+
+---
+
+### 6. DAQ (Data Acquisition)
+
+**System:** LCLS-II DAQ (`psdaq.control.DaqControl`)  
+**Access:** `from mfx.db import daq`
+
+The DAQ runs continuously during the energy scan. It records events at each energy point with timing determined by the `wait_time` array.
+
+**State machine:**
+```
+configured → running → paused → running → ... → configured
+```
+
+**Lifecycle during a scan:**
+1. `setState("configured")` — prepare DAQ
+2. `setRecord(True/False)` — enable data persistence
+3. `setState("running")` — start event collection
+4. At K boundaries: `setState("paused")` → move K → `setState("running")`
+5. End of scan: `setState("configured")` → `setRecord(False)`
+
+**Pulse picker** (`from mfx.db import pp`):
+- `'open'` — pulse picker fully open
+- `'flip'` — flip-flop mode (alternating shots)
+- Closed on scan completion
+
+---
+
+## Energy Range Generation
+
+**Class:** `EXAFSEnergyRangeBuilder` (exafs.py:1669–2009)
+
+Generates an optimized energy point array with four distinct regions:
+
+### Region Layout
+
+| Region | Spacing | Default Time | Purpose |
+|--------|---------|--------------|---------|
+| Pre-pre-edge | 5 eV | 2 s | Baseline normalization |
+| Pre-edge | 0.5 eV | 2 s | Near-edge features |
+| Edge | 1 eV | 1 s | XANES structure |
+| EXAFS | 0.1 Å⁻¹ in K-space | K³-weighted | Fine structure oscillations |
+
+### K-space Conversion
+
+```
+K (Å⁻¹) = √(0.2625 × (E − E₀))
+E (eV)  = K² / 0.2625 + E₀
+```
+
+Where E₀ is the absorption threshold energy for the element.
+
+### K³-weighted Acquisition Times
+
+EXAFS signal decays as ~1/K³, so acquisition time scales with K³ to maintain constant signal-to-noise:
+
+```python
+K_time = K_values ** 3
+normalized_time = min_time + (max_time - min_time) * (K_time_range - min) / (max - min)
+```
+
+Default range: 0.5 s (low K) to 10 s (high K).
+
+### Supported Elements
+
+| Element | Foil Energy (eV) | Threshold Energy (eV) |
+|---------|-------------------|----------------------|
+| Sc | 4492.8 | 4510.0 |
+| Ti | 4966.4 | 4985.0 |
+| V | 5465.1 | 5485.0 |
+| Cr | 5989.2 | 6010.0 |
+| Mn | 6539.0 | 6560.0 |
+| Fe | 7111.2 | 7130.0 |
+| Co | 7708.9 | 7730.0 |
+| Ni | 8332.8 | 8350.0 |
+| Cu | 8978.9 | 9000.0 |
+| Zn | 9658.6 | 9680.0 |
+
+---
+
+## Main Scan Loop — `long_escan()`
+
+### Parameters Summary
+
+**Energy Control:**
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `start_eV` | 0.0 | Scan start (eV) |
+| `end_eV` | None | Scan end (eV), overrides max_k |
+| `min_k` | 2.0 | Minimum K (Å⁻¹) |
+| `max_k` | 12.0 | Maximum K (Å⁻¹) |
+| `element` | 'Fe' | Target element |
+| `energies_list` | [] | Custom energy array (overrides auto-generation) |
+| `wait_time_list` | [] | Custom time array (must match energies_list) |
+
+**Undulator K Control:**
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `k_stepsize` | 120 | K step size (eV) |
+| `k_offset` | 0 | K energy offset (eV) |
+| `reverse` | False | Scan high→low |
+| `min_k_keV` | 7.035 | Minimum K energy (keV) |
+
+**Tracking & Calibration:**
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `tchk` | False | Vernier tracking mode (False/True/'single') |
+| `diagnostic` | 'dg2' | Vernier alignment diagnostic |
+| `track_focus` | False | Enable focus tracking |
+| `track_feespec` | False | Track FEE spectrometer at K boundaries |
+| `track_feespec_cam` | False | Track FEE camera at every point |
+| `map_focus_track` | False | Pre-compute focus map and exit |
+| `map_tchk_track` | False | Build new vernier offset map |
+| `crystal_angle_offset` | 0.0 | FEE spectrometer crystal offset (degrees) |
+
+**Data Acquisition:**
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `record` | False | Enable data recording |
+| `picker` | None | Pulse picker mode ('open'/'flip'/None) |
+| `runs` | 1 | Number of scan repetitions |
+| `daq_delay` | 5 | Delay between runs (seconds) |
+| `flux_threshold` | None | Minimum beam flux (mJ) |
+| `attenuation` | None | Attenuation value |
+
+**Undulator Pointing:**
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `undulator_point` | False | Enable undulator pointing |
+| `undulator_on_diagnostic` | 'dg1' | Pointing diagnostic |
+| `undulator_using_device` | 'yag' | Pointing device |
+| `undulator_with_method` | 'calib' | Pointing method |
+| `undulator_grid_bins` | 5 | Grid bins for calibration |
+
+---
+
+### Execution Flow
+
+```
+long_escan()
+│
+├── 1. Store initial positions (DCCM energy, K energy)
+├── 2. Build energy & time arrays
+│       └── EXAFSEnergyRangeBuilder.build_energy_range()
+│           or use custom energies_list/wait_time_list
+│
+├── 3. Initialize tracking systems
+│       ├── Load track_focus_results.json (if track_focus)
+│       ├── _init_tfs() (transfocator setup)
+│       └── _init_tchk() (vernier tracking setup)
+│
+├── 4. FOR each run (1..runs):
+│       │
+│       ├── 4a. _initialize_energies_and_move()
+│       │       ├── Calculate initial K energy
+│       │       ├── Reverse arrays if reverse=True
+│       │       ├── Move DCCM to first energy
+│       │       ├── Move K to initial position
+│       │       └── Move FEE spectrometer (if track_feespec)
+│       │
+│       ├── 4b. check_beam_status() — pause if flux low
+│       │
+│       ├── 4c. _setup_daq_and_start_recording()
+│       │       ├── Connect to LCLS-II DAQ
+│       │       ├── Check DAQ state (abort if error)
+│       │       ├── Open/flip pulse picker
+│       │       ├── Configure DAQ
+│       │       └── Start recording
+│       │
+│       ├── 4d. _align_undulator() (if undulator_point=True)
+│       │
+│       ├── 4e. FOR each energy point:
+│       │       │
+│       │       ├── _move_k_if_necessary()
+│       │       │   ├── Check delta to K > k_stepsize/2
+│       │       │   ├── Pause DAQ
+│       │       │   ├── Move FEE spectrometer
+│       │       │   ├── Move undulator K
+│       │       │   └── Resume DAQ
+│       │       │
+│       │       ├── _move_tfs_to_energy() (if track_focus)
+│       │       │   ├── Lookup lens config in tracking data
+│       │       │   ├── Move Z stage
+│       │       │   ├── Insert/remove lenses
+│       │       │   └── Set attenuation
+│       │       │
+│       │       ├── check_beam_status()
+│       │       │
+│       │       ├── _move_dccm_energy_with_vernier()
+│       │       │   └── Moves DCCM crystals + requests vernier
+│       │       │
+│       │       ├── Vernier alignment (if tchk):
+│       │       │   ├── 'single': lookup or measure once
+│       │       │   └── True: full _align_vernier_to_dccm()
+│       │       │
+│       │       ├── track_feespec_camera() (if track_feespec_cam)
+│       │       │
+│       │       ├── _measure_lens_beam_offset() (if mapping)
+│       │       │
+│       │       └── _wait(wait_time) — dwell for data collection
+│       │
+│       ├── 4f. Save tracking data (tchk, lens offset)
+│       ├── 4g. Post to elog (if recording)
+│       └── 4h. sleep(daq_delay) between runs
+│
+├── 5. EXCEPT KeyboardInterrupt:
+│       ├── Post "Run ended prematurely" to elog
+│       ├── Return motors to initial positions
+│       └── Return FEE spectrometer to initial position
+│
+└── 6. _finalize_scan()
+        ├── Return DCCM to start energy
+        ├── Return K to start position
+        └── Return FEE spectrometer to start position
+```
+
+---
+
+## Beam Status Monitoring
+
+**Method:** `check_beam_status(flux_threshold)`  
+**Source:** `mfx.optimize.beam_status.BeamCheck`
+
+When `flux_threshold` is set (mJ), beam intensity is monitored at every energy point:
+
+1. Read gas detector average (`gdet_ave`)
+2. If flux < threshold AND DAQ is running → pause DAQ
+3. Poll every 1 second until flux recovers
+4. Resume DAQ when flux restored
+
+This handles beam dumps and injection interrupts without losing the scan position.
+
+---
+
+## Tracking Data Files
+
+All tracking data is stored as JSON in the user's home directory (`Path.home()`):
+
+| File | Contents |
+|------|----------|
+| `track_focus_results.json` | Lens configurations and Z positions vs. energy |
+| `track_tchk_results.json` | Vernier offsets vs. energy |
+| `track_lens_beam_offset_results.json` | Lens beam energy calibration |
+
+**Example `track_focus_results.json` entry:**
+```json
+{
+    "energy": 7200.0,
+    "z_position": 451.23,
+    "inserted_lenses": ["SIM::MFX:LENS:L1", "SIM::MFX:LENS:L3"]
+}
+```
+
+**Example `track_tchk_results.json` entry:**
+```json
+{
+    "energy": 7130.0,
+    "vernier_offset": -1.2
+}
+```
+
+---
+
+## Simulation Mode
+
+When `simulate=True`:
+- Real motor moves are replaced with `sim.fast_motor1` / `sim.slow_motor1`
+- DAQ interactions return immediately with success
+- Transfocator uses `make_tfs_sim()` (simulated lens system)
+- K energy stored locally instead of reading from EPICS
+- No pulse picker, elog, or beam status operations
+
+This allows testing the full scan logic without hardware access.
+
+---
+
+## XAS Module (Simpler Scans)
+
+For quick XANES or single-region scans without full EXAFS automation, `xas.py` provides:
+
+### `continuous_dccmscan(energies, pointTime, move_vernier, bidirectional)`
+
+- Steps DCCM through a provided energy list
+- Optional vernier coordination
+- Optional bidirectional scanning (forward + reverse)
+- Returns to initial energy on completion or Ctrl+C
+- Does NOT manage DAQ (user starts/stops independently)
+
+---
+
+## Key EPICS PVs
+
+| System | PV | Purpose |
+|--------|-----|---------|
+| DCCM θ1 | `SP1L0:DCCM:MMS:TH1` | Upstream Bragg angle |
+| DCCM θ2 | `SP1L0:DCCM:MMS:TH2` | Downstream Bragg angle |
+| DCCM state | `SP1L0:DCCM:MMS:STATE:SET` | IN/OUT control |
+| Undulator K | `MFX:AO805` (pv_index=2) | K energy request |
+| Vernier | `MFX:AO805` (pv_index=1) | Vernier energy request |
+| DG1 intensity | `MFX:DG1:W8:01:SUM` | Beam monitor |
+| DG2 intensity | `MFX:DG2:BMMON:SUM` | Beam monitor (default tchk) |
+| XCS intensity | `HXX:DG1:BMMON:SUM` | Alternative diagnostic |
+| FEE Spec crystal | `STEP:XRT1` (th) | Spectrometer crystal angle |
+| FEE Spec camera | `STEP:XRT1` (tth) | Spectrometer camera angle |
+| FEE Spec cam Y | `STEP:XRT1` (camy) | Camera Y position |
+| FEE camera acq | `CAMR:FEE1:441:Acquire` | Camera acquisition state |
+| XRT transmission | `XRT:HXS:TRNS.SEVR` | Transmission alarm |
+| Attenuator status | `MFX:ATT:COM:STATUS` | Attenuator fault state |
+| Lens beam energy | `MFX:LENS:BEAM:ENERGY` | Lens system energy readback |
+
+---
+
+## Error Handling
+
+### Keyboard Interrupt (Ctrl+C)
+
+Caught at the outer scan loop level. Cleanup:
+1. Post "Run ended prematurely" to elog (if recording)
+2. Return DCCM to initial energy
+3. Return K to initial position
+4. Return FEE spectrometer to initial position
+
+### DAQ Connection Failure
+
+If `daq.control.getInstrument()` returns None or DAQ is in error state, the scan breaks out of the run loop cleanly.
+
+### Attenuator Fault
+
+When setting attenuation, a 20-second timeout loop waits for the `MFX:ATT:COM:STATUS` PV to clear from `Faulted`. If timeout expires, it forces `OK` status and continues.
+
+### XRT Transmission Alarm
+
+After any FEE spectrometer move, the `XRT:HXS:TRNS.SEVR` alarm is checked. If not `NO_ALARM`, motors return to their previous positions immediately.
+
+---
+
+## Elog Integration
+
+When `record=True`, the system posts to the MFX electronic logbook at:
+- Scan start (with parameter summary)
+- Scan completion
+- Premature abort
+
+Posts include all scan parameters and optionally an inspirational quote (`inspire=True`).
+
+---
+
+## Typical Invocation Examples
+
+### Standard Fe K-edge EXAFS scan
+```python
+exafs = Exafs()
+exafs.long_escan(
+    element='Fe',
+    sample='FeO_sample1',
+    min_k=2.0,
+    max_k=12.0,
+    k_stepsize=120,
+    record=True,
+    picker='open',
+    runs=3
+)
+```
+
+### XANES-only scan (no EXAFS region)
+```python
+exafs.long_escan(
+    element='Fe',
+    start_eV=7080,
+    end_eV=7180,
+    record=True
+)
+```
+
+### Full scan with all tracking enabled
+```python
+exafs.long_escan(
+    element='Cu',
+    min_k=2.0,
+    max_k=14.0,
+    tchk='single',
+    track_focus=True,
+    track_feespec=True,
+    track_feespec_cam=True,
+    undulator_point=True,
+    record=True,
+    picker='open',
+    flux_threshold=0.5
+)
+```
+
+### Build focus tracking map (does not run scan)
+```python
+exafs.long_escan(
+    element='Fe',
+    map_focus_track=True,
+    ref_focal_length_um=3500,
+    ref_z_stage_mm=450.0
+)
+```
+
+### Reverse scan with custom K parameters
+```python
+exafs.long_escan(
+    element='Mn',
+    reverse=True,
+    k_stepsize=100,
+    k_offset=10,
+    min_k_keV=6.5,
+    min_time_EXAFS=1.0,
+    max_time_EXAFS=15.0,
+    record=True
+)
+```
+
+---
+
+## Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `ophyd` | EPICS device framework (EpicsSignal, PseudoPositioner) |
+| `pcdsdevices` | LCLS device library (BeckhoffAxis, BeamEnergyRequest, IMS) |
+| `tfs` | Transfocator lens control and simulation |
+| `psdaq` | LCLS-II DAQ control interface |
+| `hutch_python` | Hutch infrastructure (simulation hardware, utilities) |
+| `numpy` | Array operations, energy calculations |
+| `matplotlib` | Scan profile visualization |
+| `epics` | Low-level EPICS channel access (caput) |
+
+---
+
+## Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Exafs.long_escan()                       │
+│                   (main scan controller)                      │
+└───────┬──────────┬──────────┬──────────┬──────────┬─────────┘
+        │          │          │          │          │
+        ▼          ▼          ▼          ▼          ▼
+┌───────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────────┐
+│   DCCM    │ │  K     │ │Vernier │ │  TFS   │ │ FEE Spec   │
+│(crystals) │ │(undulr)│ │(fine E)│ │(focus) │ │(diagnostic)│
+├───────────┤ ├────────┤ ├────────┤ ├────────┤ ├────────────┤
+│Si(111) θ  │ │ACR req │ │ACR req │ │Lenses  │ │Crystal θ   │
+│Bragg's Law│ │pv_idx=2│ │pv_idx=1│ │Z stage │ │Camera 2θ   │
+│4-25 keV   │ │120eV   │ │±2.5eV  │ │JSON cfg│ │Camera Y    │
+│           │ │steps   │ │scan    │ │        │ │            │
+└─────┬─────┘ └───┬────┘ └───┬────┘ └───┬────┘ └─────┬──────┘
+      │            │          │          │            │
+      ▼            ▼          ▼          ▼            ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    EPICS Control System                       │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    LCLS-II DAQ System                         │
+│            (continuous recording, paused at K moves)          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Timing Considerations
+
+For a typical Fe K-edge EXAFS scan (K=2–12 Å⁻¹):
+
+- ~12 pre-pre-edge points × 2 s = 24 s
+- ~12 pre-edge points × 2 s = 24 s
+- ~18 edge points × 1 s = 18 s
+- ~100 EXAFS points × (0.5–10 s, K³-weighted) ≈ 300 s
+- K moves (~5 pauses × ~3 s each) ≈ 15 s
+- **Total per run: ~6–7 minutes**
+
+With `runs=3`, total scan time ≈ 20 minutes plus inter-run delays.
+
+Focus tracking, vernier alignment, and undulator pointing add overhead at each relevant point (typically 2–5 s per alignment).

--- a/mfx/docs/K_XAS_SCAN_IMPLEMENTATION.md
+++ b/mfx/docs/K_XAS_SCAN_IMPLEMENTATION.md
@@ -1,0 +1,174 @@
+# k_xas_scan — Requirements & Implementation Plan
+
+**Date:** 2026-06-19  
+**Status:** IN PROGRESS  
+**Target file:** `/sdf/home/l/lbgee/mfx_main/mfx/mfx/exafs.py`
+
+---
+
+## Requirements (from grilling session)
+
+### Purpose
+New scan method on the `Exafs` class where the **undulator K is the primary scan axis** and the DCCM fills in a small energy window around each K position. Designed for commissioning undulator motion at MFX and evaluating whether data can be collected during K transit.
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Separate method vs mode flag | New method `k_xas_scan` | No regression risk to `long_escan` |
+| DCCM motion mode | `dccm.energy.move()` (crystal-only) | No vernier requests — vernier PV will be rejected by accelerator |
+| K step size | Defaults to `2 * dccm_window_eV` | Seamless tiling of DCCM windows |
+| DCCM window | ±2 eV default, 1 eV step | Matches SASE bandwidth for upcoming experiment |
+| K move behavior | `'pause'` (default) or `'concurrent'` | Concurrent mode tests whether data during K transit is usable |
+| Concurrent mode behavior | Request K non-blocking → move DCCM to first offset → step through grid | Early points = during transit, later points = settled |
+| K positions | Start at `start_eV`, step by `k_step_eV`, stop when > `end_eV` | Simple, predictable (option A) |
+| Simulation | Full support | Must test before precious beam time |
+| Elog | Skip for MVP | Print params at start is sufficient |
+| Return value | Lightweight summary list + print | Quick in-hutch evaluation |
+
+### Constraints
+- **No vernier access** in upcoming experiment
+- **No transfocator** (negligible focus change over 50 eV)
+- **No undulator pointing** for MVP
+- **No K³ time weighting** — uniform dwell
+
+### What's Included (MVP)
+- [x] K-primary scan loop
+- [x] Two K move modes: `'pause'` and `'concurrent'`
+- [x] Configurable DCCM window (±eV, step size)
+- [x] Optional `dccm_offsets` list override
+- [x] FEE spectrometer tracking (optional)
+- [x] Beam status monitoring (optional)
+- [x] Simulation mode
+- [x] Parameter printout at start
+- [x] Summary returned at end
+- [x] KeyboardInterrupt cleanup
+
+### What's Excluded (MVP)
+- Vernier alignment (tchk)
+- Transfocator tracking
+- Elog posting
+- Undulator pointing
+- K³-weighted timing
+- Adaptive DCCM window
+
+---
+
+## Method Signature
+
+```python
+def k_xas_scan(self,
+    start_eV, end_eV, element='Fe',
+    k_step_eV=None,            # defaults to 2*dccm_window_eV
+    k_move_mode='pause',       # 'pause' or 'concurrent'
+    dccm_window_eV=2.0,        # ±this around K center
+    dccm_step_eV=1.0,          # step within window
+    dccm_offsets=None,         # explicit list override (eV relative to K)
+    dwell_time=1.0,            # seconds per DCCM point
+    record=False,
+    picker=None,
+    track_feespec=False,
+    flux_threshold=None,
+    crystal_angle_offset=0.0,
+    sample='?',
+    simulate=False,
+    runs=1,
+):
+```
+
+---
+
+## Execution Flow
+
+```
+k_xas_scan()
+│
+├── 1. Validate parameters, compute defaults
+│       ├── k_step_eV = 2 * dccm_window_eV if None
+│       ├── Compute dccm_offsets from window/step if not provided
+│       └── Compute K positions: arange(start_eV, end_eV + k_step_eV, k_step_eV)
+│
+├── 2. Print scan configuration
+│
+├── 3. Store initial positions (DCCM energy, K energy)
+│
+├── 4. FOR each run (1..runs):
+│       │
+│       ├── 4a. Setup DAQ (pause/resume for whole scan)
+│       │
+│       ├── 4b. FOR each K position:
+│       │       │
+│       │       ├── IF k_move_mode == 'pause':
+│       │       │   ├── Pause DAQ
+│       │       │   ├── Move K (blocking)
+│       │       │   ├── Move FEE spec (if track_feespec)
+│       │       │   ├── Resume DAQ
+│       │       │   └── FOR each dccm_offset:
+│       │       │       ├── Move DCCM (crystal only)
+│       │       │       ├── check_beam_status()
+│       │       │       ├── Wait dwell_time
+│       │       │       └── Record to summary
+│       │       │
+│       │       └── IF k_move_mode == 'concurrent':
+│       │           ├── Request K move (non-blocking)
+│       │           ├── Move FEE spec (if track_feespec)
+│       │           └── FOR each dccm_offset:
+│       │               ├── Move DCCM (crystal only)
+│       │               ├── check_beam_status()
+│       │               ├── Wait dwell_time
+│       │               └── Record to summary
+│       │
+│       └── 4c. End of run
+│
+├── 5. EXCEPT KeyboardInterrupt:
+│       ├── Return to initial positions
+│       └── Print abort message
+│
+├── 6. _finalize: Return to initial positions
+│
+└── 7. Print and return summary
+```
+
+---
+
+## Implementation Steps
+
+- [ ] Step 1: Write `k_xas_scan` method skeleton with full docstring
+- [ ] Step 2: Implement parameter validation and K/DCCM position computation
+- [ ] Step 3: Implement `'pause'` mode scan loop
+- [ ] Step 4: Implement `'concurrent'` mode scan loop
+- [ ] Step 5: Implement summary generation and return
+- [ ] Step 6: Test in simulation mode (dry run the logic)
+
+---
+
+## Progress Log
+
+| Time | Action | Status |
+|------|--------|--------|
+| 2026-06-19 | Requirements finalized from grilling session | DONE |
+| 2026-06-19 | Implementation plan written | DONE |
+| 2026-06-19 | `k_xas_scan` method implemented in exafs.py | DONE |
+| 2026-06-19 | `_k_xas_move_pause` helper implemented | DONE |
+| 2026-06-19 | `_k_xas_move_concurrent` helper implemented | DONE |
+| 2026-06-19 | AST parse verification (Python 3.8) | PASSED |
+| 2026-06-19 | Logic test (numpy, tiling, coverage) | PASSED |
+
+---
+
+## Test Results
+
+### AST Parse
+- Python 3.8: PASS
+- Methods found: `k_xas_scan`, `_k_xas_move_pause`, `_k_xas_move_concurrent`
+
+### Logic Test (7100-7150 eV, ±2 eV window, 1 eV step)
+- K positions: 13 (7100 to 7148 eV, step 4 eV)
+- DCCM offsets: [-2, -1, 0, +1, +2] (5 points per K)
+- Total points: 65
+- Energy coverage: 7098–7150 eV
+- Max gap: 1.0 eV (seamless tiling)
+- Est. time (pause): 117s (1.9 min)
+- Est. time (concurrent): 65s (1.1 min)
+
+---

--- a/mfx/exafs.py
+++ b/mfx/exafs.py
@@ -1665,6 +1665,325 @@ class Exafs:
 
         self._finalize_scan(energy_start, k_energy_start, crystal_angle_offset)
 
+    # ==================== K-Primary XAS Scan ====================
+
+    def k_xas_scan(self, start_eV, end_eV, element='Fe',
+                   k_step_eV=None, k_move_mode='pause',
+                   dccm_window_eV=2.0, dccm_step_eV=1.0,
+                   dccm_offsets=None, dwell_time=1.0,
+                   record=False, picker=None,
+                   track_feespec=False, flux_threshold=None,
+                   crystal_angle_offset=0.0,
+                   sample='?', simulate=False, runs=1):
+        """
+        K-primary XAS scan: undulator K is the primary scan axis,
+        DCCM steps within a small window around each K position.
+
+        Designed for commissioning undulator motion and evaluating
+        data quality during K transit. No vernier requests are made.
+
+        Parameters
+        ----------
+        start_eV : float
+            Starting energy in eV
+        end_eV : float
+            Ending energy in eV
+        element : str, optional
+            Element symbol (default: 'Fe')
+        k_step_eV : float or None, optional
+            K step size in eV. Defaults to 2*dccm_window_eV (seamless tiling)
+        k_move_mode : str, optional
+            'pause': Pause DAQ, move K, wait, resume DAQ (default)
+            'concurrent': Request K non-blocking, immediately step DCCM
+        dccm_window_eV : float, optional
+            DCCM scans ±this around K center (default: 2.0)
+        dccm_step_eV : float, optional
+            DCCM step size within window (default: 1.0)
+        dccm_offsets : list or None, optional
+            Explicit list of DCCM offsets in eV relative to K center.
+            If provided, overrides dccm_window_eV and dccm_step_eV.
+        dwell_time : float, optional
+            Collection time per DCCM point in seconds (default: 1.0)
+        record : bool, optional
+            Enable DAQ recording (default: False)
+        picker : str or None, optional
+            Pulse picker mode: 'open', 'flip', or None
+        track_feespec : bool, optional
+            Track FEE spectrometer at each K move (default: False)
+        flux_threshold : float or None, optional
+            Minimum beam flux in mJ (default: None)
+        crystal_angle_offset : float, optional
+            FEE spectrometer crystal angle offset in degrees (default: 0.0)
+        sample : str, optional
+            Sample name (default: '?')
+        simulate : bool, optional
+            Run in simulation mode (default: False)
+        runs : int, optional
+            Number of scan repetitions (default: 1)
+
+        Returns
+        -------
+        list of dict
+            Summary of each collection point:
+            [{'k_target_eV': float, 'dccm_energy_eV': float,
+              'dccm_offset_eV': float, 'k_move_mode': str,
+              'run_index': int, 'point_index': int}, ...]
+        """
+        self.simulate = simulate
+
+        # === Parameter defaults and validation ===
+        if k_step_eV is None:
+            k_step_eV = 2 * dccm_window_eV
+
+        if k_move_mode not in ('pause', 'concurrent'):
+            raise ValueError(f"k_move_mode must be 'pause' or 'concurrent', got '{k_move_mode}'")
+
+        if dccm_offsets is None:
+            dccm_offsets = list(np.arange(
+                -dccm_window_eV, dccm_window_eV + dccm_step_eV / 2, dccm_step_eV
+            ))
+
+        # Compute K positions
+        k_positions_eV = list(np.arange(start_eV, end_eV + k_step_eV / 2, k_step_eV))
+
+        # Total points
+        total_points = len(k_positions_eV) * len(dccm_offsets) * runs
+
+        # === Print scan configuration ===
+        print("\n" + "=" * 60)
+        print("K-PRIMARY XAS SCAN (k_xas_scan)")
+        print("=" * 60)
+        print(f"  Element:         {element}")
+        print(f"  Energy range:    {start_eV:.1f} - {end_eV:.1f} eV")
+        print(f"  K step:          {k_step_eV:.1f} eV")
+        print(f"  K positions:     {len(k_positions_eV)} ({k_positions_eV[0]:.1f} to {k_positions_eV[-1]:.1f} eV)")
+        print(f"  K move mode:     {k_move_mode}")
+        print(f"  DCCM offsets:    {dccm_offsets} eV")
+        print(f"  DCCM points/K:   {len(dccm_offsets)}")
+        print(f"  Dwell time:      {dwell_time:.2f} s")
+        print(f"  Runs:            {runs}")
+        print(f"  Total points:    {total_points}")
+        print(f"  Record:          {record}")
+        print(f"  Picker:          {picker}")
+        print(f"  Track FEE spec:  {track_feespec}")
+        print(f"  Flux threshold:  {flux_threshold}")
+        print(f"  Simulate:        {simulate}")
+        print(f"  Sample:          {sample}")
+        est_time = total_points * dwell_time
+        if k_move_mode == 'pause':
+            est_time += len(k_positions_eV) * runs * 4  # ~4s per K move
+        print(f"  Est. time:       {est_time:.0f}s ({est_time/60:.1f} min)")
+        print("=" * 60 + "\n")
+
+        # === Store initial positions ===
+        if simulate:
+            energy_start = 7.0  # dummy for sim
+            k_energy_start = start_eV
+        else:
+            energy_start = self.dccm.energy_with_vernier.energy()
+            k_energy_start = self.acr_energy_k.get().setpoint
+
+        # === Summary collector ===
+        summary = []
+        point_index = 0
+
+        # === Main scan loop ===
+        try:
+            for run_idx in range(runs):
+                self.logger.warning(f"Starting run {run_idx + 1}/{runs}")
+
+                # Setup DAQ
+                run_number, daq_success = self._setup_daq_and_start_recording(
+                    sample, picker, False, record, run_idx
+                )
+                if not daq_success:
+                    self.logger.error("DAQ setup failed, aborting")
+                    break
+
+                for k_idx, k_target_eV in enumerate(k_positions_eV):
+                    k_target_keV = k_target_eV / 1000.0
+
+                    self.logger.warning(
+                        f"K position {k_idx + 1}/{len(k_positions_eV)}: "
+                        f"{k_target_eV:.1f} eV [{k_move_mode}]"
+                    )
+
+                    if k_move_mode == 'pause':
+                        self._k_xas_move_pause(
+                            k_target_eV, k_target_keV,
+                            track_feespec, crystal_angle_offset
+                        )
+                    elif k_move_mode == 'concurrent':
+                        self._k_xas_move_concurrent(
+                            k_target_eV, k_target_keV,
+                            track_feespec, crystal_angle_offset
+                        )
+
+                    # Step DCCM through offsets
+                    for offset in dccm_offsets:
+                        dccm_energy_eV = k_target_eV + offset
+                        dccm_energy_keV = dccm_energy_eV / 1000.0
+
+                        self.logger.info(
+                            f"  DCCM: {dccm_energy_eV:.1f} eV "
+                            f"(offset {offset:+.1f})"
+                        )
+
+                        # Move DCCM (crystal only, no vernier)
+                        if simulate:
+                            self.sim.fast_motor1.mv(dccm_energy_keV)
+                        else:
+                            self.dccm.energy.move(dccm_energy_keV, wait=True)
+
+                        # Check beam
+                        if flux_threshold:
+                            self.check_beam_status(flux_threshold)
+
+                        # Collect
+                        self._wait(dwell_time)
+
+                        # Record summary
+                        summary.append({
+                            'k_target_eV': k_target_eV,
+                            'dccm_energy_eV': dccm_energy_eV,
+                            'dccm_offset_eV': offset,
+                            'k_move_mode': k_move_mode,
+                            'run_index': run_idx,
+                            'point_index': point_index,
+                        })
+                        point_index += 1
+
+                # End of run — stop DAQ
+                if not simulate:
+                    from mfx.db import daq
+                    daq.control.setState("configured")
+                    while daq.control.getState() != "configured":
+                        sleep(0.01)
+                    daq.control.setRecord(False)
+
+                if runs > 1 and run_idx < runs - 1:
+                    self.logger.info("Inter-run delay (5s)")
+                    sleep(5)
+
+        except KeyboardInterrupt:
+            self.logger.warning("Scan aborted by user (Ctrl+C)")
+            if not simulate:
+                from mfx.db import daq, pp
+                try:
+                    daq.control.setState("configured")
+                    daq.control.setRecord(False)
+                    pp.close()
+                except Exception:
+                    pass
+
+        # === Return to initial positions ===
+        self.logger.info("Returning to initial positions")
+        if simulate:
+            self.sim.fast_motor1.mv(energy_start)
+            self.sim.slow_motor1.mv(k_energy_start)
+        else:
+            self.dccm.energy.move(energy_start, wait=True)
+            if round(k_energy_start, 1) != round(self.acr_energy_k.get().setpoint, 1):
+                self.acr_energy_k.move(k_energy_start)
+            if track_feespec:
+                self.xrtspec.move_feespec_energy(
+                    energy_start, crystal_angle_offset=crystal_angle_offset)
+
+        # === Print summary ===
+        print("\n" + "=" * 60)
+        print("SCAN COMPLETE")
+        print("=" * 60)
+        print(f"  Total points collected: {len(summary)}")
+        print(f"  K positions visited:    {len(k_positions_eV) * min(runs, run_idx + 1)}")
+        print(f"  K move mode:            {k_move_mode}")
+        if summary:
+            print(f"  Energy range covered:   "
+                  f"{min(s['dccm_energy_eV'] for s in summary):.1f} - "
+                  f"{max(s['dccm_energy_eV'] for s in summary):.1f} eV")
+        print("=" * 60 + "\n")
+
+        return summary
+
+    def _k_xas_move_pause(self, k_target_eV, k_target_keV,
+                          track_feespec, crystal_angle_offset):
+        """
+        Move K in 'pause' mode: pause DAQ, move K, wait, resume.
+
+        Parameters
+        ----------
+        k_target_eV : float
+            Target K energy in eV
+        k_target_keV : float
+            Target K energy in keV
+        track_feespec : bool
+            Track FEE spectrometer
+        crystal_angle_offset : float
+            FEE crystal angle offset in degrees
+        """
+        if self.simulate:
+            self.sim.slow_motor1.mv(k_target_eV)
+            self.k_energy = k_target_eV
+            return
+
+        from mfx.db import daq
+
+        # Pause DAQ
+        if daq.control.getState() == "running":
+            daq.control.setState("paused")
+            while daq.control.getState() != "paused":
+                sleep(0.01)
+            sleep(0.5)
+
+        # Move FEE spec before K
+        if track_feespec:
+            self.xrtspec.move_feespec_energy(
+                k_target_keV, crystal_angle_offset=crystal_angle_offset)
+
+        # Move K (blocking)
+        self.acr_energy_k.move(k_target_eV)
+        self.k_energy = k_target_eV
+
+        # Verify FEE spec
+        if track_feespec:
+            self.xrtspec.check_feespec_crystal_angle(
+                k_target_keV, crystal_angle_offset=crystal_angle_offset)
+
+        # Resume DAQ
+        if daq.control.getState() == "paused":
+            daq.control.setState("running")
+            while daq.control.getState() != "running":
+                sleep(0.01)
+
+    def _k_xas_move_concurrent(self, k_target_eV, k_target_keV,
+                               track_feespec, crystal_angle_offset):
+        """
+        Move K in 'concurrent' mode: request K non-blocking, don't wait.
+
+        Parameters
+        ----------
+        k_target_eV : float
+            Target K energy in eV
+        k_target_keV : float
+            Target K energy in keV
+        track_feespec : bool
+            Track FEE spectrometer
+        crystal_angle_offset : float
+            FEE crystal angle offset in degrees
+        """
+        if self.simulate:
+            self.sim.slow_motor1.mv(k_target_eV)
+            self.k_energy = k_target_eV
+            return
+
+        # Move FEE spec (fast, do before K)
+        if track_feespec:
+            self.xrtspec.move_feespec_energy(
+                k_target_keV, crystal_angle_offset=crystal_angle_offset)
+
+        # Request K move — non-blocking (don't wait for completion)
+        self.acr_energy_k.move(k_target_eV, wait=False)
+        self.k_energy = k_target_eV
+
 
 class EXAFSEnergyRangeBuilder:
     """

--- a/mfx/exafs.py
+++ b/mfx/exafs.py
@@ -12,15 +12,28 @@ import json
 import logging
 from time import sleep, time
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import matplotlib.pyplot as plt
 
-from ophyd import EpicsSignalRO
-from pcdsdevices.beam_stats import BeamEnergyRequestACRWait
+try:
+    from ophyd import EpicsSignalRO
+    from pcdsdevices.beam_stats import BeamEnergyRequestACRWait
+    from tfs.sim_transfocator import make_tfs_sim
+    from tfs.transfocator import Transfocator
+    _HW_AVAILABLE = True
+except ImportError:
+    _HW_AVAILABLE = False
 
-from tfs.sim_transfocator import make_tfs_sim
-from tfs.transfocator import Transfocator
+
+class _SimMotor:
+    """Minimal simulated motor for offline testing."""
+    def __init__(self):
+        self.position = 0.0
+
+    def mv(self, value):
+        self.position = float(value)
 
 
 class Exafs:
@@ -61,35 +74,48 @@ class Exafs:
         Vernier device controller
     """
 
-    ipm_sum = EpicsSignalRO("MFX:DG1:W8:01:SUM", name="dg1_sum")
+    if _HW_AVAILABLE:
+        ipm_sum = EpicsSignalRO("MFX:DG1:W8:01:SUM", name="dg1_sum")
 
-    acr_energy_v = BeamEnergyRequestACRWait(
-        name='acr_energy', prefix='MFX', acr_status_suffix='AO805'
-    )
-    acr_energy_k = BeamEnergyRequestACRWait(
-        name='acr_energy', prefix='MFX', acr_status_suffix='AO805', pv_index=2
-    )
+        acr_energy_v = BeamEnergyRequestACRWait(
+            name='acr_energy', prefix='MFX', acr_status_suffix='AO805'
+        )
+        acr_energy_k = BeamEnergyRequestACRWait(
+            name='acr_energy', prefix='MFX', acr_status_suffix='AO805', pv_index=2
+        )
 
-    def __init__(self):
+    def __init__(self, simulate=False):
         """
         Initialize EXAFS controller.
 
-        Creates logger, initializes DCCM and Vernier controllers,
-        sets up energy range builder, and configures simulation mode.
+        Parameters
+        ----------
+        simulate : bool, optional
+            If True, skip all hardware connections and use mock motors.
+            Allows fully offline instantiation for testing. (default: False)
         """
-        from mfx.dccm import DCCM
-        from hutch_python import sim
-        from mfx.xrt_spec import XRTspec
-        self.xrtspec = XRTspec()
         self.logger = logging.getLogger(__name__)
-        self.dccm = DCCM(name='DCCM')
+        self.simulate = simulate
         self.exafs_energy_range_builder = EXAFSEnergyRangeBuilder()
-        self.simulate = False
-        self.sim = sim.get_hw()
         self.tfs = None
         self.k_energy = None
         self.vernier_offset = None
         self.vernier_device = None
+
+        if simulate:
+            self.dccm = None
+            self.xrtspec = None
+            self.sim = SimpleNamespace(
+                fast_motor1=_SimMotor(),
+                slow_motor1=_SimMotor(),
+            )
+        else:
+            from mfx.dccm import DCCM
+            from hutch_python import sim
+            from mfx.xrt_spec import XRTspec
+            self.xrtspec = XRTspec()
+            self.dccm = DCCM(name='DCCM')
+            self.sim = sim.get_hw()
 
     # ==================== Core Motion Methods ====================
 
@@ -1667,8 +1693,8 @@ class Exafs:
 
     # ==================== K-Primary XAS Scan ====================
 
-    def k_xas_scan(self, start_eV, end_eV, element='Fe',
-                   k_step_eV=None, k_move_mode='pause',
+    def k_xas_scan(self, start_eV=None, end_eV=None, element='Fe',
+                   k_step_eV=None, k_positions=None, k_move_mode='pause',
                    dccm_window_eV=2.0, dccm_step_eV=1.0,
                    dccm_offsets=None, dwell_time=1.0,
                    record=False, picker=None,
@@ -1684,14 +1710,19 @@ class Exafs:
 
         Parameters
         ----------
-        start_eV : float
-            Starting energy in eV
-        end_eV : float
-            Ending energy in eV
+        start_eV : float or None, optional
+            Starting energy in eV (ignored if k_positions provided)
+        end_eV : float or None, optional
+            Ending energy in eV (ignored if k_positions provided)
         element : str, optional
             Element symbol (default: 'Fe')
         k_step_eV : float or None, optional
-            K step size in eV. Defaults to 2*dccm_window_eV (seamless tiling)
+            K step size in eV. Defaults to 2*dccm_window_eV (seamless tiling).
+            Ignored if k_positions provided.
+        k_positions : array_like or None, optional
+            Explicit list of K energies in eV. If provided, overrides
+            start_eV/end_eV/k_step_eV. Rounded to 0.1 eV, deduplicated,
+            and sorted ascending.
         k_move_mode : str, optional
             'pause': Pause DAQ, move K, wait, resume DAQ (default)
             'concurrent': Request K non-blocking, immediately step DCCM
@@ -1745,28 +1776,28 @@ class Exafs:
 
         Examples
         --------
-        Fe K-edge commissioning (7100-7150 eV), simulation:
+        Mode 1 — K at every point (undulator moves at each energy):
 
-        >>> summary = exafs.k_xas_scan(7100, 7150, element='Fe',
-        ...     dccm_window_eV=2.0, dccm_step_eV=1.0, simulate=True)
+        >>> roi_scan = [7095, 7098, 7101, 7104, 7106.3, 7106.6, ...]
+        >>> summary = exafs.k_xas_scan(k_positions=roi_scan,
+        ...     dccm_offsets=[0.0], dwell_time=1.0,
+        ...     track_feespec=True, simulate=True)
 
-        Same scan with concurrent K moves and FEE tracking:
+        Mode 2 — DCCM probes window around each K position:
 
-        >>> summary = exafs.k_xas_scan(7100, 7150, element='Fe',
-        ...     k_move_mode='concurrent', track_feespec=True,
-        ...     record=True, sample='FeO_film')
+        >>> summary = exafs.k_xas_scan(start_eV=7095, end_eV=7195,
+        ...     k_step_eV=4.0, dccm_window_eV=2.0, dccm_step_eV=1.0,
+        ...     track_feespec=True, simulate=True)
 
-        Custom DCCM offsets (asymmetric window):
+        Concurrent K moves (collect during transit):
 
-        >>> summary = exafs.k_xas_scan(7100, 7150, element='Fe',
-        ...     dccm_offsets=[-1.0, 0.0, 0.5, 1.0, 2.0])
+        >>> summary = exafs.k_xas_scan(start_eV=7095, end_eV=7195,
+        ...     k_step_eV=1.0, dccm_offsets=[0.0],
+        ...     k_move_mode='concurrent', simulate=True)
         """
         self.simulate = simulate
 
         # === Parameter defaults and validation ===
-        if k_step_eV is None:
-            k_step_eV = 2 * dccm_window_eV
-
         if k_move_mode not in ('pause', 'concurrent'):
             raise ValueError(f"k_move_mode must be 'pause' or 'concurrent', got '{k_move_mode}'")
 
@@ -1777,10 +1808,17 @@ class Exafs:
             dccm_offsets = sorted(set(dccm_offsets))
 
         # Compute K positions
-        k_positions_eV = np.round(
-            np.arange(start_eV, end_eV + k_step_eV / 2, k_step_eV), 1
-        )
-        k_positions_eV = sorted(set(k_positions_eV.tolist()))
+        if k_positions is not None:
+            k_positions_eV = sorted(set(np.round(k_positions, 1).tolist()))
+        else:
+            if start_eV is None or end_eV is None:
+                raise ValueError("Must provide either k_positions or both start_eV and end_eV")
+            if k_step_eV is None:
+                k_step_eV = 2 * dccm_window_eV
+            k_positions_eV = np.round(
+                np.arange(start_eV, end_eV + k_step_eV / 2, k_step_eV), 1
+            )
+            k_positions_eV = sorted(set(k_positions_eV.tolist()))
 
         # Total points
         total_points = len(k_positions_eV) * len(dccm_offsets) * runs
@@ -1790,8 +1828,11 @@ class Exafs:
         print("K-PRIMARY XAS SCAN (k_xas_scan)")
         print("=" * 60)
         print(f"  Element:         {element}")
-        print(f"  Energy range:    {start_eV:.1f} - {end_eV:.1f} eV")
-        print(f"  K step:          {k_step_eV:.1f} eV")
+        print(f"  Energy range:    {k_positions_eV[0]:.1f} - {k_positions_eV[-1]:.1f} eV")
+        if k_step_eV is not None:
+            print(f"  K step:          {k_step_eV:.1f} eV")
+        else:
+            print(f"  K step:          custom ({len(k_positions_eV)} positions)")
         print(f"  K positions:     {len(k_positions_eV)} ({k_positions_eV[0]:.1f} to {k_positions_eV[-1]:.1f} eV)")
         print(f"  K move mode:     {k_move_mode}")
         print(f"  DCCM offsets:    {dccm_offsets} eV")
@@ -1814,7 +1855,7 @@ class Exafs:
         # === Store initial positions ===
         if simulate:
             energy_start = 7.0  # dummy for sim
-            k_energy_start = start_eV
+            k_energy_start = k_positions_eV[0]
         else:
             energy_start = self.dccm.energy_with_vernier.energy()
             k_energy_start = self.acr_energy_k.get().setpoint

--- a/mfx/exafs.py
+++ b/mfx/exafs.py
@@ -1728,6 +1728,38 @@ class Exafs:
             [{'k_target_eV': float, 'dccm_energy_eV': float,
               'dccm_offset_eV': float, 'k_move_mode': str,
               'run_index': int, 'point_index': int}, ...]
+
+        Notes
+        -----
+        K positions are computed as arange(start_eV, end_eV, k_step_eV).
+        Default k_step_eV = 2*dccm_window_eV gives seamless energy tiling
+        with no gaps between successive DCCM windows.
+
+        Uses dccm.energy (crystal-only) — no vernier requests are issued.
+        This is required for experiments where the vernier PV is rejected
+        by the accelerator.
+
+        In 'concurrent' mode, early DCCM points at each K position are
+        collected while the undulator is still settling. This allows
+        evaluating data quality during transit vs. after settling.
+
+        Examples
+        --------
+        Fe K-edge commissioning (7100-7150 eV), simulation:
+
+        >>> summary = exafs.k_xas_scan(7100, 7150, element='Fe',
+        ...     dccm_window_eV=2.0, dccm_step_eV=1.0, simulate=True)
+
+        Same scan with concurrent K moves and FEE tracking:
+
+        >>> summary = exafs.k_xas_scan(7100, 7150, element='Fe',
+        ...     k_move_mode='concurrent', track_feespec=True,
+        ...     record=True, sample='FeO_film')
+
+        Custom DCCM offsets (asymmetric window):
+
+        >>> summary = exafs.k_xas_scan(7100, 7150, element='Fe',
+        ...     dccm_offsets=[-1.0, 0.0, 0.5, 1.0, 2.0])
         """
         self.simulate = simulate
 
@@ -1739,12 +1771,16 @@ class Exafs:
             raise ValueError(f"k_move_mode must be 'pause' or 'concurrent', got '{k_move_mode}'")
 
         if dccm_offsets is None:
-            dccm_offsets = list(np.arange(
+            dccm_offsets = np.round(np.arange(
                 -dccm_window_eV, dccm_window_eV + dccm_step_eV / 2, dccm_step_eV
-            ))
+            ), 1).tolist()
+            dccm_offsets = sorted(set(dccm_offsets))
 
         # Compute K positions
-        k_positions_eV = list(np.arange(start_eV, end_eV + k_step_eV / 2, k_step_eV))
+        k_positions_eV = np.round(
+            np.arange(start_eV, end_eV + k_step_eV / 2, k_step_eV), 1
+        )
+        k_positions_eV = sorted(set(k_positions_eV.tolist()))
 
         # Total points
         total_points = len(k_positions_eV) * len(dccm_offsets) * runs
@@ -1919,6 +1955,13 @@ class Exafs:
             Track FEE spectrometer
         crystal_angle_offset : float
             FEE crystal angle offset in degrees
+
+        Notes
+        -----
+        Sequence: pause DAQ → move FEE spec (optional) → move K
+        (blocking) → verify FEE → resume DAQ. Data collection stops
+        during K transit. Typical K move takes 2-5 s depending on
+        step size.
         """
         if self.simulate:
             self.sim.slow_motor1.mv(k_target_eV)
@@ -1969,6 +2012,13 @@ class Exafs:
             Track FEE spectrometer
         crystal_angle_offset : float
             FEE crystal angle offset in degrees
+
+        Notes
+        -----
+        Issues acr_energy_k.move(wait=False) so data collection can
+        continue while the undulator settles. Early DCCM points in the
+        subsequent offset loop will be collected during K transit — useful
+        for evaluating whether in-transit data is scientifically usable.
         """
         if self.simulate:
             self.sim.slow_motor1.mv(k_target_eV)
@@ -2155,7 +2205,7 @@ class EXAFSEnergyRangeBuilder:
         )
 
         K_values = np.arange(min_K_value, max_K_value + K_spacing, K_spacing)
-        energy_K_range = [self.K_to_eV(K) for K in K_values]
+        energy_K_range = np.array([self.K_to_eV(K) for K in K_values])
 
         energy_in_edge = np.arange(
             preedge_end + edge_eV_increment, np.min(energy_K_range), edge_eV_increment
@@ -2174,6 +2224,11 @@ class EXAFSEnergyRangeBuilder:
         time_range = np.concatenate((
             time_before_edge_arr, time_in_preedge_arr, time_in_edge_arr, time_EXAFS
         ))
+
+        # Round to 0.1 eV, remove duplicates, sort ascending
+        energy_range = np.round(energy_range, 1)
+        energy_range, unique_idx = np.unique(energy_range, return_index=True)
+        time_range = time_range[unique_idx]
 
         # Store for plotting
         if start_ev >= preedge_end:

--- a/mfx/exafs.py
+++ b/mfx/exafs.py
@@ -1696,7 +1696,7 @@ class Exafs:
     def k_xas_scan(self, start_eV=None, end_eV=None, element='Fe',
                    k_step_eV=None, k_positions=None, k_move_mode='pause',
                    dccm_window_eV=2.0, dccm_step_eV=1.0,
-                   dccm_offsets=None, dwell_time=1.0,
+                   dccm_offsets=None, dwell_time=3.0,
                    record=False, picker=None,
                    track_feespec=False, flux_threshold=None,
                    crystal_angle_offset=0.0,
@@ -1734,7 +1734,7 @@ class Exafs:
             Explicit list of DCCM offsets in eV relative to K center.
             If provided, overrides dccm_window_eV and dccm_step_eV.
         dwell_time : float, optional
-            Collection time per DCCM point in seconds (default: 1.0)
+            Collection time per DCCM point in seconds (default: 3.0)
         record : bool, optional
             Enable DAQ recording (default: False)
         picker : str or None, optional


### PR DESCRIPTION
---


  Summary

  - Add k_xas_scan method to Exafs class: undulator K is the primary scan axis, DCCM steps within a small window (±2 eV default) around each K position. Designed for commissioning undulator motion without vernier access. Supports pause and concurrent K move modes.
  - Add k_positions parameter for custom K energy arrays (non-uniform spacing, ROI scans, exact ACR array matching).
  - Add Exafs(simulate=True) mode: skips all hardware imports, uses mock motors, enables fully offline testing.
  - Round energy arrays to 0.1 eV, remove duplicates, sort ascending (with paired time arrays kept in sync).
  - Add beamtime runbook (docs/beamtime_20260624.md) for June 24 & 26 K-scan commissioning and Wolter first-light shifts with executable recipes, shift schedule, troubleshooting, and parameter reference.

  Other changes

  - Replace mfx_pulsepicker references with pp (current device name)
  - Remove stale tape drive and Wolter motor definitions from beamline.py (moved elsewhere)
  - Simplify Wire class init (remove hardcoded PV args)
  - Remove unused scripts/analyze_timing_v2.py
  - Minor cleanup in autorun.py, timing.py, scan.py, notch_scan.py, attenuator_scan.py, vernier.py, yano.py, xrt_spec.py

  Test plan

  - [x] Exafs(simulate=True) instantiates without EPICS/hardware
  - [x] k_xas_scan(..., simulate=True) runs full scan loop offline
  - [ ] On-hutch commissioning: June 24 beamtime with Fe foil at 10 Hz

  ---
